### PR TITLE
docs: scope install with --agent claude-code; clarify gw is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,31 @@ Skills and agents follow the open [Agent Skills](https://agentskills.io/) format
 
 ## Install
 
-**Universal** (works with any [Agent Skills](https://agentskills.io)-compatible tool):
+> **Tip — keep it tidy.** Always pass `--agent <your-tool>` (e.g. `--agent claude-code`). Without it, `npx skills` symlinks every skill into ~24 different AI-tool directories at once (`.codebuddy/`, `.continue/`, `.crush/`, …). Scoping the install to the tool you actually use keeps your workspace clean and your `git status` short.
+
+**Recommended — Claude Code only:**
+
+```bash
+npx skills add https://github.com/mthines/agent-skills \
+  --skill confidence \
+  --agent claude-code \
+  --yes
+```
+
+To install all skills:
+
+```bash
+npx skills add https://github.com/mthines/agent-skills --all --agent claude-code
+```
+
+**Universal** (works with any [Agent Skills](https://agentskills.io)-compatible tool — only use this if you switch between many tools):
 
 ```bash
 npx skills add https://github.com/mthines/agent-skills --all
 ```
 
-To install a single skill:
-
-```bash
-npx skills add https://github.com/mthines/agent-skills --skill confidence
-```
-
 <details>
-<summary>Claude Code</summary>
+<summary>Claude Code (plugin marketplace)</summary>
 
 ```bash
 /plugin marketplace add mthines/agent-skills
@@ -181,8 +192,9 @@ npx skills add https://github.com/mthines/agent-skills \
   --skill autonomous-workflow create-plan create-walkthrough confidence \
           code-quality holistic-analysis tdd ux update-claude \
           review-changes create-pr ci-auto-fix \
+  --agent claude-code \
   --global --yes
-bash ~/.agents/skills/autonomous-workflow/install.sh --global
+bash ~/.claude/skills/autonomous-workflow/install.sh --global
 ```
 
 **Per-project** (team use, committable):
@@ -192,9 +204,15 @@ npx skills add https://github.com/mthines/agent-skills \
   --skill autonomous-workflow create-plan create-walkthrough confidence \
           code-quality holistic-analysis tdd ux update-claude \
           review-changes create-pr ci-auto-fix \
+  --agent claude-code \
   --yes
-bash .agents/skills/autonomous-workflow/install.sh
+bash .claude/skills/autonomous-workflow/install.sh
 ```
+
+> The `--agent claude-code` flag scopes the install to `.claude/skills/` only.
+> Without it the CLI symlinks the skills into every supported AI-tool's directory
+> (`.codebuddy/`, `.continue/`, `.crush/`, …) — fine if you switch tools, noisy
+> otherwise. Use `--agent '*'` to opt into the universal install explicitly.
 
 Run `bash install.sh --help` for script options.
 

--- a/skills/autonomous-workflow/README.md
+++ b/skills/autonomous-workflow/README.md
@@ -48,30 +48,38 @@ phase rules and the companion registry carry the procedural detail.
 
 ### Step 1: Install prerequisites
 
-| Tool | Status      | Why                                                                 |
-| ---- | ----------- | ------------------------------------------------------------------- |
-| `gh` | **REQUIRED**| PR creation (Phase 6) and CI watching (Phase 7)                     |
-| `gw` | Recommended | Worktree management with auto-copy of secrets, pre/post-checkout hooks, smart cleanup, and shell-integrated `gw cd` |
+| Tool | Status                       | Why                                                                 |
+| ---- | ---------------------------- | ------------------------------------------------------------------- |
+| `gh` | **Required**                 | PR creation (Phase 6) and CI watching (Phase 7)                     |
+| `gw` | **Recommended** *(optional)* | Worktree management with auto-copy of secrets, pre/post-checkout hooks, smart cleanup, and shell-integrated `gw cd`. The workflow falls back to native `git worktree` if `gw` is absent. |
 
 ```bash
 # Required
 brew install gh && gh auth login
 
-# Recommended (optional)
+# Recommended — gw makes worktree-heavy workflows nicer, but is NOT required
 brew install mthines/gw-tools/gw
 ```
 
-If `gw` is not installed, the workflow falls back to native `git worktree`
-commands using the same sibling-directory layout (`../<repo>-<branch-slug>/`).
-You'll be warned once at the start of Phase 2 about the features you're missing
-(auto-copy of secrets, pre/post-checkout hooks, smart cleanup, shell-integrated
-`gw cd`). See [`rules/prerequisites.md#fallback-to-native-git-worktree`](./rules/prerequisites.md#fallback-to-native-git-worktree)
+`gw` is **not a hard requirement** — if it's not on `PATH`, Phase 2 detects
+that at Step 0 and falls through to native `git worktree` commands using the
+same sibling-directory layout (`../<repo>-<branch-slug>/`). You'll be warned
+once about the features you're missing (auto-copy of secrets, pre/post-checkout
+hooks, smart cleanup, shell-integrated `gw cd`), then the workflow continues
+normally. See [`rules/prerequisites.md#fallback-to-native-git-worktree`](./rules/prerequisites.md#fallback-to-native-git-worktree)
 for the full feature comparison.
 
 ### Step 2: Install the skill + agents
 
 The skill ships with [`install.sh`](./install.sh) which handles the agent +
 routing-rule symlinks for you. Two steps: download skills, then run install.
+
+> **Pass `--agent claude-code`.** Without it, `npx skills` symlinks every skill
+> into ~24 different AI-tool directories at once (`.codebuddy/`, `.continue/`,
+> `.crush/`, `.factory/`, `.goose/`, `.junie/`, `.kilocode/`, …). Scoping the
+> install to the tool you actually use keeps your workspace tidy and your
+> `git status` short. Drop the flag (or use `--agent '*'`) only if you really
+> want the universal install.
 
 #### Option A: Global (personal use, all projects)
 
@@ -80,8 +88,9 @@ npx skills add https://github.com/mthines/agent-skills \
   --skill autonomous-workflow create-plan create-walkthrough confidence \
           code-quality holistic-analysis tdd ux update-claude \
           review-changes create-pr ci-auto-fix \
+  --agent claude-code \
   --global --yes
-bash ~/.agents/skills/autonomous-workflow/install.sh --global
+bash ~/.claude/skills/autonomous-workflow/install.sh --global
 ```
 
 #### Option B: Per-project (team use, committable)
@@ -91,8 +100,9 @@ npx skills add https://github.com/mthines/agent-skills \
   --skill autonomous-workflow create-plan create-walkthrough confidence \
           code-quality holistic-analysis tdd ux update-claude \
           review-changes create-pr ci-auto-fix \
+  --agent claude-code \
   --yes
-bash .agents/skills/autonomous-workflow/install.sh
+bash .claude/skills/autonomous-workflow/install.sh
 ```
 
 To run with fewer companions, omit them from the `--skill` list. See
@@ -169,6 +179,7 @@ npx skills add https://github.com/mthines/agent-skills \
   --skill autonomous-workflow create-plan create-walkthrough confidence \
           code-quality holistic-analysis update-claude \
           review-changes create-pr ci-auto-fix \
+  --agent claude-code \
   --yes
 ```
 

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -246,8 +246,9 @@ npx skills add https://github.com/mthines/agent-skills \
   --skill autonomous-workflow create-plan create-walkthrough confidence \
           code-quality holistic-analysis tdd ux update-claude \
           review-changes create-pr ci-auto-fix \
+  --agent claude-code \
   --global --yes
-bash ~/.agents/skills/autonomous-workflow/install.sh --global
+bash ~/.claude/skills/autonomous-workflow/install.sh --global
 ```
 
 **Per-project** (team use, committable):
@@ -257,9 +258,15 @@ npx skills add https://github.com/mthines/agent-skills \
   --skill autonomous-workflow create-plan create-walkthrough confidence \
           code-quality holistic-analysis tdd ux update-claude \
           review-changes create-pr ci-auto-fix \
+  --agent claude-code \
   --yes
-bash .agents/skills/autonomous-workflow/install.sh
+bash .claude/skills/autonomous-workflow/install.sh
 ```
+
+> The `--agent claude-code` flag is recommended — it scopes the install to
+> `.claude/skills/` only. Without it the CLI symlinks the skills into every
+> supported AI tool's directory at once (`.codebuddy/`, `.continue/`, `.crush/`,
+> …). Drop it (or use `--agent '*'`) only if you want the universal install.
 
 After the script runs, two agents are linked into your `.claude/agents/`
 directory: `autonomous-planner.md` and `autonomous-executor.md`. The routing

--- a/skills/autonomous-workflow/install.sh
+++ b/skills/autonomous-workflow/install.sh
@@ -71,11 +71,21 @@ done
 case "$MODE" in
   global)
     CLAUDE_DIR="$HOME/.claude"
-    SKILL_DIR="$HOME/.agents/skills/autonomous-workflow"
+    # Try .claude/skills/ first (--agent claude-code layout),
+    # then fall back to .agents/skills/ (universal layout).
+    if [[ -d "$HOME/.claude/skills/autonomous-workflow" ]]; then
+      SKILL_DIR="$HOME/.claude/skills/autonomous-workflow"
+    else
+      SKILL_DIR="$HOME/.agents/skills/autonomous-workflow"
+    fi
     ;;
   project)
     CLAUDE_DIR="$(pwd)/.claude"
-    SKILL_DIR="$(pwd)/.agents/skills/autonomous-workflow"
+    if [[ -d "$(pwd)/.claude/skills/autonomous-workflow" ]]; then
+      SKILL_DIR="$(pwd)/.claude/skills/autonomous-workflow"
+    else
+      SKILL_DIR="$(pwd)/.agents/skills/autonomous-workflow"
+    fi
     ;;
   development)
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -96,6 +106,7 @@ if [[ ! -d "$SKILL_DIR" ]]; then
       echo "    --skill autonomous-workflow create-plan create-walkthrough confidence \\" >&2
       echo "            code-quality holistic-analysis tdd ux update-claude \\" >&2
       echo "            review-changes create-pr ci-auto-fix \\" >&2
+      echo "    --agent claude-code \\" >&2
       echo "    --global --yes" >&2
       ;;
     project)
@@ -104,6 +115,7 @@ if [[ ! -d "$SKILL_DIR" ]]; then
       echo "    --skill autonomous-workflow create-plan create-walkthrough confidence \\" >&2
       echo "            code-quality holistic-analysis tdd ux update-claude \\" >&2
       echo "            review-changes create-pr ci-auto-fix \\" >&2
+      echo "    --agent claude-code \\" >&2
       echo "    --yes" >&2
       ;;
     development)

--- a/skills/autonomous-workflow/templates/agent.template.md
+++ b/skills/autonomous-workflow/templates/agent.template.md
@@ -56,6 +56,7 @@ npx skills add https://github.com/mthines/agent-skills \
   --skill autonomous-workflow create-plan create-walkthrough confidence \
           code-quality holistic-analysis tdd ux update-claude \
           review-changes create-pr ci-auto-fix \
+  --agent claude-code \
   --yes
 ```
 


### PR DESCRIPTION
## Summary

Two related cleanups based on real-world install pain:

### 1. Recommend `--agent claude-code` everywhere

The default `npx skills add` command (with no `--agent` flag) symlinks every selected skill into **~24 different AI tool directories at once**: `.codebuddy/`, `.commandcode/`, `.continue/`, `.crush/`, `.factory/`, `.goose/`, `.junie/skills/`, `.kilocode/skills/`, `.kiro/skills/`, `.kode/skills/`, `.mcpjam/skills/`, `.mux/skills/`, `.neovate/skills/`, `.openhands/skills/`, `.pi/skills/`, `.pochi/skills/`, `.qoder/skills/`, `.qwen/skills/`, `.roo/skills/`, `.trae/skills/`, `.windsurf/skills/`, `.zencoder/skills/`, plus `.agents/skills/` and `.claude/skills/`.

For users on a single tool, this floods the workspace and produces a 400+ file `git status`.

**Fix:** all install commands in the repo now recommend `--agent claude-code`, which scopes the install to `.claude/skills/` only. A callout block explains the trade-off and how to opt into the universal install (`--agent '*'`) if desired.

### 2. Clarify that `gw` is optional, not required

The autonomous-workflow README's prerequisites table previously listed `gw` as "Recommended" but the surrounding language treated it as a near-requirement. Updated to **explicitly** say `gw` is **not a hard requirement** — Phase 2 detects its absence and falls through to native `git worktree`.

### 3. install.sh dual-layout support

Updated `skills/autonomous-workflow/install.sh` to look for the skill in either layout:

- `.claude/skills/autonomous-workflow/` (when `--agent claude-code` was used)
- `.agents/skills/autonomous-workflow/` (universal install fallback)

So it works regardless of which install path the user picked.

## Files changed

- `README.md` — recommended Claude Code-scoped install at the top of the Install section
- `skills/autonomous-workflow/README.md` — strengthened gw-optional language; added `--agent claude-code` to all 3 install snippets; new tip block
- `skills/autonomous-workflow/SKILL.md` — added `--agent claude-code` + `.claude/skills/` paths to both install snippets
- `skills/autonomous-workflow/install.sh` — dual-layout SKILL_DIR detection; updated error messages
- `skills/autonomous-workflow/templates/agent.template.md` — added `--agent claude-code` flag

## Test plan

- [ ] Run the per-project install command from the updated README in a clean directory; verify only `.claude/skills/` is created (no `.codebuddy/`, `.continue/`, etc.)
- [ ] Run `bash .claude/skills/autonomous-workflow/install.sh` from that directory; verify the agents/rule are linked correctly
- [ ] Run the install with the OLD universal layout (no `--agent` flag); verify `install.sh` still works (dual-layout fallback)
- [ ] Verify the README's gw section reads as "optional, not required" without ambiguity