### PR TITLE
feat(vscode-agent-tasks): add Sessions panel for Claude Code session history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Nx
 .nx/
 
+# Agent workflow artifacts
+.agent
+
 # Agent/tool config directories
 .claude
 .adal

--- a/packages/vscode-agent-tasks/CLAUDE.md
+++ b/packages/vscode-agent-tasks/CLAUDE.md
@@ -25,13 +25,16 @@ nx release vscode-agent-tasks --configuration=dry-run  # Dry-run release
 
 ```
 src/
-  extension.ts           # Entry point, command registration
-  providers/             # TreeDataProviders for sidebar views
-    agent-tasks-provider # Agent tasks explorer view
-  parsers/               # Markdown parsing utilities
-    markdown-parser.ts   # Parses task.md, plan.md, walkthrough.md
-  watchers/              # File system watchers for artifact directories
-    artifact-watcher.ts  # Watches configured dirs for changes
+  extension.ts              # Entry point, command registration
+  providers/                # TreeDataProviders for sidebar views
+    agent-tasks-provider    # Agent tasks explorer view
+    sessions-provider       # Sessions panel — lists Claude Code session history
+  parsers/                  # Parsing utilities (NO VS Code dependency — testable with vitest)
+    markdown-parser.ts      # Parses task.md, plan.md, walkthrough.md
+    session-jsonl-parser.ts # Parses ~/.claude/projects/<encoded-cwd>/*.jsonl files
+  watchers/                 # File system watchers
+    artifact-watcher.ts     # Watches .agent/.gw dirs for artifact changes
+    session-watcher.ts      # Watches ~/.claude/projects/<encoded-cwd>/ for JSONL changes
 ```
 
 ## Key Concepts
@@ -40,6 +43,9 @@ src/
 - **Agent Tasks** — read from `<dir>/<branch>/` directories (`task.md`, `plan.md`, `walkthrough.md`)
 - **Artifact Watcher** — watches configured dirs for changes, triggers view refresh; auto-opens `walkthrough.md` and `plan.md` on creation; rebuilds watchers when `agentTasks.directories` changes or a configured root appears after activation
 - **Bare-repo indirection** — only for `.gw/`: reads `config.json` to find the default-branch worktree's `.gw/` dir
+- **Sessions** — read from `~/.claude/projects/<encoded-cwd>/` JSONL files; `<encoded-cwd>` replaces every `/` in the absolute workspace path with `-`. Status is a heuristic derived from file mtime (active <2m, recent <1h, idle otherwise)
+- **Session Watcher** — watches the session directories; debounces at 500 ms (vs 150 ms for artifacts) because JSONL files are written continuously during active sessions
+- **Worktree grouping in Sessions** — checks `.gw/config.json` first; falls back to `git worktree list --porcelain`; shows flat list when only one worktree detected
 
 ## Configuration namespace
 
@@ -51,27 +57,30 @@ All settings use `agentTasks.*` (NOT `gw.*`):
 - `agentTasks.autoOpenWalkthrough` — auto-open `walkthrough.md` on create
 - `agentTasks.autoOpenPlan` — auto-open `plan.md` on create
 - `agentTasks.openMarkdownInPreview` — preview mode
+- `agentTasks.sessions.openWith` — `"editor"` (default) or `"resume"` — what clicking a session does
 
 ## Extension Manifest
 
 All commands, views, settings, and keybindings are defined in `package.json`:
 
 - Commands: `contributes.commands` (all `agentTasks.*`)
-- Views: `contributes.views` (`agentTasksExplorer` inside `agentTasks` activity bar)
+- Views: `contributes.views` (`agentTasksExplorer` and `agentSessionsExplorer` inside `agentTasks` activity bar)
 - Settings: `contributes.configuration` (`agentTasks.*` namespace)
-- Activation: `workspaceContains:.agent` and `workspaceContains:.gw`
+- Activation: `workspaceContains:.agent`, `workspaceContains:.gw`, `onStartupFinished`, `onView:agentSessionsExplorer`
 
 ## Command IDs
 
 | Command | Description |
 |---------|-------------|
-| `agentTasks.refresh` | Refresh tree |
+| `agentTasks.refresh` | Refresh Agent Tasks tree |
 | `agentTasks.sort` | Sort picker QuickPick |
 | `agentTasks.focus` | Focus sidebar |
 | `agentTasks.openMarkdown` | Internal — open a markdown file path |
 | `agentTasks.openPlan` | Open plan.md for a branch item |
 | `agentTasks.openTask` | Open task.md for a branch item |
 | `agentTasks.openWalkthrough` | Open walkthrough.md for a branch item |
+| `agentTasks.sessions.refresh` | Refresh Sessions tree |
+| `agentTasks.sessions.openSession` | Internal — open or resume a session (registered on SessionItem) |
 
 ## Code Style
 
@@ -93,3 +102,6 @@ All commands, views, settings, and keybindings are defined in `package.json`:
 - `vscode` import will fail in vitest — isolate parsers from VS Code types
 - The bare-repo `.gw/config.json` indirection only fires when `dirName === '.gw'`
 - Do NOT add ANSI handling, git CLI calls, or QuickPick to the parsers
+- Sessions JSONL format is undocumented and owned by the Claude Code team — all parsing is in `session-jsonl-parser.ts`; unknown events are silently skipped
+- `vi.spyOn(fs, ...)` does not work with ESM modules in vitest — use real temp directories for parser tests instead of mocking `fs`
+- Session status icons are heuristic (mtime-based) — document this caveat clearly in any user-facing text

--- a/packages/vscode-agent-tasks/README.md
+++ b/packages/vscode-agent-tasks/README.md
@@ -133,6 +133,12 @@ If you previously used `vscode-gw` (gw Worktrees) with Agent Tasks, the settings
 | `Agent Tasks: Refresh Agent Tasks` | Reload the tree from disk |
 | `Agent Tasks: Sort Agent Tasks` | Interactive sort picker |
 | `Agent Tasks: Focus Agent Tasks Sidebar` | Focus the sidebar panel |
+| `Agent Tasks: Refresh Sessions` | Reload the Sessions panel and rebuild the file watcher |
+| `Agent Tasks: Toggle Sessions Scope` | Switch between current-worktree and all-worktrees views |
+
+## Logging
+
+The extension writes structured timestamped logs to a dedicated output channel — open it via **View → Output → mthines.agent-tasks**. The channel records activation, command invocations, watcher rebuilds, session refresh events, terminal lifecycle (create / focus existing / close), and errors. Useful when reporting issues or sanity-checking why a session doesn't appear.
 
 ## Artifacts recognized
 

--- a/packages/vscode-agent-tasks/README.md
+++ b/packages/vscode-agent-tasks/README.md
@@ -32,23 +32,35 @@ The **Sessions** panel (below the Agent Tasks view in the same activity-bar cont
 
 ### How it works
 
-Sessions are read from `~/.claude/projects/<encoded-cwd>/` — where `<encoded-cwd>` is your absolute workspace path with every `/` replaced by `-`. For example `/Users/you/myrepo` becomes `-Users-you-myrepo`.
+Sessions are read from `~/.claude/projects/<encoded-cwd>/` — where `<encoded-cwd>` is your absolute workspace path with every non-alphanumeric character replaced by `-`. For example `/Users/you/myrepo.git/main` becomes `-Users-you-myrepo-git-main`.
 
 Each session entry shows:
-- **Label** — the first user message (up to 80 characters)
-- **Description** — the git branch and a relative timestamp (`5m ago`, `2h ago`, etc.)
+- **Label** — the first user message, whitespace-collapsed and truncated to ~50 characters
+- **Description** — relative time when grouped by worktree; `branch · time` when flat
 - **Icon** — reflects a heuristic status based on the file's last-modified time:
   - Blue pulse — **active** (file written within the last 2 minutes)
-  - Blue history — **recent** (file written within the last hour)
+  - Blue clock — **recent** (file written within the last hour)
   - Gray history — **idle** (older than 1 hour)
+
+Relative time switches to absolute (`Apr 23`) for sessions older than 7 days, and the panel auto-refreshes every 60 seconds while visible so labels don't go stale.
 
 > **Note:** The status icon is a heuristic derived from file mtime, not a real signal from Claude Code. A paused session that last wrote 90 seconds ago will show as "active" even if Claude has stopped.
 
-Hover over a session for a tooltip with: full first message, session ID, message count, last activity timestamp, CWD, and file path.
+Hover over a session for a tooltip with: heuristic disclosure, last activity, branch, message count, session ID, CWD, and file path.
 
 ### Worktree grouping
 
-When your workspace is a gw-managed bare repo, sessions are automatically grouped by worktree. When `.gw/config.json` is present, sibling worktrees are discovered via that config. Otherwise, `git worktree list` is used as a fallback. If only one worktree is detected, sessions are shown flat (no grouping).
+When the workspace is part of a multi-worktree setup (gw-managed or plain git), sessions are grouped by worktree. The current worktree is pinned to the top, marked **(current)**, and expanded by default; other worktrees are collapsed. Discovery priority: `.gw/config.json` (sibling worktrees) → `git worktree list --porcelain` → just the workspace path. Single-worktree workspaces show a flat list.
+
+Sessions launched from sub-directories of a worktree (e.g. `apps/api/` inside `feat/foo/`) are also surfaced and bucketed under their parent worktree by reading the `cwd` field on the session events.
+
+### Filtering
+
+Use the **filter icon** in the Sessions panel header (or the command **Toggle Sessions Scope**) to switch between:
+- **All worktrees** (default) — every worktree's sessions, grouped, current first
+- **Current worktree only** — flat list of just this worktree's sessions
+
+The choice is persisted in `agentTasks.sessions.scope`.
 
 ### Click behavior
 
@@ -76,6 +88,7 @@ As of this release, the extension also activates via `onStartupFinished` so the 
 | `agentTasks.autoOpenPlan` | `true` | Auto-open `plan.md` in Preview when created. |
 | `agentTasks.openMarkdownInPreview` | `true` | Open artifact files in Markdown Preview mode. |
 | `agentTasks.sessions.openWith` | `"editor"` | What to do when a session is clicked: `"editor"` opens the JSONL file; `"resume"` runs `claude --resume <session-id>` in a new terminal. |
+| `agentTasks.sessions.scope` | `"all"` | Which worktrees the Sessions panel includes: `"all"` shows every worktree (grouped, current first); `"current"` shows only the current worktree. Toggle quickly via the filter icon in the panel header. |
 
 ### Configurable directories
 

--- a/packages/vscode-agent-tasks/README.md
+++ b/packages/vscode-agent-tasks/README.md
@@ -68,8 +68,12 @@ Clicking a session does one of two things depending on the `agentTasks.sessions.
 
 | Value | Behavior |
 |-------|----------|
-| `"editor"` (default) | Opens the JSONL transcript file in the VS Code text editor |
-| `"resume"` | Opens a new terminal and runs `claude --resume <session-id>` |
+| `"resume"` (default) | Opens a terminal in the session's original CWD and runs `claude --resume <session-id>` |
+| `"editor"` | Opens the JSONL transcript file in the VS Code text editor |
+
+In **resume** mode the extension tracks which terminal belongs to which session within this VS Code window. Clicking the same session again focuses the existing terminal tab instead of spawning a duplicate. Closing the terminal removes the association, so a subsequent click starts a fresh process.
+
+Cross-window terminal tracking isn't possible — the VS Code extension API is window-scoped. If you've resumed the same session in another VS Code window, clicking here will start a second `claude --resume` against the same JSONL. Claude Code itself handles this gracefully but you'll have two processes appending to the same file.
 
 > **Note:** `resume` mode requires `claude` to be on your `PATH`. If `claude` is not installed or not found, the terminal will show an error — the extension does not validate the command.
 
@@ -87,7 +91,7 @@ As of this release, the extension also activates via `onStartupFinished` so the 
 | `agentTasks.autoOpenWalkthrough` | `true` | Auto-open `walkthrough.md` in Preview when created. |
 | `agentTasks.autoOpenPlan` | `true` | Auto-open `plan.md` in Preview when created. |
 | `agentTasks.openMarkdownInPreview` | `true` | Open artifact files in Markdown Preview mode. |
-| `agentTasks.sessions.openWith` | `"editor"` | What to do when a session is clicked: `"editor"` opens the JSONL file; `"resume"` runs `claude --resume <session-id>` in a new terminal. |
+| `agentTasks.sessions.openWith` | `"resume"` | What to do when a session is clicked: `"resume"` opens a terminal in the session's original CWD and runs `claude --resume <session-id>`; `"editor"` opens the JSONL file instead. |
 | `agentTasks.sessions.scope` | `"all"` | Which worktrees the Sessions panel includes: `"all"` shows every worktree (grouped, current first); `"current"` shows only the current worktree. Toggle quickly via the filter icon in the panel header. |
 
 ### Configurable directories

--- a/packages/vscode-agent-tasks/README.md
+++ b/packages/vscode-agent-tasks/README.md
@@ -10,6 +10,7 @@ Visualize autonomous agent workflow artifacts (`plan.md`, `task.md`, `walkthroug
 - **Walkthrough & plan auto-open** — when a `walkthrough.md` or `plan.md` is created, the extension opens it automatically in Markdown Preview (each toggleable)
 - **Configurable directories** — scan `.agent/`, `.gw/`, or any custom directory name
 - **Sort** — sort by date, name, or status; ascending or descending
+- **Sessions panel** — view Claude Code session history for the current workspace and sibling worktrees; click to open the transcript or resume the session in a terminal
 
 ## Install
 
@@ -25,6 +26,45 @@ mthines.agent-tasks
 2. Click the **Agent Tasks** icon in the Activity Bar.
 3. Expand a branch entry to see tasks, plan, and walkthrough.
 
+## Sessions
+
+The **Sessions** panel (below the Agent Tasks view in the same activity-bar container) lists Claude Code session history for the current workspace.
+
+### How it works
+
+Sessions are read from `~/.claude/projects/<encoded-cwd>/` — where `<encoded-cwd>` is your absolute workspace path with every `/` replaced by `-`. For example `/Users/you/myrepo` becomes `-Users-you-myrepo`.
+
+Each session entry shows:
+- **Label** — the first user message (up to 80 characters)
+- **Description** — the git branch and a relative timestamp (`5m ago`, `2h ago`, etc.)
+- **Icon** — reflects a heuristic status based on the file's last-modified time:
+  - Blue pulse — **active** (file written within the last 2 minutes)
+  - Blue history — **recent** (file written within the last hour)
+  - Gray history — **idle** (older than 1 hour)
+
+> **Note:** The status icon is a heuristic derived from file mtime, not a real signal from Claude Code. A paused session that last wrote 90 seconds ago will show as "active" even if Claude has stopped.
+
+Hover over a session for a tooltip with: full first message, session ID, message count, last activity timestamp, CWD, and file path.
+
+### Worktree grouping
+
+When your workspace is a gw-managed bare repo, sessions are automatically grouped by worktree. When `.gw/config.json` is present, sibling worktrees are discovered via that config. Otherwise, `git worktree list` is used as a fallback. If only one worktree is detected, sessions are shown flat (no grouping).
+
+### Click behavior
+
+Clicking a session does one of two things depending on the `agentTasks.sessions.openWith` setting:
+
+| Value | Behavior |
+|-------|----------|
+| `"editor"` (default) | Opens the JSONL transcript file in the VS Code text editor |
+| `"resume"` | Opens a new terminal and runs `claude --resume <session-id>` |
+
+> **Note:** `resume` mode requires `claude` to be on your `PATH`. If `claude` is not installed or not found, the terminal will show an error — the extension does not validate the command.
+
+### Activation note
+
+As of this release, the extension also activates via `onStartupFinished` so the Sessions panel works in any workspace — even those without `.agent/` or `.gw/` directories. This means the extension is active in all workspaces. The startup overhead is minimal (~50 ms). If you only want it active in agent-workflow repos, remove `onStartupFinished` from `activationEvents` in a local extension build.
+
 ## Settings
 
 | Setting | Default | Description |
@@ -35,6 +75,7 @@ mthines.agent-tasks
 | `agentTasks.autoOpenWalkthrough` | `true` | Auto-open `walkthrough.md` in Preview when created. |
 | `agentTasks.autoOpenPlan` | `true` | Auto-open `plan.md` in Preview when created. |
 | `agentTasks.openMarkdownInPreview` | `true` | Open artifact files in Markdown Preview mode. |
+| `agentTasks.sessions.openWith` | `"editor"` | What to do when a session is clicked: `"editor"` opens the JSONL file; `"resume"` runs `claude --resume <session-id>` in a new terminal. |
 
 ### Configurable directories
 

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {
@@ -109,6 +109,12 @@
         "command": "agentTasks.sessions.openSession",
         "title": "Open Session",
         "category": "Agent Tasks"
+      },
+      {
+        "command": "agentTasks.sessions.toggleScope",
+        "title": "Toggle Sessions Scope (current / all worktrees)",
+        "icon": "$(filter)",
+        "category": "Agent Tasks"
       }
     ],
     "menus": {
@@ -146,9 +152,14 @@
           "group": "navigation"
         },
         {
+          "command": "agentTasks.sessions.toggleScope",
+          "when": "view == agentSessionsExplorer",
+          "group": "navigation@1"
+        },
+        {
           "command": "agentTasks.sessions.refresh",
           "when": "view == agentSessionsExplorer",
-          "group": "navigation"
+          "group": "navigation@2"
         }
       ],
       "view/item/context": [
@@ -239,9 +250,28 @@
             "Open a terminal and run 'claude --resume <session-id>'"
           ],
           "description": "What to do when a session is clicked in the Sessions panel."
+        },
+        "agentTasks.sessions.scope": {
+          "type": "string",
+          "default": "all",
+          "enum": [
+            "current",
+            "all"
+          ],
+          "enumDescriptions": [
+            "Show only sessions for the current worktree",
+            "Show sessions for the current worktree and all sibling worktrees"
+          ],
+          "description": "Which worktrees the Sessions panel includes. Toggle quickly via the filter icon in the panel header."
         }
       }
-    }
+    },
+    "viewsWelcome": [
+      {
+        "view": "agentSessionsExplorer",
+        "contents": "No Claude Code sessions found for this workspace yet.\n\nStart one in a terminal:\n[Open Terminal](command:workbench.action.terminal.new)\n\nThen run `claude` in your project directory.\n\n_Tip: press Enter on a session to open it, or change `agentTasks.sessions.openWith` to `resume` to continue it in a terminal._"
+      }
+    ]
   },
   "devDependencies": {
     "@types/node": "20.19.9",

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {
@@ -240,14 +240,14 @@
         },
         "agentTasks.sessions.openWith": {
           "type": "string",
-          "default": "editor",
+          "default": "resume",
           "enum": [
-            "editor",
-            "resume"
+            "resume",
+            "editor"
           ],
           "enumDescriptions": [
-            "Open the session JSONL file in the text editor",
-            "Open a terminal and run 'claude --resume <session-id>'"
+            "Open a terminal in the session's original CWD and run 'claude --resume <session-id>'",
+            "Open the session JSONL transcript file in the text editor"
           ],
           "description": "What to do when a session is clicked in the Sessions panel."
         },
@@ -269,7 +269,7 @@
     "viewsWelcome": [
       {
         "view": "agentSessionsExplorer",
-        "contents": "No Claude Code sessions found for this workspace yet.\n\nStart one in a terminal:\n[Open Terminal](command:workbench.action.terminal.new)\n\nThen run `claude` in your project directory.\n\n_Tip: press Enter on a session to open it, or change `agentTasks.sessions.openWith` to `resume` to continue it in a terminal._"
+        "contents": "No Claude Code sessions found for this workspace yet.\n\nStart one in a terminal:\n[Open Terminal](command:workbench.action.terminal.new)\n\nThen run `claude` in your project directory.\n\n_Tip: press Enter on a session to resume it in a terminal. Set `agentTasks.sessions.openWith` to `editor` to open the JSONL transcript instead._"
       }
     ]
   },

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {
@@ -26,7 +26,9 @@
   ],
   "activationEvents": [
     "workspaceContains:.agent",
-    "workspaceContains:.gw"
+    "workspaceContains:.gw",
+    "onStartupFinished",
+    "onView:agentSessionsExplorer"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -46,6 +48,12 @@
           "name": "Agent Tasks",
           "icon": "$(tasklist)",
           "contextualTitle": "Agent Tasks"
+        },
+        {
+          "id": "agentSessionsExplorer",
+          "name": "Sessions",
+          "icon": "$(history)",
+          "contextualTitle": "Claude Sessions"
         }
       ]
     },
@@ -90,6 +98,17 @@
         "command": "agentTasks.openMarkdown",
         "title": "Open Markdown File",
         "category": "Agent Tasks"
+      },
+      {
+        "command": "agentTasks.sessions.refresh",
+        "title": "Refresh Sessions",
+        "icon": "$(refresh)",
+        "category": "Agent Tasks"
+      },
+      {
+        "command": "agentTasks.sessions.openSession",
+        "title": "Open Session",
+        "category": "Agent Tasks"
       }
     ],
     "menus": {
@@ -109,6 +128,10 @@
         {
           "command": "agentTasks.openMarkdown",
           "when": "false"
+        },
+        {
+          "command": "agentTasks.sessions.openSession",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -120,6 +143,11 @@
         {
           "command": "agentTasks.sort",
           "when": "view == agentTasksExplorer",
+          "group": "navigation"
+        },
+        {
+          "command": "agentTasks.sessions.refresh",
+          "when": "view == agentSessionsExplorer",
           "group": "navigation"
         }
       ],
@@ -198,6 +226,19 @@
             "Descending (newest/Z-A first)"
           ],
           "description": "Sort order for agent tasks"
+        },
+        "agentTasks.sessions.openWith": {
+          "type": "string",
+          "default": "editor",
+          "enum": [
+            "editor",
+            "resume"
+          ],
+          "enumDescriptions": [
+            "Open the session JSONL file in the text editor",
+            "Open a terminal and run 'claude --resume <session-id>'"
+          ],
+          "description": "What to do when a session is clicked in the Sessions panel."
         }
       }
     }

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-agent-tasks/src/extension.ts
+++ b/packages/vscode-agent-tasks/src/extension.ts
@@ -142,6 +142,60 @@ export function activate(context: vscode.ExtensionContext): void {
     sessionWatcher.rebuild(sessionsProvider.sessionDirs);
   });
 
+  const sessionsToggleScopeCmd = vscode.commands.registerCommand(
+    'agentTasks.sessions.toggleScope',
+    async () => {
+      const cfg = vscode.workspace.getConfiguration('agentTasks.sessions');
+      const current = cfg.get<string>('scope', 'all');
+      const next = current === 'current' ? 'all' : 'current';
+      await cfg.update('scope', next, vscode.ConfigurationTarget.Global);
+      sessionsProvider.refresh();
+      sessionWatcher.rebuild(sessionsProvider.sessionDirs);
+      vscode.window.setStatusBarMessage(
+        next === 'current'
+          ? 'Sessions: showing current worktree only'
+          : 'Sessions: showing all worktrees',
+        2500
+      );
+    }
+  );
+
+  // Periodic refresh while the Sessions view is visible. Relative-time labels
+  // (e.g. "1m ago") would otherwise stay stale until the next file write
+  // triggers a watcher event. Tick every 60s, but only when visible to avoid
+  // wasted work in the background.
+  let tickTimer: ReturnType<typeof setInterval> | undefined;
+  const startTick = () => {
+    if (tickTimer) return;
+    tickTimer = setInterval(() => sessionsProvider.refresh(), 60_000);
+  };
+  const stopTick = () => {
+    if (tickTimer) {
+      clearInterval(tickTimer);
+      tickTimer = undefined;
+    }
+  };
+  if (sessionsView.visible) startTick();
+  const visibilitySub = sessionsView.onDidChangeVisibility((e) => {
+    if (e.visible) {
+      sessionsProvider.refresh();
+      startTick();
+    } else {
+      stopTick();
+    }
+  });
+
+  const tickDisposable: vscode.Disposable = { dispose: stopTick };
+
+  // React to scope config changes from settings UI (so the user doesn't have
+  // to manually refresh after editing settings.json).
+  const configSub = vscode.workspace.onDidChangeConfiguration((e) => {
+    if (e.affectsConfiguration('agentTasks.sessions.scope')) {
+      sessionsProvider.refresh();
+      sessionWatcher.rebuild(sessionsProvider.sessionDirs);
+    }
+  });
+
   const openSessionCmd = vscode.commands.registerCommand(
     'agentTasks.sessions.openSession',
     async (item: SessionItem) => {
@@ -184,6 +238,10 @@ export function activate(context: vscode.ExtensionContext): void {
     sessionWatcher,
     workspaceFolderSub,
     sessionsRefreshCmd,
+    sessionsToggleScopeCmd,
+    visibilitySub,
+    tickDisposable,
+    configSub,
     openSessionCmd
   );
 }

--- a/packages/vscode-agent-tasks/src/extension.ts
+++ b/packages/vscode-agent-tasks/src/extension.ts
@@ -9,8 +9,11 @@ import { AgentTasksProvider } from './providers/agent-tasks-provider';
 import { ArtifactWatcher } from './watchers/artifact-watcher';
 import { SessionsProvider, SessionItem } from './providers/sessions-provider';
 import { SessionWatcher } from './watchers/session-watcher';
+import { initLogger, log, logError } from './lib/logger';
 
 export function activate(context: vscode.ExtensionContext): void {
+  initLogger(context);
+  log('agent-tasks extension activated');
   // Create the tree data provider
   const agentTasksProvider = new AgentTasksProvider();
 
@@ -119,12 +122,13 @@ export function activate(context: vscode.ExtensionContext): void {
   const sessionWatcher = new SessionWatcher();
 
   sessionWatcher.onSessionChanged(() => {
+    log('Session file changed → refreshing tree');
     sessionsProvider.refresh();
   });
 
   // Rebuild the watcher whenever the workspace folders change
   const workspaceFolderSub = vscode.workspace.onDidChangeWorkspaceFolders(() => {
-    // Refresh provider first so sessionDirs is updated
+    log('Workspace folders changed — refreshing sessions');
     sessionsProvider.refresh();
     sessionWatcher.rebuild(sessionsProvider.sessionDirs);
   });
@@ -134,12 +138,15 @@ export function activate(context: vscode.ExtensionContext): void {
   // the tree view completes its first getChildren call.
   void Promise.resolve().then(() => {
     sessionWatcher.rebuild(sessionsProvider.sessionDirs);
+    log(`Initial sessions watcher attached: ${sessionsProvider.sessionDirs.length} dir(s)`);
   });
 
   const sessionsRefreshCmd = vscode.commands.registerCommand('agentTasks.sessions.refresh', () => {
+    log('Command: sessions.refresh');
     sessionsProvider.refresh();
     // Rebuild watchers in case new worktrees appeared
     sessionWatcher.rebuild(sessionsProvider.sessionDirs);
+    log(`Sessions watcher rebuilt: ${sessionsProvider.sessionDirs.length} dir(s)`);
   });
 
   const sessionsToggleScopeCmd = vscode.commands.registerCommand(
@@ -148,6 +155,7 @@ export function activate(context: vscode.ExtensionContext): void {
       const cfg = vscode.workspace.getConfiguration('agentTasks.sessions');
       const current = cfg.get<string>('scope', 'all');
       const next = current === 'current' ? 'all' : 'current';
+      log(`Command: sessions.toggleScope (${current} → ${next})`);
       await cfg.update('scope', next, vscode.ConfigurationTarget.Global);
       sessionsProvider.refresh();
       sessionWatcher.rebuild(sessionsProvider.sessionDirs);
@@ -206,6 +214,7 @@ export function activate(context: vscode.ExtensionContext): void {
     for (const [sid, term] of sessionTerminals) {
       if (term === t) {
         sessionTerminals.delete(sid);
+        log(`Terminal closed for session ${sid.slice(0, 8)}`);
         break;
       }
     }
@@ -220,14 +229,21 @@ export function activate(context: vscode.ExtensionContext): void {
         .getConfiguration('agentTasks.sessions')
         .get<string>('openWith', 'resume');
 
+      const sid = item.session.sessionId;
+      log(`Command: sessions.openSession (id=${sid.slice(0, 8)}, mode=${openWith})`);
+
       if (openWith === 'resume') {
-        const sid = item.session.sessionId;
+        // Optimistic UI: flip the icon to "active" right now so the panel
+        // feels instant. The watcher will overwrite this with the real mtime
+        // as soon as claude writes its first event.
+        sessionsProvider.touchActive(sid);
 
         // If we already have a terminal for this session and it's still alive,
         // just focus it. exitStatus stays `undefined` while the process is
         // running and gets set when it exits.
         const existing = sessionTerminals.get(sid);
         if (existing && existing.exitStatus === undefined) {
+          log(`Focusing existing terminal for session ${sid.slice(0, 8)}`);
           existing.show(/* preserveFocus */ false);
           return;
         }
@@ -240,6 +256,8 @@ export function activate(context: vscode.ExtensionContext): void {
         const shortId = sid.slice(0, 8);
         const cwd =
           item.session.cwd ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+        log(`Creating terminal for session ${shortId} (branch=${branch}, cwd=${cwd ?? '?'})`);
 
         const terminal = vscode.window.createTerminal({
           name: `Claude · ${branch} · ${shortId}`,
@@ -255,7 +273,8 @@ export function activate(context: vscode.ExtensionContext): void {
         try {
           const doc = await vscode.workspace.openTextDocument(uri);
           await vscode.window.showTextDocument(doc, { preview: false });
-        } catch {
+        } catch (err) {
+          logError(`Failed to open session file ${item.session.filePath}`, err);
           vscode.window.showWarningMessage(`Could not open session file: ${item.session.filePath}`);
         }
       }

--- a/packages/vscode-agent-tasks/src/extension.ts
+++ b/packages/vscode-agent-tasks/src/extension.ts
@@ -214,6 +214,7 @@ export function activate(context: vscode.ExtensionContext): void {
     for (const [sid, term] of sessionTerminals) {
       if (term === t) {
         sessionTerminals.delete(sid);
+        sessionsProvider.setTerminalOpen(sid, false);
         log(`Terminal closed for session ${sid.slice(0, 8)}`);
         break;
       }
@@ -233,17 +234,13 @@ export function activate(context: vscode.ExtensionContext): void {
       log(`Command: sessions.openSession (id=${sid.slice(0, 8)}, mode=${openWith})`);
 
       if (openWith === 'resume') {
-        // Optimistic UI: flip the icon to "active" right now so the panel
-        // feels instant. The watcher will overwrite this with the real mtime
-        // as soon as claude writes its first event.
-        sessionsProvider.touchActive(sid);
-
         // If we already have a terminal for this session and it's still alive,
         // just focus it. exitStatus stays `undefined` while the process is
         // running and gets set when it exits.
         const existing = sessionTerminals.get(sid);
         if (existing && existing.exitStatus === undefined) {
           log(`Focusing existing terminal for session ${sid.slice(0, 8)}`);
+          sessionsProvider.setTerminalOpen(sid, true); // idempotent
           existing.show(/* preserveFocus */ false);
           return;
         }
@@ -265,6 +262,9 @@ export function activate(context: vscode.ExtensionContext): void {
           iconPath: new vscode.ThemeIcon('comment-discussion'),
         });
         sessionTerminals.set(sid, terminal);
+        // Mark as active immediately so the icon updates without waiting for
+        // claude's first JSONL write.
+        sessionsProvider.setTerminalOpen(sid, true);
         terminal.show();
         terminal.sendText(`claude --resume ${sid}`);
       } else {

--- a/packages/vscode-agent-tasks/src/extension.ts
+++ b/packages/vscode-agent-tasks/src/extension.ts
@@ -7,6 +7,8 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { AgentTasksProvider } from './providers/agent-tasks-provider';
 import { ArtifactWatcher } from './watchers/artifact-watcher';
+import { SessionsProvider, SessionItem } from './providers/sessions-provider';
+import { SessionWatcher } from './watchers/session-watcher';
 
 export function activate(context: vscode.ExtensionContext): void {
   // Create the tree data provider
@@ -99,6 +101,74 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  // -------------------------------------------------------------------------
+  // Sessions panel
+  // -------------------------------------------------------------------------
+
+  const sessionsProvider = new SessionsProvider();
+
+  const sessionsView = vscode.window.createTreeView('agentSessionsExplorer', {
+    treeDataProvider: sessionsProvider,
+    showCollapseAll: true,
+  });
+
+  // Start watching the session dirs that the provider discovered on first render.
+  // We need to trigger a first getChildren call to populate sessionDirs; we do
+  // that lazily on the first onSessionChanged subscription by scheduling a
+  // deferred rebuild below.
+  const sessionWatcher = new SessionWatcher();
+
+  sessionWatcher.onSessionChanged(() => {
+    sessionsProvider.refresh();
+  });
+
+  // Rebuild the watcher whenever the workspace folders change
+  const workspaceFolderSub = vscode.workspace.onDidChangeWorkspaceFolders(() => {
+    // Refresh provider first so sessionDirs is updated
+    sessionsProvider.refresh();
+    sessionWatcher.rebuild(sessionsProvider.sessionDirs);
+  });
+
+  // Deferred watcher rebuild: after the first tree render the sessionDirs
+  // will be populated. We schedule this as a micro-task so it fires after
+  // the tree view completes its first getChildren call.
+  void Promise.resolve().then(() => {
+    sessionWatcher.rebuild(sessionsProvider.sessionDirs);
+  });
+
+  const sessionsRefreshCmd = vscode.commands.registerCommand('agentTasks.sessions.refresh', () => {
+    sessionsProvider.refresh();
+    // Rebuild watchers in case new worktrees appeared
+    sessionWatcher.rebuild(sessionsProvider.sessionDirs);
+  });
+
+  const openSessionCmd = vscode.commands.registerCommand(
+    'agentTasks.sessions.openSession',
+    async (item: SessionItem) => {
+      if (!item?.session?.filePath) return;
+
+      const openWith = vscode.workspace
+        .getConfiguration('agentTasks.sessions')
+        .get<string>('openWith', 'editor');
+
+      if (openWith === 'resume') {
+        const terminal = vscode.window.createTerminal('Claude Resume');
+        terminal.show();
+        terminal.sendText(`claude --resume ${item.session.sessionId}`);
+      } else {
+        // editor (default)
+        const uri = vscode.Uri.file(item.session.filePath);
+        try {
+          const doc = await vscode.workspace.openTextDocument(uri);
+          await vscode.window.showTextDocument(doc, { preview: false });
+        } catch {
+          // File may have been deleted — show a message
+          vscode.window.showWarningMessage(`Could not open session file: ${item.session.filePath}`);
+        }
+      }
+    }
+  );
+
   context.subscriptions.push(
     agentTasksView,
     artifactWatcher,
@@ -108,7 +178,13 @@ export function activate(context: vscode.ExtensionContext): void {
     openMarkdownCmd,
     openPlanCmd,
     openTaskCmd,
-    openWalkthroughCmd
+    openWalkthroughCmd,
+    // Sessions panel
+    sessionsView,
+    sessionWatcher,
+    workspaceFolderSub,
+    sessionsRefreshCmd,
+    openSessionCmd
   );
 }
 

--- a/packages/vscode-agent-tasks/src/extension.ts
+++ b/packages/vscode-agent-tasks/src/extension.ts
@@ -196,6 +196,21 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  // Map of sessionId → terminal currently running `claude --resume` for that
+  // session in THIS window. Used so re-clicking a session focuses its existing
+  // terminal tab instead of spawning a duplicate. Cross-window tracking is not
+  // possible — VS Code's extension API is window-scoped.
+  const sessionTerminals = new Map<string, vscode.Terminal>();
+
+  const closeTerminalSub = vscode.window.onDidCloseTerminal((t) => {
+    for (const [sid, term] of sessionTerminals) {
+      if (term === t) {
+        sessionTerminals.delete(sid);
+        break;
+      }
+    }
+  });
+
   const openSessionCmd = vscode.commands.registerCommand(
     'agentTasks.sessions.openSession',
     async (item: SessionItem) => {
@@ -203,20 +218,44 @@ export function activate(context: vscode.ExtensionContext): void {
 
       const openWith = vscode.workspace
         .getConfiguration('agentTasks.sessions')
-        .get<string>('openWith', 'editor');
+        .get<string>('openWith', 'resume');
 
       if (openWith === 'resume') {
-        const terminal = vscode.window.createTerminal('Claude Resume');
+        const sid = item.session.sessionId;
+
+        // If we already have a terminal for this session and it's still alive,
+        // just focus it. exitStatus stays `undefined` while the process is
+        // running and gets set when it exits.
+        const existing = sessionTerminals.get(sid);
+        if (existing && existing.exitStatus === undefined) {
+          existing.show(/* preserveFocus */ false);
+          return;
+        }
+        if (existing) {
+          // Stale entry — terminal exited but onDidCloseTerminal hasn't fired
+          sessionTerminals.delete(sid);
+        }
+
+        const branch = item.session.gitBranch ?? '?';
+        const shortId = sid.slice(0, 8);
+        const cwd =
+          item.session.cwd ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+        const terminal = vscode.window.createTerminal({
+          name: `Claude · ${branch} · ${shortId}`,
+          cwd,
+          iconPath: new vscode.ThemeIcon('comment-discussion'),
+        });
+        sessionTerminals.set(sid, terminal);
         terminal.show();
-        terminal.sendText(`claude --resume ${item.session.sessionId}`);
+        terminal.sendText(`claude --resume ${sid}`);
       } else {
-        // editor (default)
+        // editor — opt-in via setting
         const uri = vscode.Uri.file(item.session.filePath);
         try {
           const doc = await vscode.workspace.openTextDocument(uri);
           await vscode.window.showTextDocument(doc, { preview: false });
         } catch {
-          // File may have been deleted — show a message
           vscode.window.showWarningMessage(`Could not open session file: ${item.session.filePath}`);
         }
       }
@@ -242,7 +281,8 @@ export function activate(context: vscode.ExtensionContext): void {
     visibilitySub,
     tickDisposable,
     configSub,
-    openSessionCmd
+    openSessionCmd,
+    closeTerminalSub
   );
 }
 

--- a/packages/vscode-agent-tasks/src/lib/logger.ts
+++ b/packages/vscode-agent-tasks/src/lib/logger.ts
@@ -1,0 +1,40 @@
+/**
+ * Output-channel logger for the Agent Tasks extension.
+ *
+ * Channel name: `mthines.agent-tasks` (mirrors the `gw` extension's logger
+ * pattern but namespaced by publisher.id so users can find it under
+ * View → Output → mthines.agent-tasks).
+ */
+
+import * as vscode from 'vscode';
+
+let channel: vscode.OutputChannel | undefined;
+
+function ts(): string {
+  return new Date().toLocaleTimeString();
+}
+
+/** Initialise the output channel. Idempotent — safe to call multiple times. */
+export function initLogger(context: vscode.ExtensionContext): void {
+  if (channel) return;
+  channel = vscode.window.createOutputChannel('mthines.agent-tasks');
+  context.subscriptions.push(channel);
+  log('Logger initialised');
+}
+
+/** Append a timestamped line to the output channel. No-op if not initialised. */
+export function log(message: string): void {
+  channel?.appendLine(`[${ts()}] ${message}`);
+}
+
+/**
+ * Log an error with optional context. Renders the error message and stack on
+ * a separate line for grep-ability in the channel.
+ */
+export function logError(message: string, err: unknown): void {
+  const msg = err instanceof Error ? err.message : String(err);
+  channel?.appendLine(`[${ts()}] ERROR ${message}: ${msg}`);
+  if (err instanceof Error && err.stack) {
+    channel?.appendLine(err.stack);
+  }
+}

--- a/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.test.ts
+++ b/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.test.ts
@@ -89,6 +89,28 @@ describe('encodeWorkspacePath', () => {
   it('handles path with no slashes (edge case)', () => {
     expect(encodeWorkspacePath('noslash')).toBe('noslash');
   });
+
+  it('replaces dots with dashes (e.g. `.git` → `-git`)', () => {
+    expect(encodeWorkspacePath('/Users/mthines/Workspace/yourstory-ai.git/main')).toBe(
+      '-Users-mthines-Workspace-yourstory-ai-git-main'
+    );
+  });
+
+  it('encodes a leading dot directory (`/.claude` → `--claude`)', () => {
+    expect(encodeWorkspacePath('/Users/mthines/.claude')).toBe('-Users-mthines--claude');
+  });
+
+  it('replaces spaces with dashes', () => {
+    expect(encodeWorkspacePath('/Users/mthines/Library/Application Support/Code')).toBe(
+      '-Users-mthines-Library-Application-Support-Code'
+    );
+  });
+
+  it('preserves existing hyphens in path segments', () => {
+    expect(encodeWorkspacePath('/Users/mthines/Workspace/gw-tools.git/main')).toBe(
+      '-Users-mthines-Workspace-gw-tools-git-main'
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.test.ts
+++ b/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  encodeWorkspacePath,
+  getSessionStatus,
+  parseSessionFile,
+  parseSessionsInDir,
+  getClaudeProjectsDir,
+  getSessionsDir,
+} from './session-jsonl-parser';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a JSONL string from an array of event objects.
+ * Each object is serialised to one line.
+ */
+function buildJsonl(events: object[]): string {
+  return events.map((e) => JSON.stringify(e)).join('\n');
+}
+
+const SAMPLE_SESSION_ID = 'abc12345-dead-beef-0000-111122223333';
+
+/** Minimal valid `user` event. */
+function userEvent(overrides: object = {}): object {
+  return {
+    type: 'user',
+    sessionId: SAMPLE_SESSION_ID,
+    gitBranch: 'feat/my-feature',
+    cwd: '/Users/mthines/Workspace/myrepo',
+    timestamp: '2026-04-30T12:00:00.000Z',
+    isSidechain: false,
+    message: { content: 'Hello, Claude!' },
+    ...overrides,
+  };
+}
+
+/** Minimal valid `assistant` event. */
+function assistantEvent(overrides: object = {}): object {
+  return {
+    type: 'assistant',
+    sessionId: SAMPLE_SESSION_ID,
+    timestamp: '2026-04-30T12:01:00.000Z',
+    message: { content: [{ type: 'text', text: 'Hello, human!' }] },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Temp-directory fixture
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Write JSONL content to a file in tmpDir and return the absolute path. */
+function writeJsonl(name: string, content: string): string {
+  const filePath = path.join(tmpDir, name);
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// encodeWorkspacePath
+// ---------------------------------------------------------------------------
+
+describe('encodeWorkspacePath', () => {
+  it('replaces all slashes with dashes', () => {
+    expect(encodeWorkspacePath('/Users/mthines/Workspace/mthines/repo')).toBe(
+      '-Users-mthines-Workspace-mthines-repo'
+    );
+  });
+
+  it('handles root slash', () => {
+    expect(encodeWorkspacePath('/foo')).toBe('-foo');
+  });
+
+  it('handles path with no slashes (edge case)', () => {
+    expect(encodeWorkspacePath('noslash')).toBe('noslash');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSessionsDir
+// ---------------------------------------------------------------------------
+
+describe('getSessionsDir', () => {
+  it('combines claude projects dir with encoded path', () => {
+    const result = getSessionsDir('/Users/mthines/myrepo');
+    expect(result).toBe(`${getClaudeProjectsDir()}/-Users-mthines-myrepo`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSessionStatus
+// ---------------------------------------------------------------------------
+
+describe('getSessionStatus', () => {
+  it('returns active within 2 minutes', () => {
+    const mtime = Date.now() - 60 * 1000; // 1 minute ago
+    expect(getSessionStatus(mtime)).toBe('active');
+  });
+
+  it('returns recent within 1 hour', () => {
+    const mtime = Date.now() - 30 * 60 * 1000; // 30 minutes ago
+    expect(getSessionStatus(mtime)).toBe('recent');
+  });
+
+  it('returns idle beyond 1 hour', () => {
+    const mtime = Date.now() - 2 * 60 * 60 * 1000; // 2 hours ago
+    expect(getSessionStatus(mtime)).toBe('idle');
+  });
+
+  it('returns active at exactly 0ms age', () => {
+    expect(getSessionStatus(Date.now())).toBe('active');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSessionFile
+// ---------------------------------------------------------------------------
+
+describe('parseSessionFile', () => {
+  it('returns null for empty file', () => {
+    const filePath = writeJsonl('empty.jsonl', '');
+    expect(parseSessionFile(filePath)).toBeNull();
+  });
+
+  it('returns null when file does not exist', () => {
+    expect(parseSessionFile(path.join(tmpDir, 'nonexistent.jsonl'))).toBeNull();
+  });
+
+  it('returns null for file with no user events', () => {
+    const jsonl = buildJsonl([
+      { type: 'file-history-snapshot', files: [] },
+      { type: 'permission-mode', mode: 'default' },
+    ]);
+    const filePath = writeJsonl('no-user.jsonl', jsonl);
+    expect(parseSessionFile(filePath)).toBeNull();
+  });
+
+  it('parses sessionId from first user event', () => {
+    const filePath = writeJsonl('session.jsonl', buildJsonl([userEvent()]));
+    const result = parseSessionFile(filePath);
+    expect(result?.sessionId).toBe(SAMPLE_SESSION_ID);
+  });
+
+  it('extracts title from string content', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([userEvent({ message: { content: 'Please implement the login feature' } })])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.title).toBe('Please implement the login feature');
+  });
+
+  it('extracts title from list content with text part', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([
+        userEvent({
+          message: {
+            content: [
+              { type: 'tool_result', content: 'ignored' },
+              { type: 'text', text: 'Implement the payments module' },
+            ],
+          },
+        }),
+      ])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.title).toBe('Implement the payments module');
+  });
+
+  it('truncates title to 80 chars with ellipsis', () => {
+    const longMessage = 'A'.repeat(100);
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([userEvent({ message: { content: longMessage } })])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.title).toBe('A'.repeat(80) + '\u2026');
+    expect(result?.title?.length).toBe(81);
+  });
+
+  it('falls back to sessionId prefix when no user message content found', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([{ type: 'user', sessionId: SAMPLE_SESSION_ID, message: { content: '' } }])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.title).toBe(SAMPLE_SESSION_ID.slice(0, 8));
+  });
+
+  it('skips isSidechain user events for title extraction', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([
+        userEvent({
+          isSidechain: true,
+          message: { content: 'SIDECHAIN: should be ignored' },
+        }),
+        userEvent({
+          isSidechain: false,
+          message: { content: 'Real user message' },
+          timestamp: '2026-04-30T12:05:00.000Z',
+        }),
+      ])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.title).toBe('Real user message');
+  });
+
+  it('extracts gitBranch and cwd from first user event', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([userEvent({ gitBranch: 'main', cwd: '/Users/mthines/project' })])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.gitBranch).toBe('main');
+    expect(result?.cwd).toBe('/Users/mthines/project');
+  });
+
+  it('handles missing gitBranch gracefully', () => {
+    // Build event without gitBranch
+    const event: Record<string, unknown> = {
+      type: 'user',
+      sessionId: SAMPLE_SESSION_ID,
+      cwd: '/Users/mthines/project',
+      timestamp: '2026-04-30T12:00:00.000Z',
+      message: { content: 'Hello' },
+    };
+    const filePath = writeJsonl('session.jsonl', buildJsonl([event]));
+    const result = parseSessionFile(filePath);
+    expect(result?.gitBranch).toBeUndefined();
+  });
+
+  it('counts user and assistant messages', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([
+        userEvent(),
+        assistantEvent(),
+        userEvent({ timestamp: '2026-04-30T12:02:00.000Z' }),
+        assistantEvent({ timestamp: '2026-04-30T12:03:00.000Z' }),
+        userEvent({ timestamp: '2026-04-30T12:04:00.000Z' }),
+      ])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.messageCount).toBe(5);
+  });
+
+  it('counts sidechain user events in messageCount', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([
+        userEvent({ isSidechain: true }),
+        userEvent({ isSidechain: false }),
+        assistantEvent(),
+      ])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.messageCount).toBe(3);
+  });
+
+  it('handles unknown event types without throwing', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([
+        { type: 'widget-result', data: { foo: 'bar' } },
+        { type: 'attachment', content: 'base64data' },
+        { type: 'last-prompt', prompt: 'blah' },
+        userEvent(),
+      ])
+    );
+    expect(() => parseSessionFile(filePath)).not.toThrow();
+    const result = parseSessionFile(filePath);
+    expect(result?.sessionId).toBe(SAMPLE_SESSION_ID);
+    // Unknown events not counted in messageCount
+    expect(result?.messageCount).toBe(1);
+  });
+
+  it('extracts firstTimestamp from first user event', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([
+        userEvent({ timestamp: '2026-04-30T10:00:00.000Z' }),
+        assistantEvent({ timestamp: '2026-04-30T10:01:00.000Z' }),
+      ])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.firstTimestamp).toBe('2026-04-30T10:00:00.000Z');
+  });
+
+  it('extracts lastTimestamp from last user or assistant event', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([
+        userEvent({ timestamp: '2026-04-30T10:00:00.000Z' }),
+        assistantEvent({ timestamp: '2026-04-30T10:05:00.000Z' }),
+      ])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.lastTimestamp).toBe('2026-04-30T10:05:00.000Z');
+  });
+
+  it('returns mtime from the actual file', () => {
+    const filePath = writeJsonl('session.jsonl', buildJsonl([userEvent()]));
+    const stat = fs.statSync(filePath);
+    const result = parseSessionFile(filePath);
+    expect(result?.mtime).toBe(stat.mtimeMs);
+  });
+
+  it('survives a malformed JSON line without throwing', () => {
+    const goodLine = JSON.stringify(userEvent());
+    const badLine = '{ "type": "user", broken json ';
+    const filePath = writeJsonl('session.jsonl', `${badLine}\n${goodLine}`);
+    expect(() => parseSessionFile(filePath)).not.toThrow();
+    const result = parseSessionFile(filePath);
+    expect(result?.sessionId).toBe(SAMPLE_SESSION_ID);
+  });
+
+  it('handles file-history-snapshot before first user event', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([
+        { type: 'file-history-snapshot', sessionId: SAMPLE_SESSION_ID, files: [] },
+        { type: 'permission-mode', mode: 'default' },
+        userEvent({ message: { content: 'Actual task description' } }),
+      ])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.title).toBe('Actual task description');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSessionsInDir
+// ---------------------------------------------------------------------------
+
+describe('parseSessionsInDir', () => {
+  it('returns empty array for non-existent directory', () => {
+    expect(parseSessionsInDir(path.join(tmpDir, 'nonexistent'))).toEqual([]);
+  });
+
+  it('returns empty array for directory with no jsonl files', () => {
+    fs.writeFileSync(path.join(tmpDir, 'README.md'), '# hello');
+    fs.writeFileSync(path.join(tmpDir, 'config.json'), '{}');
+    expect(parseSessionsInDir(tmpDir)).toEqual([]);
+  });
+
+  it('parses multiple jsonl files and sorts newest-first', () => {
+    // Write two session files
+    const file1 = writeJsonl('session1.jsonl', buildJsonl([userEvent({ sessionId: 'aaa00000' })]));
+    const file2 = writeJsonl(
+      'session2.jsonl',
+      buildJsonl([userEvent({ sessionId: 'bbb11111', message: { content: 'Second session' } })])
+    );
+
+    // Touch file2 to make it newer
+    const now = Date.now();
+    fs.utimesSync(file1, new Date(now - 5000), new Date(now - 5000));
+    fs.utimesSync(file2, new Date(now), new Date(now));
+
+    const results = parseSessionsInDir(tmpDir);
+    expect(results).toHaveLength(2);
+    // Newest first
+    expect(results[0].sessionId).toBe('bbb11111');
+    expect(results[1].sessionId).toBe('aaa00000');
+  });
+
+  it('silently excludes files that fail to parse', () => {
+    writeJsonl('good.jsonl', buildJsonl([userEvent()]));
+    writeJsonl('bad.jsonl', ''); // empty — parses as null
+
+    const results = parseSessionsInDir(tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].sessionId).toBe(SAMPLE_SESSION_ID);
+  });
+
+  it('ignores non-jsonl files in directory', () => {
+    writeJsonl('session.jsonl', buildJsonl([userEvent()]));
+    fs.writeFileSync(path.join(tmpDir, 'notes.txt'), 'some notes');
+    fs.writeFileSync(path.join(tmpDir, 'config.json'), '{}');
+    fs.writeFileSync(path.join(tmpDir, '.DS_Store'), '');
+
+    const results = parseSessionsInDir(tmpDir);
+    expect(results).toHaveLength(1);
+  });
+});

--- a/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.test.ts
+++ b/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.test.ts
@@ -205,24 +205,33 @@ describe('parseSessionFile', () => {
     expect(result?.title).toBe('Implement the payments module');
   });
 
-  it('truncates title to 80 chars with ellipsis', () => {
+  it('truncates title to MAX_TITLE_LEN chars with ellipsis', () => {
     const longMessage = 'A'.repeat(100);
     const filePath = writeJsonl(
       'session.jsonl',
       buildJsonl([userEvent({ message: { content: longMessage } })])
     );
     const result = parseSessionFile(filePath);
-    expect(result?.title).toBe('A'.repeat(80) + '\u2026');
-    expect(result?.title?.length).toBe(81);
+    expect(result?.title).toBe('A'.repeat(50) + '\u2026');
+    expect(result?.title?.length).toBe(51);
   });
 
-  it('falls back to sessionId prefix when no user message content found', () => {
+  it('collapses internal whitespace and newlines into single spaces', () => {
+    const filePath = writeJsonl(
+      'session.jsonl',
+      buildJsonl([userEvent({ message: { content: '  Hello\n\n  Claude\t\tworld   ' } })])
+    );
+    const result = parseSessionFile(filePath);
+    expect(result?.title).toBe('Hello Claude world');
+  });
+
+  it('falls back to "Untitled session" when no user message content found', () => {
     const filePath = writeJsonl(
       'session.jsonl',
       buildJsonl([{ type: 'user', sessionId: SAMPLE_SESSION_ID, message: { content: '' } }])
     );
     const result = parseSessionFile(filePath);
-    expect(result?.title).toBe(SAMPLE_SESSION_ID.slice(0, 8));
+    expect(result?.title).toBe('Untitled session');
   });
 
   it('skips isSidechain user events for title extraction', () => {

--- a/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.test.ts
+++ b/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.test.ts
@@ -212,8 +212,8 @@ describe('parseSessionFile', () => {
       buildJsonl([userEvent({ message: { content: longMessage } })])
     );
     const result = parseSessionFile(filePath);
-    expect(result?.title).toBe('A'.repeat(50) + '\u2026');
-    expect(result?.title?.length).toBe(51);
+    expect(result?.title).toBe('A'.repeat(35) + '\u2026');
+    expect(result?.title?.length).toBe(36);
   });
 
   it('collapses internal whitespace and newlines into single spaces', () => {

--- a/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.ts
+++ b/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.ts
@@ -1,0 +1,298 @@
+/**
+ * Parser for Claude Code session JSONL transcript files.
+ *
+ * IMPORTANT: This module has NO dependency on the VS Code API so it can be
+ * unit-tested with vitest. All VS Code-specific logic belongs in providers/
+ * or watchers/.
+ *
+ * NOTE: The ~/.claude/projects/ JSONL format is undocumented and owned by the
+ * Claude Code team. It can change between versions without notice. All parsing
+ * is centralised here so a schema bump is a one-file change. Unknown event
+ * types and unknown fields on known event types are silently skipped / ignored.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface SessionMetadata {
+  /** Session identifier read from the `sessionId` field of JSONL events. */
+  sessionId: string;
+  /** Absolute path to the source `.jsonl` file. */
+  filePath: string;
+  /**
+   * First user message (non-sidechain), truncated to 80 chars.
+   * Falls back to the first 8 chars of the sessionId if no user message found.
+   */
+  title: string;
+  /** `gitBranch` field from the first `user` event, or undefined if absent. */
+  gitBranch: string | undefined;
+  /** `cwd` field from the first `user` event, or undefined if absent. */
+  cwd: string | undefined;
+  /** ISO 8601 timestamp of the first `user` event. */
+  firstTimestamp: string | undefined;
+  /** ISO 8601 timestamp of the last `user` or `assistant` event. */
+  lastTimestamp: string | undefined;
+  /** Count of `user` + `assistant` events (including sidechain events). */
+  messageCount: number;
+  /** File mtime in milliseconds (from `fs.statSync`). */
+  mtime: number;
+}
+
+/**
+ * Heuristic status derived from file mtime.
+ *
+ * HEURISTIC: Claude Code does not write terminal markers or heartbeat records.
+ * The only available signal is the file mtime. Classifications:
+ *   - active  — mtime within the last 2 minutes (Claude likely still writing)
+ *   - recent  — mtime within the last 1 hour
+ *   - idle    — older than 1 hour
+ *
+ * This WILL misclassify paused sessions and very fast sessions. Accepted
+ * limitation for v1.
+ */
+export type SessionStatus = 'active' | 'recent' | 'idle';
+
+// ---------------------------------------------------------------------------
+// Utility: path encoding
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode an absolute workspace path to the directory name used by Claude Code
+ * under `~/.claude/projects/`.
+ *
+ * Encoding rule (verified against live files 2026-04-30):
+ *   Replace every `/` in the path with `-`.
+ *
+ * Example: `/Users/mthines/Workspace/mthines/repo.git/main`
+ *       →  `-Users-mthines-Workspace-mthines-repo-git-main`
+ *
+ * Note: No percent-encoding or other substitutions were observed.
+ */
+export function encodeWorkspacePath(absolutePath: string): string {
+  return absolutePath.split('/').join('-');
+}
+
+/** Returns `~/.claude/projects` expanded to an absolute path. */
+export function getClaudeProjectsDir(): string {
+  return path.join(os.homedir(), '.claude', 'projects');
+}
+
+/**
+ * Returns the session directory for a given workspace path.
+ * Does NOT check whether the directory exists.
+ */
+export function getSessionsDir(workspacePath: string): string {
+  return path.join(getClaudeProjectsDir(), encodeWorkspacePath(workspacePath));
+}
+
+// ---------------------------------------------------------------------------
+// Utility: status classification
+// ---------------------------------------------------------------------------
+
+const ACTIVE_THRESHOLD_MS = 2 * 60 * 1000; // 2 minutes
+const RECENT_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Classify a session by its file mtime.
+ *
+ * HEURISTIC — see `SessionStatus` type for caveats.
+ */
+export function getSessionStatus(mtimeMs: number): SessionStatus {
+  const age = Date.now() - mtimeMs;
+  if (age < ACTIVE_THRESHOLD_MS) return 'active';
+  if (age < RECENT_THRESHOLD_MS) return 'recent';
+  return 'idle';
+}
+
+// ---------------------------------------------------------------------------
+// JSONL parsing internals
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of a parsed JSONL line (typed loosely — unknown fields ok). */
+interface RawEvent {
+  type?: string;
+  sessionId?: string;
+  gitBranch?: string;
+  cwd?: string;
+  timestamp?: string;
+  isSidechain?: boolean;
+  message?: {
+    content?: string | Array<{ type?: string; text?: string }>;
+  };
+}
+
+/**
+ * Extract a plain-text title from a `user` event's `message.content`.
+ * Returns undefined if the content yields no non-empty text.
+ */
+function extractContentText(
+  content: string | Array<{ type?: string; text?: string }> | undefined
+): string | undefined {
+  if (!content) return undefined;
+
+  if (typeof content === 'string') {
+    return content.trim() || undefined;
+  }
+
+  // Array of content parts — find the first `text` part with non-empty text
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      if (part?.type === 'text' && typeof part.text === 'string' && part.text.trim()) {
+        return part.text.trim();
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/** Truncate a string to maxLen characters, appending `…` if truncated. */
+function truncate(s: string, maxLen = 80): string {
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen) + '\u2026'; // …
+}
+
+// ---------------------------------------------------------------------------
+// Public parsing API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a single JSONL session file and return `SessionMetadata`.
+ *
+ * Returns `null` when:
+ * - the file cannot be read
+ * - the file is empty
+ * - no `user` event is found to provide a sessionId
+ *
+ * Unknown event types are silently skipped. Missing fields degrade to
+ * `undefined` — nothing throws.
+ */
+export function parseSessionFile(filePath: string): SessionMetadata | null {
+  let raw: string;
+  let mtime: number;
+
+  try {
+    const stat = fs.statSync(filePath);
+    mtime = stat.mtimeMs;
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  if (!raw.trim()) return null;
+
+  const lines = raw.split('\n').filter((l) => l.trim());
+
+  let sessionId: string | undefined;
+  let title: string | undefined;
+  let gitBranch: string | undefined;
+  let cwd: string | undefined;
+  let firstTimestamp: string | undefined;
+  let lastTimestamp: string | undefined;
+  let messageCount = 0;
+  let titleFound = false;
+
+  for (const line of lines) {
+    let event: RawEvent;
+    try {
+      event = JSON.parse(line) as RawEvent;
+    } catch {
+      // Malformed line — skip
+      continue;
+    }
+
+    const type = event.type;
+
+    // Only process user and assistant events for the main data fields
+    if (type !== 'user' && type !== 'assistant') {
+      // Unknown / other event types → silently skip
+      continue;
+    }
+
+    messageCount++;
+
+    if (type === 'user') {
+      // Set sessionId from first user event that has one
+      if (!sessionId && event.sessionId) {
+        sessionId = event.sessionId;
+      }
+
+      // Set envelope fields from first user event
+      if (!gitBranch && event.gitBranch) {
+        gitBranch = event.gitBranch;
+      }
+      if (!cwd && event.cwd) {
+        cwd = event.cwd;
+      }
+
+      // First timestamp from first user event
+      if (!firstTimestamp && event.timestamp) {
+        firstTimestamp = event.timestamp;
+      }
+
+      // Title: first non-sidechain user event with extractable text content
+      if (!titleFound && event.isSidechain !== true) {
+        const text = extractContentText(event.message?.content);
+        if (text) {
+          title = truncate(text, 80);
+          titleFound = true;
+        }
+      }
+    }
+
+    // Last timestamp from last user or assistant event
+    if (event.timestamp) {
+      lastTimestamp = event.timestamp;
+    }
+  }
+
+  // We require at least a sessionId to return a result
+  if (!sessionId) return null;
+
+  return {
+    sessionId,
+    filePath,
+    title: title ?? sessionId.slice(0, 8),
+    gitBranch,
+    cwd,
+    firstTimestamp,
+    lastTimestamp,
+    messageCount,
+    mtime,
+  };
+}
+
+/**
+ * Parse all `*.jsonl` files in `dirPath` and return them sorted newest-first
+ * by mtime (descending).
+ *
+ * Files that fail to parse are silently excluded. Non-existent directories
+ * return an empty array without throwing.
+ */
+export function parseSessionsInDir(dirPath: string): SessionMetadata[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const sessions: SessionMetadata[] = [];
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+      const session = parseSessionFile(path.join(dirPath, entry.name));
+      if (session) {
+        sessions.push(session);
+      }
+    }
+  }
+
+  // Sort newest-first by mtime
+  sessions.sort((a, b) => b.mtime - a.mtime);
+  return sessions;
+}

--- a/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.ts
+++ b/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.ts
@@ -134,9 +134,7 @@ interface RawEvent {
  * Extract a plain-text title from a `user` event's `message.content`.
  * Returns undefined if the content yields no non-empty text.
  */
-function extractContentText(
-  content: string | Array<{ type?: string; text?: string }> | undefined
-): string | undefined {
+function extractContentText(content: string | Array<{ type?: string; text?: string }> | undefined): string | undefined {
   if (!content) return undefined;
 
   if (typeof content === 'string') {
@@ -157,10 +155,13 @@ function extractContentText(
 
 /**
  * Maximum visible characters for a session title in the tree view label.
- * Tuned for a typical narrow VS Code sidebar (~30–40 chars visible per row),
- * leaving room for the description (`relative time` / `branch · time`).
+ *
+ * Tuned tight (35) so the muted-grey description (relative time / branch)
+ * has room to render alongside the label even on narrow side panels.
+ * Going wider — 50, 80 — pushed the description off-screen and made the
+ * timestamp invisible.
  */
-export const MAX_TITLE_LEN = 50;
+export const MAX_TITLE_LEN = 35;
 
 /**
  * Collapse all whitespace runs (newlines, tabs, repeated spaces) into single

--- a/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.ts
+++ b/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.ts
@@ -66,15 +66,18 @@ export type SessionStatus = 'active' | 'recent' | 'idle';
  * under `~/.claude/projects/`.
  *
  * Encoding rule (verified against live files 2026-04-30):
- *   Replace every `/` in the path with `-`.
+ *   Replace every character that is not `[A-Za-z0-9-]` with `-`.
+ *   This collapses `/`, `.`, spaces, and other punctuation into dashes —
+ *   notably `.git` becomes `-git`, and `/.claude` becomes `--claude`.
  *
- * Example: `/Users/mthines/Workspace/mthines/repo.git/main`
- *       →  `-Users-mthines-Workspace-mthines-repo-git-main`
- *
- * Note: No percent-encoding or other substitutions were observed.
+ * Examples:
+ *   `/Users/mthines/Workspace/repo.git/main` → `-Users-mthines-Workspace-repo-git-main`
+ *   `/Users/mthines/.claude`                 → `-Users-mthines--claude`
+ *   `/Users/mthines/Library/Application Support/Code` →
+ *     `-Users-mthines-Library-Application-Support-Code`
  */
 export function encodeWorkspacePath(absolutePath: string): string {
-  return absolutePath.split('/').join('-');
+  return absolutePath.replace(/[^A-Za-z0-9-]/g, '-');
 }
 
 /** Returns `~/.claude/projects` expanded to an absolute path. */

--- a/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.ts
+++ b/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.ts
@@ -182,6 +182,27 @@ function truncate(s: string, maxLen = MAX_TITLE_LEN): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * In-process cache of parsed sessions, keyed by absolute file path. Stores
+ * the mtime that produced the cached metadata; a `parseSessionFile` call only
+ * re-reads + re-parses when the file's mtime has changed since the cache
+ * entry was written.
+ *
+ * This dramatically speeds up tree refreshes when most sessions on disk are
+ * unchanged (the common case) — without it every refresh would re-read every
+ * JSONL file, including multi-MB ones.
+ *
+ * Bounded in practice by the number of distinct session files the user has
+ * (tens to hundreds). New mtimes overwrite old entries for the same path, so
+ * memory growth is one entry per unique session file.
+ */
+const parseCache = new Map<string, { mtime: number; data: SessionMetadata }>();
+
+/** Reset the parse cache. Exposed mainly for tests. */
+export function clearSessionParseCache(): void {
+  parseCache.clear();
+}
+
+/**
  * Parse a single JSONL session file and return `SessionMetadata`.
  *
  * Returns `null` when:
@@ -191,6 +212,8 @@ function truncate(s: string, maxLen = MAX_TITLE_LEN): string {
  *
  * Unknown event types are silently skipped. Missing fields degrade to
  * `undefined` — nothing throws.
+ *
+ * Uses an mtime-keyed cache; unchanged files skip the read+parse entirely.
  */
 export function parseSessionFile(filePath: string): SessionMetadata | null {
   let raw: string;
@@ -199,6 +222,10 @@ export function parseSessionFile(filePath: string): SessionMetadata | null {
   try {
     const stat = fs.statSync(filePath);
     mtime = stat.mtimeMs;
+    const cached = parseCache.get(filePath);
+    if (cached && cached.mtime === mtime) {
+      return cached.data;
+    }
     raw = fs.readFileSync(filePath, 'utf-8');
   } catch {
     return null;
@@ -274,7 +301,7 @@ export function parseSessionFile(filePath: string): SessionMetadata | null {
   // We require at least a sessionId to return a result
   if (!sessionId) return null;
 
-  return {
+  const data: SessionMetadata = {
     sessionId,
     filePath,
     title: title ?? 'Untitled session',
@@ -285,6 +312,8 @@ export function parseSessionFile(filePath: string): SessionMetadata | null {
     messageCount,
     mtime,
   };
+  parseCache.set(filePath, { mtime, data });
+  return data;
 }
 
 /**

--- a/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.ts
+++ b/packages/vscode-agent-tasks/src/parsers/session-jsonl-parser.ts
@@ -25,8 +25,9 @@ export interface SessionMetadata {
   /** Absolute path to the source `.jsonl` file. */
   filePath: string;
   /**
-   * First user message (non-sidechain), truncated to 80 chars.
-   * Falls back to the first 8 chars of the sessionId if no user message found.
+   * First user message (non-sidechain), whitespace-collapsed and truncated to
+   * `MAX_TITLE_LEN` characters. Falls back to "Untitled session" when no user
+   * message has any text content.
    */
   title: string;
   /** `gitBranch` field from the first `user` event, or undefined if absent. */
@@ -154,8 +155,24 @@ function extractContentText(
   return undefined;
 }
 
+/**
+ * Maximum visible characters for a session title in the tree view label.
+ * Tuned for a typical narrow VS Code sidebar (~30–40 chars visible per row),
+ * leaving room for the description (`relative time` / `branch · time`).
+ */
+export const MAX_TITLE_LEN = 50;
+
+/**
+ * Collapse all whitespace runs (newlines, tabs, repeated spaces) into single
+ * spaces and trim the result. Keeps single-line tree view labels readable for
+ * messages that originally contained markdown, code fences, or template blocks.
+ */
+function collapseWhitespace(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
 /** Truncate a string to maxLen characters, appending `…` if truncated. */
-function truncate(s: string, maxLen = 80): string {
+function truncate(s: string, maxLen = MAX_TITLE_LEN): string {
   if (s.length <= maxLen) return s;
   return s.slice(0, maxLen) + '\u2026'; // …
 }
@@ -242,7 +259,7 @@ export function parseSessionFile(filePath: string): SessionMetadata | null {
       if (!titleFound && event.isSidechain !== true) {
         const text = extractContentText(event.message?.content);
         if (text) {
-          title = truncate(text, 80);
+          title = truncate(collapseWhitespace(text));
           titleFound = true;
         }
       }
@@ -260,7 +277,7 @@ export function parseSessionFile(filePath: string): SessionMetadata | null {
   return {
     sessionId,
     filePath,
-    title: title ?? sessionId.slice(0, 8),
+    title: title ?? 'Untitled session',
     gitBranch,
     cwd,
     firstTimestamp,

--- a/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
+++ b/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
@@ -2,15 +2,21 @@
  * TreeDataProvider for the "Sessions" panel.
  *
  * Surfaces Claude Code session history from `~/.claude/projects/<encoded-cwd>/`
- * for the current workspace and optionally for sibling worktrees when detected
- * via `.gw/config.json` or `git worktree list --porcelain`.
+ * for the current workspace and (optionally) sibling worktrees discovered via
+ * `.gw/config.json` or `git worktree list --porcelain`.
  *
  * Tree structure:
- *   Single worktree → flat list of SessionItems
- *   Multiple worktrees → WorktreeGroupItems (each containing SessionItems)
+ *   - Single worktree → flat list of SessionItems
+ *   - Multiple worktrees → WorktreeGroupItems (current first, marked), each
+ *     containing SessionItems
  *
- * NOTE: This provider depends on the VS Code API and cannot be unit-tested with
- * vitest. Manual smoke-test checklist is in the PR description / walkthrough.
+ * Sessions started from sub-directories of a worktree (e.g. `apps/api/`) are
+ * also surfaced: candidate dirs are matched by encoded prefix, then verified
+ * by the `cwd` field on the session events and bucketed under the longest
+ * matching worktree.
+ *
+ * NOTE: This provider depends on the VS Code API and cannot be unit-tested
+ * with vitest. Manual smoke-test checklist is in the PR description.
  */
 
 import * as vscode from 'vscode';
@@ -20,8 +26,9 @@ import * as child_process from 'child_process';
 import {
   SessionMetadata,
   SessionStatus,
+  encodeWorkspacePath,
+  getClaudeProjectsDir,
   getSessionStatus,
-  getSessionsDir,
   parseSessionsInDir,
 } from '../parsers/session-jsonl-parser';
 
@@ -29,19 +36,35 @@ import {
 // Relative time formatting
 // ---------------------------------------------------------------------------
 
+const MONTH_NAMES = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
 /**
- * Format a millisecond age as a human-readable relative-time string.
- * Uses simple integer rounding — no external libraries.
+ * Format a session mtime as a compact, human-readable timestamp.
+ *
+ * Uses relative time for recent activity ("just now", "5m ago", "3h ago",
+ * "2d ago" up to 7 days), then switches to absolute "MMM D" so old sessions
+ * don't read as "187d ago" — matches the UX writing guidance to use
+ * relative-for-recent and absolute-for-older.
  */
-function relativeTime(ageMs: number): string {
+function formatTime(mtimeMs: number, now = Date.now()): string {
+  const ageMs = now - mtimeMs;
   const seconds = Math.floor(ageMs / 1000);
   if (seconds < 60) return 'just now';
+
   const minutes = Math.floor(seconds / 60);
   if (minutes < 60) return `${minutes}m ago`;
+
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h ago`;
+
   const days = Math.floor(hours / 24);
-  return `${days}d ago`;
+  if (days < 7) return `${days}d ago`;
+
+  const d = new Date(mtimeMs);
+  return `${MONTH_NAMES[d.getMonth()]} ${d.getDate()}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,20 +72,21 @@ function relativeTime(ageMs: number): string {
 // ---------------------------------------------------------------------------
 
 /**
- * A collapsible group node representing one worktree in a multi-worktree
- * workspace.
+ * A collapsible group node representing one worktree.
  *
- * Label is the last two path segments joined with `/` to keep it readable
- * without being excessively long (full path is in the tooltip).
+ * Visual treatment:
+ *   - current worktree → `circle-filled` (charts.blue), expanded by default,
+ *     description "(current) · N"
+ *   - other worktrees  → `git-branch` (default color), collapsed, description "N"
  *
- * Example:
- *   `/Users/mthines/Workspace/mthines/agent-skills.git/main`
- *   → label: `agent-skills.git/main`
+ * Label is the last 1–2 path segments, joined with `/`. Full path lives in the
+ * tooltip.
  */
 export class WorktreeGroupItem extends vscode.TreeItem {
   constructor(
     public readonly worktreePath: string,
-    public readonly sessions: SessionMetadata[]
+    public readonly sessions: SessionMetadata[],
+    public readonly isCurrent: boolean
   ) {
     const segments = worktreePath.split(path.sep).filter(Boolean);
     const label =
@@ -70,13 +94,26 @@ export class WorktreeGroupItem extends vscode.TreeItem {
         ? segments.slice(-2).join('/')
         : segments[segments.length - 1] ?? worktreePath;
 
-    super(label, vscode.TreeItemCollapsibleState.Expanded);
-    this.iconPath = new vscode.ThemeIcon('source-control');
-    this.description = `${sessions.length} session${sessions.length !== 1 ? 's' : ''}`;
-    this.tooltip = new vscode.MarkdownString(
-      `**Worktree:** \`${worktreePath}\`\n\n${sessions.length} session(s)`
+    super(
+      label,
+      isCurrent
+        ? vscode.TreeItemCollapsibleState.Expanded
+        : vscode.TreeItemCollapsibleState.Collapsed
     );
-    this.contextValue = 'claudeWorktreeGroup';
+
+    this.iconPath = isCurrent
+      ? new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('charts.blue'))
+      : new vscode.ThemeIcon('git-branch');
+
+    const countLabel = `${sessions.length} session${sessions.length !== 1 ? 's' : ''}`;
+    this.description = isCurrent ? `(current) · ${countLabel}` : countLabel;
+
+    const md = new vscode.MarkdownString();
+    if (isCurrent) md.appendMarkdown(`**Current worktree**\n\n`);
+    md.appendMarkdown(`\`${worktreePath}\`\n\n${countLabel}`);
+    this.tooltip = md;
+
+    this.contextValue = isCurrent ? 'claudeWorktreeGroupCurrent' : 'claudeWorktreeGroup';
   }
 }
 
@@ -87,26 +124,24 @@ export class WorktreeGroupItem extends vscode.TreeItem {
 /**
  * A leaf node representing one Claude Code session.
  *
- * - Label: first user message truncated to 80 chars
- * - Description: `<branch> · <relative time>`
- * - Icon: varies by mtime-based heuristic status (active/recent/idle)
- * - Tooltip: full title, session ID, message count, last activity, cwd, file path
+ * Description rules:
+ *   - inside a WorktreeGroupItem → just relative time (branch is implied)
+ *   - flat (single worktree)     → "branch · time"
  *
- * HEURISTIC: icon/status is derived from file mtime — see `getSessionStatus`
- * for caveats.
+ * Status is a heuristic from file mtime (see `getSessionStatus`) — disclosed
+ * up-front in the tooltip so users don't mistake the icon for ground truth.
  */
 export class SessionItem extends vscode.TreeItem {
-  constructor(public readonly session: SessionMetadata) {
+  constructor(public readonly session: SessionMetadata, options: { grouped: boolean }) {
     super(session.title, vscode.TreeItemCollapsibleState.None);
 
     const status: SessionStatus = getSessionStatus(session.mtime);
-    const age = Date.now() - session.mtime;
-    const timeStr = relativeTime(age);
+    const timeStr = formatTime(session.mtime);
     const branch = session.gitBranch ?? '?';
 
-    this.description = `${branch} · ${timeStr}`;
+    this.description = options.grouped ? timeStr : `${branch} · ${timeStr}`;
     this.iconPath = SessionItem.iconForStatus(status);
-    this.tooltip = SessionItem.buildTooltip(session, timeStr);
+    this.tooltip = SessionItem.buildTooltip(session, timeStr, status, branch);
     this.contextValue = 'claudeSession';
 
     // Command fires on click — handled in extension.ts
@@ -117,36 +152,43 @@ export class SessionItem extends vscode.TreeItem {
     };
   }
 
+  /**
+   * Status icons differ in BOTH shape AND luminance so the distinction
+   * survives color-blindness and dark/light theme changes (WCAG 1.4.1).
+   *   - active → blue pulse  (likely still writing)
+   *   - recent → blue clock  (ended within the last hour)
+   *   - idle   → gray history (older)
+   */
   private static iconForStatus(status: SessionStatus): vscode.ThemeIcon {
     switch (status) {
       case 'active':
-        // Blue pulse — heuristic: Claude is likely still writing
         return new vscode.ThemeIcon('pulse', new vscode.ThemeColor('charts.blue'));
       case 'recent':
-        // Blue history — heuristic: session ended recently
-        return new vscode.ThemeIcon('history', new vscode.ThemeColor('charts.blue'));
+        return new vscode.ThemeIcon('clock', new vscode.ThemeColor('charts.blue'));
       case 'idle':
       default:
-        // Default (gray) history — session is old
         return new vscode.ThemeIcon('history');
     }
   }
 
-  private static buildTooltip(session: SessionMetadata, timeStr: string): vscode.MarkdownString {
+  private static buildTooltip(
+    session: SessionMetadata,
+    timeStr: string,
+    status: SessionStatus,
+    branch: string
+  ): vscode.MarkdownString {
     const md = new vscode.MarkdownString();
-    md.appendMarkdown(`**${session.title}**\n\n`);
-    md.appendMarkdown(`**Session ID:** \`${session.sessionId}\`\n\n`);
+    md.appendMarkdown(
+      `_Status icon is heuristic — derived from file mtime, not a real signal._\n\n`
+    );
+    md.appendMarkdown(`**Last activity:** ${timeStr} · _${status}_\n\n`);
+    md.appendMarkdown(`**Branch:** \`${branch}\`\n\n`);
     md.appendMarkdown(`**Messages:** ${session.messageCount}\n\n`);
-    if (session.lastTimestamp) {
-      md.appendMarkdown(`**Last activity:** ${session.lastTimestamp} (${timeStr})\n\n`);
-    }
+    md.appendMarkdown(`**Session ID:** \`${session.sessionId}\`\n\n`);
     if (session.cwd) {
       md.appendMarkdown(`**CWD:** \`${session.cwd}\`\n\n`);
     }
-    md.appendMarkdown(`**File:** \`${session.filePath}\`\n\n`);
-    md.appendMarkdown(
-      `\n\n_Status icon is a heuristic based on file mtime and may not reflect actual session state._`
-    );
+    md.appendMarkdown(`**File:** \`${session.filePath}\``);
     return md;
   }
 }
@@ -162,18 +204,19 @@ type SessionTreeItem = WorktreeGroupItem | SessionItem;
 // ---------------------------------------------------------------------------
 
 /**
- * Walk up from `startPath` up to `maxLevels` ancestors looking for a
- * `.gw/config.json` file. Returns the parsed config object or null.
+ * Walk up from `startPath` up to `maxLevels` looking for a `.gw/config.json`.
+ * Returns the directory containing `.gw/` (the gw root) or null. We use the
+ * directory itself rather than any `root` field because real gw configs don't
+ * always store `root`.
  */
-function findGwConfig(startPath: string, maxLevels = 5): { root?: string; defaultBranch?: string } | null {
+function findGwRoot(startPath: string, maxLevels = 5): string | null {
   let dir = startPath;
   for (let i = 0; i < maxLevels; i++) {
     const configPath = path.join(dir, '.gw', 'config.json');
     try {
-      const content = fs.readFileSync(configPath, 'utf-8');
-      return JSON.parse(content) as { root?: string; defaultBranch?: string };
+      if (fs.statSync(configPath).isFile()) return dir;
     } catch {
-      // Not found at this level — try parent
+      // not found, continue
     }
     const parent = path.dirname(dir);
     if (parent === dir) break;
@@ -183,44 +226,50 @@ function findGwConfig(startPath: string, maxLevels = 5): { root?: string; defaul
 }
 
 /**
- * Enumerate worktree paths using `.gw/config.json`.
- *
- * Reads `root` from the config and lists subdirectories that contain a `.git`
- * file (worktree marker, not a directory `.git` which would be the main repo).
+ * Enumerate worktree paths under a gw root by scanning subdirectories that
+ * contain a `.git` *file* (worktree marker) — not a `.git` directory which
+ * would be the bare repo itself. Recurses one level for the `feat/<branch>`
+ * convention.
  */
-function getWorktreePathsFromGwConfig(workspacePath: string): string[] | null {
-  const config = findGwConfig(workspacePath);
-  if (!config?.root) return null;
-
-  const root = config.root;
-  let subdirs: fs.Dirent[];
-  try {
-    subdirs = fs.readdirSync(root, { withFileTypes: true });
-  } catch {
-    return null;
-  }
+function getWorktreePathsFromGw(workspacePath: string): string[] | null {
+  const root = findGwRoot(workspacePath);
+  if (!root) return null;
 
   const paths: string[] = [];
-  for (const entry of subdirs) {
-    if (!entry.isDirectory()) continue;
-    const worktreePath = path.join(root, entry.name);
-    // A git worktree (not the bare repo itself) has a `.git` FILE
-    const gitPath = path.join(worktreePath, '.git');
+  const visit = (dir: string, depth: number): void => {
+    if (depth > 2) return;
+    let entries: fs.Dirent[];
     try {
-      const stat = fs.statSync(gitPath);
-      if (stat.isFile()) {
-        paths.push(worktreePath);
-      }
+      entries = fs.readdirSync(dir, { withFileTypes: true });
     } catch {
-      // No .git — not a worktree
+      return;
     }
-  }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name === '.gw' || entry.name.startsWith('.')) continue;
+      const sub = path.join(dir, entry.name);
+      const gitPath = path.join(sub, '.git');
+      try {
+        const stat = fs.statSync(gitPath);
+        if (stat.isFile()) {
+          paths.push(sub);
+          continue; // don't recurse into a worktree
+        }
+      } catch {
+        // no .git here; recurse to find nested worktrees (e.g. feat/x)
+      }
+      visit(sub, depth + 1);
+    }
+  };
+
+  visit(root, 0);
   return paths.length > 0 ? paths : null;
 }
 
 /**
- * Enumerate worktree paths via `git worktree list --porcelain`.
- * Returns null if the command fails (not a git repo, git not installed, etc.).
+ * Enumerate worktree paths via `git worktree list --porcelain`. Returns null
+ * if the command fails (not a git repo, git missing, etc.).
  */
 function getWorktreePathsFromGit(workspacePath: string): string[] | null {
   try {
@@ -243,35 +292,32 @@ function getWorktreePathsFromGit(workspacePath: string): string[] | null {
 }
 
 /**
- * Return the deduplicated list of worktree paths for the workspace.
- * Always includes the workspace path itself.
+ * Return the deduplicated list of worktree paths for the workspace. Always
+ * includes the workspace path itself.
  *
  * Priority:
- *   1. `.gw/config.json` if present
+ *   1. gw root + sibling worktrees (gw-aware)
  *   2. `git worktree list --porcelain` fallback
- *   3. Just the workspace path (single-worktree / non-git scenario)
+ *   3. Just the workspace path (single-worktree / non-git)
  */
 function discoverWorktreePaths(workspacePath: string): string[] {
   const seen = new Set<string>();
   const paths: string[] = [];
-
   const add = (p: string) => {
-    const normalised = p.replace(/\/$/, '');
+    const normalised = p.replace(/[/\\]+$/, '');
     if (!seen.has(normalised)) {
       seen.add(normalised);
       paths.push(normalised);
     }
   };
 
-  // Try gw config first
-  const gwPaths = getWorktreePathsFromGwConfig(workspacePath);
+  const gwPaths = getWorktreePathsFromGw(workspacePath);
   if (gwPaths) {
     for (const p of gwPaths) add(p);
-    add(workspacePath); // ensure workspace itself is included
+    add(workspacePath);
     return paths;
   }
 
-  // Fallback to git worktree list
   const gitPaths = getWorktreePathsFromGit(workspacePath);
   if (gitPaths) {
     for (const p of gitPaths) add(p);
@@ -279,14 +325,91 @@ function discoverWorktreePaths(workspacePath: string): string[] {
     return paths;
   }
 
-  // Just the workspace
   add(workspacePath);
   return paths;
 }
 
 // ---------------------------------------------------------------------------
+// Session discovery (subdirectory-aware)
+// ---------------------------------------------------------------------------
+
+/**
+ * Find every `~/.claude/projects/*` directory whose encoded prefix matches at
+ * least one of the worktree paths. Includes both exact matches (the worktree
+ * itself) and prefix matches (subdirectories of the worktree, since
+ * `encodeWorkspacePath` deterministically maps `/<segment>` → `-<segment>`).
+ *
+ * Over-matching by encoded prefix is cheap and is corrected later by the
+ * cwd-based bucketing pass, so siblings with overlapping name prefixes
+ * (e.g. `foo` vs `foo-bar`) don't get cross-attributed.
+ */
+function findCandidateSessionDirs(worktreePaths: string[]): string[] {
+  const projectsDir = getClaudeProjectsDir();
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(projectsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const encodedPrefixes = worktreePaths.map((wt) => encodeWorkspacePath(wt));
+  const out: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    for (const encoded of encodedPrefixes) {
+      if (entry.name === encoded || entry.name.startsWith(encoded + '-')) {
+        out.push(path.join(projectsDir, entry.name));
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse all sessions from candidate dirs and bucket them by the longest
+ * matching worktree path (using the session's `cwd` field). Sessions whose
+ * `cwd` doesn't fall under any worktree are dropped. Each bucket is sorted
+ * newest-first.
+ */
+function bucketSessionsByWorktree(
+  worktreePaths: string[],
+  candidateDirs: string[]
+): Map<string, SessionMetadata[]> {
+  // Sort by descending path length for longest-prefix match
+  const sortedWts = [...worktreePaths].sort((a, b) => b.length - a.length);
+
+  const buckets = new Map<string, SessionMetadata[]>();
+  for (const wt of worktreePaths) buckets.set(wt, []);
+
+  for (const dir of candidateDirs) {
+    const sessions = parseSessionsInDir(dir);
+    for (const session of sessions) {
+      const cwd = session.cwd;
+      if (!cwd) continue;
+      const match = sortedWts.find(
+        (wt) => cwd === wt || cwd.startsWith(wt + path.sep)
+      );
+      if (match) {
+        const bucket = buckets.get(match);
+        if (bucket) bucket.push(session);
+      }
+    }
+  }
+
+  for (const sessions of buckets.values()) {
+    sessions.sort((a, b) => b.mtime - a.mtime);
+  }
+
+  return buckets;
+}
+
+// ---------------------------------------------------------------------------
 // SessionsProvider
 // ---------------------------------------------------------------------------
+
+export type SessionsScope = 'current' | 'all';
 
 export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem> {
   private _onDidChangeTreeData = new vscode.EventEmitter<SessionTreeItem | undefined | void>();
@@ -294,12 +417,6 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
 
   /** Cache of session dirs being watched — exposed for SessionWatcher rebuild. */
   private _sessionDirs: string[] = [];
-
-  // No constructor arguments required — provider is initialised lazily on first getChildren call.
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  constructor() {
-    // Intentionally empty — provider state is built lazily in buildRootItems()
-  }
 
   /** The session directories currently being observed. */
   get sessionDirs(): string[] {
@@ -316,60 +433,65 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
 
   async getChildren(element?: SessionTreeItem): Promise<SessionTreeItem[]> {
     if (element instanceof WorktreeGroupItem) {
-      return element.sessions.map((s) => new SessionItem(s));
+      return element.sessions.map((s) => new SessionItem(s, { grouped: true }));
     }
-
     if (element instanceof SessionItem) {
       return [];
     }
-
-    // Root level — build tree
     return this.buildRootItems();
   }
 
-  /**
-   * Build the root-level tree items.
-   *
-   * If only one worktree has sessions, or all sessions come from the same
-   * worktree, show them flat (no WorktreeGroupItem wrapper). Otherwise, group
-   * by worktree.
-   */
   private buildRootItems(): SessionTreeItem[] {
     const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     if (!workspacePath) return [];
 
-    const worktreePaths = discoverWorktreePaths(workspacePath);
+    const scope = vscode.workspace
+      .getConfiguration('agentTasks.sessions')
+      .get<SessionsScope>('scope', 'all');
 
-    // Collect sessions per worktree, track session dirs for watcher
-    const sessionDirs: string[] = [];
-    const groups: Array<{ worktreePath: string; sessions: SessionMetadata[] }> = [];
+    const allWorktrees = discoverWorktreePaths(workspacePath);
 
+    // Identify the current worktree as the longest worktree path that the
+    // workspacePath sits inside. Falls back to workspacePath when nothing else
+    // qualifies (e.g. single-worktree case).
+    const sortedByLength = [...allWorktrees].sort((a, b) => b.length - a.length);
+    const currentWorktree =
+      sortedByLength.find(
+        (wt) => workspacePath === wt || workspacePath.startsWith(wt + path.sep)
+      ) ?? workspacePath;
+
+    const worktreePaths = scope === 'current' ? [currentWorktree] : allWorktrees;
+
+    const candidateDirs = findCandidateSessionDirs(worktreePaths);
+    this._sessionDirs = candidateDirs;
+
+    const buckets = bucketSessionsByWorktree(worktreePaths, candidateDirs);
+
+    // Single worktree (or scope === 'current') → flat list
+    if (worktreePaths.length <= 1) {
+      const sessions = buckets.get(worktreePaths[0]) ?? [];
+      return sessions.map((s) => new SessionItem(s, { grouped: false }));
+    }
+
+    // Multi-worktree → grouped, current first, others by most-recent activity
+    const groups: Array<{ wt: string; sessions: SessionMetadata[]; mtime: number }> = [];
     for (const wt of worktreePaths) {
-      const dir = getSessionsDir(wt);
-      sessionDirs.push(dir);
-      const sessions = parseSessionsInDir(dir);
-      if (sessions.length > 0) {
-        groups.push({ worktreePath: wt, sessions });
-      }
+      const sessions = buckets.get(wt) ?? [];
+      const mtime = sessions[0]?.mtime ?? 0;
+      groups.push({ wt, sessions, mtime });
     }
 
-    // Update cached session dirs (for watcher rebuild)
-    this._sessionDirs = sessionDirs;
+    // Drop empty non-current groups so we don't show 10 collapsed empty siblings
+    const visibleGroups = groups.filter((g) => g.wt === currentWorktree || g.sessions.length > 0);
 
-    // No sessions anywhere
-    if (groups.length === 0) return [];
+    visibleGroups.sort((a, b) => {
+      if (a.wt === currentWorktree) return -1;
+      if (b.wt === currentWorktree) return 1;
+      return b.mtime - a.mtime;
+    });
 
-    // Single worktree OR all sessions from one worktree → show flat
-    if (
-      worktreePaths.length === 1 ||
-      groups.length === 1
-    ) {
-      // Combine all sessions across groups and sort newest-first
-      const allSessions = groups.flatMap((g) => g.sessions).sort((a, b) => b.mtime - a.mtime);
-      return allSessions.map((s) => new SessionItem(s));
-    }
-
-    // Multiple worktrees — show grouped
-    return groups.map((g) => new WorktreeGroupItem(g.worktreePath, g.sessions));
+    return visibleGroups.map(
+      (g) => new WorktreeGroupItem(g.wt, g.sessions, g.wt === currentWorktree)
+    );
   }
 }

--- a/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
+++ b/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
@@ -124,28 +124,29 @@ export class WorktreeGroupItem extends vscode.TreeItem {
 /**
  * A leaf node representing one Claude Code session.
  *
- * Description rules:
- *   - inside a WorktreeGroupItem → just relative time (branch is implied)
- *   - flat (single worktree)     → "branch · time"
+ * Layout:
+ *   - Label: `<time> · <message>` — time is INSIDE the label so it survives
+ *     narrow panels. The message text is what gets truncated when there's no
+ *     room, not the timestamp.
+ *   - Description: branch when flat (single worktree); empty when grouped
+ *     (branch is implicit from the parent group).
  *
- * Status is a heuristic from file mtime (see `getSessionStatus`) — disclosed
- * up-front in the tooltip so users don't mistake the icon for ground truth.
+ * Status is computed by the provider so it can layer terminal-open / closed
+ * signals on top of the raw mtime heuristic.
  */
 export class SessionItem extends vscode.TreeItem {
   constructor(
     public readonly session: SessionMetadata,
-    options: { grouped: boolean; effectiveMtime?: number }
+    options: { grouped: boolean; status: SessionStatus }
   ) {
-    super(session.title, vscode.TreeItemCollapsibleState.None);
-
-    const effectiveMtime = options.effectiveMtime ?? session.mtime;
-    const status: SessionStatus = getSessionStatus(effectiveMtime);
-    const timeStr = formatTime(effectiveMtime);
+    const timeStr = formatTime(session.mtime);
     const branch = session.gitBranch ?? '?';
 
-    this.description = options.grouped ? timeStr : `${branch} · ${timeStr}`;
-    this.iconPath = SessionItem.iconForStatus(status);
-    this.tooltip = SessionItem.buildTooltip(session, timeStr, status, branch);
+    super(`${timeStr} · ${session.title}`, vscode.TreeItemCollapsibleState.None);
+
+    this.description = options.grouped ? '' : branch;
+    this.iconPath = SessionItem.iconForStatus(options.status);
+    this.tooltip = SessionItem.buildTooltip(session, timeStr, options.status, branch);
     this.contextValue = 'claudeSession';
 
     // Command fires on click — handled in extension.ts
@@ -423,17 +424,21 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
   private _sessionDirs: string[] = [];
 
   /**
-   * Optimistic activity timestamps: when the user clicks a session to resume
-   * it, we mark it as just-opened immediately so the icon flips to "active"
-   * without waiting for the file watcher to catch the next claude write.
-   *
-   * The provider treats `max(file mtime, optimistic timestamp)` as the
-   * effective activity time. Once a real file change lands the entry becomes
-   * irrelevant naturally; we also age them out after 5 minutes so a clicked-
-   * then-quit session doesn't lie indefinitely.
+   * Sessions whose `claude --resume` terminal is currently open in THIS
+   * window. Forces the status icon to "active" regardless of mtime — a
+   * stronger signal than the file-watcher heuristic. Updated by the click
+   * handler and `onDidCloseTerminal` listener in extension.ts.
    */
-  private optimisticOpens = new Map<string, number>();
-  private static readonly OPTIMISTIC_TTL_MS = 5 * 60 * 1000;
+  private openTerminalSessions = new Set<string>();
+
+  /**
+   * Timestamp of the most recent close-of-our-terminal for a session. When
+   * the close is more recent than the file mtime, we cap the status at
+   * `recent` so a freshly-closed session can't keep showing as `active`
+   * just because its JSONL was written seconds before close. Allows the
+   * panel to react instantly to terminal close.
+   */
+  private terminalClosedAt = new Map<string, number>();
 
   /** The session directories currently being observed. */
   get sessionDirs(): string[] {
@@ -441,22 +446,38 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
   }
 
   /**
-   * Mark a session as just-opened so its icon shows "active" immediately on
-   * click, without waiting for the file watcher. Idempotent.
+   * Tell the provider that a `claude --resume` terminal for this session has
+   * just been opened (`open=true`) or closed (`open=false`) in this window.
+   * Refreshes the tree so the status icon updates immediately.
    */
-  touchActive(sessionId: string): void {
-    this.optimisticOpens.set(sessionId, Date.now());
+  setTerminalOpen(sessionId: string, open: boolean): void {
+    if (open) {
+      this.openTerminalSessions.add(sessionId);
+      this.terminalClosedAt.delete(sessionId);
+    } else {
+      this.openTerminalSessions.delete(sessionId);
+      this.terminalClosedAt.set(sessionId, Date.now());
+    }
     this.refresh();
   }
 
-  private effectiveMtime(session: SessionMetadata): number {
-    const optimistic = this.optimisticOpens.get(session.sessionId);
-    if (optimistic === undefined) return session.mtime;
-    if (Date.now() - optimistic > SessionsProvider.OPTIMISTIC_TTL_MS) {
-      this.optimisticOpens.delete(session.sessionId);
-      return session.mtime;
+  /**
+   * Compute the effective status for a session, layering UI-known signals on
+   * top of the mtime heuristic:
+   *   1. Terminal open in this window         → `active` (definite)
+   *   2. Terminal was closed after last mtime → cap at `recent` (we ended it)
+   *   3. Otherwise                            → plain mtime heuristic
+   */
+  computeStatus(session: SessionMetadata): SessionStatus {
+    if (this.openTerminalSessions.has(session.sessionId)) return 'active';
+
+    const closedAt = this.terminalClosedAt.get(session.sessionId);
+    if (closedAt !== undefined && closedAt > session.mtime) {
+      const heuristic = getSessionStatus(session.mtime);
+      return heuristic === 'active' ? 'recent' : heuristic;
     }
-    return Math.max(session.mtime, optimistic);
+
+    return getSessionStatus(session.mtime);
   }
 
   refresh(): void {
@@ -470,7 +491,7 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
   async getChildren(element?: SessionTreeItem): Promise<SessionTreeItem[]> {
     if (element instanceof WorktreeGroupItem) {
       return element.sessions.map(
-        (s) => new SessionItem(s, { grouped: true, effectiveMtime: this.effectiveMtime(s) })
+        (s) => new SessionItem(s, { grouped: true, status: this.computeStatus(s) })
       );
     }
     if (element instanceof SessionItem) {
@@ -509,17 +530,21 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
     if (worktreePaths.length <= 1) {
       const sessions = buckets.get(worktreePaths[0]) ?? [];
       return sessions.map(
-        (s) => new SessionItem(s, { grouped: false, effectiveMtime: this.effectiveMtime(s) })
+        (s) => new SessionItem(s, { grouped: false, status: this.computeStatus(s) })
       );
     }
 
     // Multi-worktree → grouped, current first, others by most-recent activity.
-    // The "most recent" mtime here uses effectiveMtime so an optimistically-
-    // touched session lifts its group's sort order too.
+    // Sessions whose terminal is currently open count as "now" for sort
+    // purposes so they bubble up to the top of their worktree group.
     const groups: Array<{ wt: string; sessions: SessionMetadata[]; mtime: number }> = [];
+    const now = Date.now();
     for (const wt of worktreePaths) {
       const sessions = buckets.get(wt) ?? [];
-      const mtime = sessions.reduce((max, s) => Math.max(max, this.effectiveMtime(s)), 0);
+      const mtime = sessions.reduce((max, s) => {
+        const effective = this.openTerminalSessions.has(s.sessionId) ? now : s.mtime;
+        return Math.max(max, effective);
+      }, 0);
       groups.push({ wt, sessions, mtime });
     }
 

--- a/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
+++ b/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
@@ -1,0 +1,375 @@
+/**
+ * TreeDataProvider for the "Sessions" panel.
+ *
+ * Surfaces Claude Code session history from `~/.claude/projects/<encoded-cwd>/`
+ * for the current workspace and optionally for sibling worktrees when detected
+ * via `.gw/config.json` or `git worktree list --porcelain`.
+ *
+ * Tree structure:
+ *   Single worktree → flat list of SessionItems
+ *   Multiple worktrees → WorktreeGroupItems (each containing SessionItems)
+ *
+ * NOTE: This provider depends on the VS Code API and cannot be unit-tested with
+ * vitest. Manual smoke-test checklist is in the PR description / walkthrough.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as child_process from 'child_process';
+import {
+  SessionMetadata,
+  SessionStatus,
+  getSessionStatus,
+  getSessionsDir,
+  parseSessionsInDir,
+} from '../parsers/session-jsonl-parser';
+
+// ---------------------------------------------------------------------------
+// Relative time formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a millisecond age as a human-readable relative-time string.
+ * Uses simple integer rounding — no external libraries.
+ */
+function relativeTime(ageMs: number): string {
+  const seconds = Math.floor(ageMs / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Tree item: WorktreeGroupItem
+// ---------------------------------------------------------------------------
+
+/**
+ * A collapsible group node representing one worktree in a multi-worktree
+ * workspace.
+ *
+ * Label is the last two path segments joined with `/` to keep it readable
+ * without being excessively long (full path is in the tooltip).
+ *
+ * Example:
+ *   `/Users/mthines/Workspace/mthines/agent-skills.git/main`
+ *   → label: `agent-skills.git/main`
+ */
+export class WorktreeGroupItem extends vscode.TreeItem {
+  constructor(
+    public readonly worktreePath: string,
+    public readonly sessions: SessionMetadata[]
+  ) {
+    const segments = worktreePath.split(path.sep).filter(Boolean);
+    const label =
+      segments.length >= 2
+        ? segments.slice(-2).join('/')
+        : segments[segments.length - 1] ?? worktreePath;
+
+    super(label, vscode.TreeItemCollapsibleState.Expanded);
+    this.iconPath = new vscode.ThemeIcon('source-control');
+    this.description = `${sessions.length} session${sessions.length !== 1 ? 's' : ''}`;
+    this.tooltip = new vscode.MarkdownString(
+      `**Worktree:** \`${worktreePath}\`\n\n${sessions.length} session(s)`
+    );
+    this.contextValue = 'claudeWorktreeGroup';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tree item: SessionItem
+// ---------------------------------------------------------------------------
+
+/**
+ * A leaf node representing one Claude Code session.
+ *
+ * - Label: first user message truncated to 80 chars
+ * - Description: `<branch> · <relative time>`
+ * - Icon: varies by mtime-based heuristic status (active/recent/idle)
+ * - Tooltip: full title, session ID, message count, last activity, cwd, file path
+ *
+ * HEURISTIC: icon/status is derived from file mtime — see `getSessionStatus`
+ * for caveats.
+ */
+export class SessionItem extends vscode.TreeItem {
+  constructor(public readonly session: SessionMetadata) {
+    super(session.title, vscode.TreeItemCollapsibleState.None);
+
+    const status: SessionStatus = getSessionStatus(session.mtime);
+    const age = Date.now() - session.mtime;
+    const timeStr = relativeTime(age);
+    const branch = session.gitBranch ?? '?';
+
+    this.description = `${branch} · ${timeStr}`;
+    this.iconPath = SessionItem.iconForStatus(status);
+    this.tooltip = SessionItem.buildTooltip(session, timeStr);
+    this.contextValue = 'claudeSession';
+
+    // Command fires on click — handled in extension.ts
+    this.command = {
+      command: 'agentTasks.sessions.openSession',
+      title: 'Open Session',
+      arguments: [this],
+    };
+  }
+
+  private static iconForStatus(status: SessionStatus): vscode.ThemeIcon {
+    switch (status) {
+      case 'active':
+        // Blue pulse — heuristic: Claude is likely still writing
+        return new vscode.ThemeIcon('pulse', new vscode.ThemeColor('charts.blue'));
+      case 'recent':
+        // Blue history — heuristic: session ended recently
+        return new vscode.ThemeIcon('history', new vscode.ThemeColor('charts.blue'));
+      case 'idle':
+      default:
+        // Default (gray) history — session is old
+        return new vscode.ThemeIcon('history');
+    }
+  }
+
+  private static buildTooltip(session: SessionMetadata, timeStr: string): vscode.MarkdownString {
+    const md = new vscode.MarkdownString();
+    md.appendMarkdown(`**${session.title}**\n\n`);
+    md.appendMarkdown(`**Session ID:** \`${session.sessionId}\`\n\n`);
+    md.appendMarkdown(`**Messages:** ${session.messageCount}\n\n`);
+    if (session.lastTimestamp) {
+      md.appendMarkdown(`**Last activity:** ${session.lastTimestamp} (${timeStr})\n\n`);
+    }
+    if (session.cwd) {
+      md.appendMarkdown(`**CWD:** \`${session.cwd}\`\n\n`);
+    }
+    md.appendMarkdown(`**File:** \`${session.filePath}\`\n\n`);
+    md.appendMarkdown(
+      `\n\n_Status icon is a heuristic based on file mtime and may not reflect actual session state._`
+    );
+    return md;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Union type for provider elements
+// ---------------------------------------------------------------------------
+
+type SessionTreeItem = WorktreeGroupItem | SessionItem;
+
+// ---------------------------------------------------------------------------
+// Worktree discovery helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk up from `startPath` up to `maxLevels` ancestors looking for a
+ * `.gw/config.json` file. Returns the parsed config object or null.
+ */
+function findGwConfig(startPath: string, maxLevels = 5): { root?: string; defaultBranch?: string } | null {
+  let dir = startPath;
+  for (let i = 0; i < maxLevels; i++) {
+    const configPath = path.join(dir, '.gw', 'config.json');
+    try {
+      const content = fs.readFileSync(configPath, 'utf-8');
+      return JSON.parse(content) as { root?: string; defaultBranch?: string };
+    } catch {
+      // Not found at this level — try parent
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Enumerate worktree paths using `.gw/config.json`.
+ *
+ * Reads `root` from the config and lists subdirectories that contain a `.git`
+ * file (worktree marker, not a directory `.git` which would be the main repo).
+ */
+function getWorktreePathsFromGwConfig(workspacePath: string): string[] | null {
+  const config = findGwConfig(workspacePath);
+  if (!config?.root) return null;
+
+  const root = config.root;
+  let subdirs: fs.Dirent[];
+  try {
+    subdirs = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const paths: string[] = [];
+  for (const entry of subdirs) {
+    if (!entry.isDirectory()) continue;
+    const worktreePath = path.join(root, entry.name);
+    // A git worktree (not the bare repo itself) has a `.git` FILE
+    const gitPath = path.join(worktreePath, '.git');
+    try {
+      const stat = fs.statSync(gitPath);
+      if (stat.isFile()) {
+        paths.push(worktreePath);
+      }
+    } catch {
+      // No .git — not a worktree
+    }
+  }
+  return paths.length > 0 ? paths : null;
+}
+
+/**
+ * Enumerate worktree paths via `git worktree list --porcelain`.
+ * Returns null if the command fails (not a git repo, git not installed, etc.).
+ */
+function getWorktreePathsFromGit(workspacePath: string): string[] | null {
+  try {
+    const output = child_process.execSync('git worktree list --porcelain', {
+      cwd: workspacePath,
+      encoding: 'utf-8',
+      timeout: 3000,
+    });
+
+    const paths: string[] = [];
+    for (const line of output.split('\n')) {
+      if (line.startsWith('worktree ')) {
+        paths.push(line.slice('worktree '.length).trim());
+      }
+    }
+    return paths.length > 0 ? paths : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return the deduplicated list of worktree paths for the workspace.
+ * Always includes the workspace path itself.
+ *
+ * Priority:
+ *   1. `.gw/config.json` if present
+ *   2. `git worktree list --porcelain` fallback
+ *   3. Just the workspace path (single-worktree / non-git scenario)
+ */
+function discoverWorktreePaths(workspacePath: string): string[] {
+  const seen = new Set<string>();
+  const paths: string[] = [];
+
+  const add = (p: string) => {
+    const normalised = p.replace(/\/$/, '');
+    if (!seen.has(normalised)) {
+      seen.add(normalised);
+      paths.push(normalised);
+    }
+  };
+
+  // Try gw config first
+  const gwPaths = getWorktreePathsFromGwConfig(workspacePath);
+  if (gwPaths) {
+    for (const p of gwPaths) add(p);
+    add(workspacePath); // ensure workspace itself is included
+    return paths;
+  }
+
+  // Fallback to git worktree list
+  const gitPaths = getWorktreePathsFromGit(workspacePath);
+  if (gitPaths) {
+    for (const p of gitPaths) add(p);
+    add(workspacePath);
+    return paths;
+  }
+
+  // Just the workspace
+  add(workspacePath);
+  return paths;
+}
+
+// ---------------------------------------------------------------------------
+// SessionsProvider
+// ---------------------------------------------------------------------------
+
+export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<SessionTreeItem | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  /** Cache of session dirs being watched — exposed for SessionWatcher rebuild. */
+  private _sessionDirs: string[] = [];
+
+  // No constructor arguments required — provider is initialised lazily on first getChildren call.
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  constructor() {
+    // Intentionally empty — provider state is built lazily in buildRootItems()
+  }
+
+  /** The session directories currently being observed. */
+  get sessionDirs(): string[] {
+    return this._sessionDirs;
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: SessionTreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(element?: SessionTreeItem): Promise<SessionTreeItem[]> {
+    if (element instanceof WorktreeGroupItem) {
+      return element.sessions.map((s) => new SessionItem(s));
+    }
+
+    if (element instanceof SessionItem) {
+      return [];
+    }
+
+    // Root level — build tree
+    return this.buildRootItems();
+  }
+
+  /**
+   * Build the root-level tree items.
+   *
+   * If only one worktree has sessions, or all sessions come from the same
+   * worktree, show them flat (no WorktreeGroupItem wrapper). Otherwise, group
+   * by worktree.
+   */
+  private buildRootItems(): SessionTreeItem[] {
+    const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!workspacePath) return [];
+
+    const worktreePaths = discoverWorktreePaths(workspacePath);
+
+    // Collect sessions per worktree, track session dirs for watcher
+    const sessionDirs: string[] = [];
+    const groups: Array<{ worktreePath: string; sessions: SessionMetadata[] }> = [];
+
+    for (const wt of worktreePaths) {
+      const dir = getSessionsDir(wt);
+      sessionDirs.push(dir);
+      const sessions = parseSessionsInDir(dir);
+      if (sessions.length > 0) {
+        groups.push({ worktreePath: wt, sessions });
+      }
+    }
+
+    // Update cached session dirs (for watcher rebuild)
+    this._sessionDirs = sessionDirs;
+
+    // No sessions anywhere
+    if (groups.length === 0) return [];
+
+    // Single worktree OR all sessions from one worktree → show flat
+    if (
+      worktreePaths.length === 1 ||
+      groups.length === 1
+    ) {
+      // Combine all sessions across groups and sort newest-first
+      const allSessions = groups.flatMap((g) => g.sessions).sort((a, b) => b.mtime - a.mtime);
+      return allSessions.map((s) => new SessionItem(s));
+    }
+
+    // Multiple worktrees — show grouped
+    return groups.map((g) => new WorktreeGroupItem(g.worktreePath, g.sessions));
+  }
+}

--- a/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
+++ b/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
@@ -132,11 +132,15 @@ export class WorktreeGroupItem extends vscode.TreeItem {
  * up-front in the tooltip so users don't mistake the icon for ground truth.
  */
 export class SessionItem extends vscode.TreeItem {
-  constructor(public readonly session: SessionMetadata, options: { grouped: boolean }) {
+  constructor(
+    public readonly session: SessionMetadata,
+    options: { grouped: boolean; effectiveMtime?: number }
+  ) {
     super(session.title, vscode.TreeItemCollapsibleState.None);
 
-    const status: SessionStatus = getSessionStatus(session.mtime);
-    const timeStr = formatTime(session.mtime);
+    const effectiveMtime = options.effectiveMtime ?? session.mtime;
+    const status: SessionStatus = getSessionStatus(effectiveMtime);
+    const timeStr = formatTime(effectiveMtime);
     const branch = session.gitBranch ?? '?';
 
     this.description = options.grouped ? timeStr : `${branch} · ${timeStr}`;
@@ -418,9 +422,41 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
   /** Cache of session dirs being watched — exposed for SessionWatcher rebuild. */
   private _sessionDirs: string[] = [];
 
+  /**
+   * Optimistic activity timestamps: when the user clicks a session to resume
+   * it, we mark it as just-opened immediately so the icon flips to "active"
+   * without waiting for the file watcher to catch the next claude write.
+   *
+   * The provider treats `max(file mtime, optimistic timestamp)` as the
+   * effective activity time. Once a real file change lands the entry becomes
+   * irrelevant naturally; we also age them out after 5 minutes so a clicked-
+   * then-quit session doesn't lie indefinitely.
+   */
+  private optimisticOpens = new Map<string, number>();
+  private static readonly OPTIMISTIC_TTL_MS = 5 * 60 * 1000;
+
   /** The session directories currently being observed. */
   get sessionDirs(): string[] {
     return this._sessionDirs;
+  }
+
+  /**
+   * Mark a session as just-opened so its icon shows "active" immediately on
+   * click, without waiting for the file watcher. Idempotent.
+   */
+  touchActive(sessionId: string): void {
+    this.optimisticOpens.set(sessionId, Date.now());
+    this.refresh();
+  }
+
+  private effectiveMtime(session: SessionMetadata): number {
+    const optimistic = this.optimisticOpens.get(session.sessionId);
+    if (optimistic === undefined) return session.mtime;
+    if (Date.now() - optimistic > SessionsProvider.OPTIMISTIC_TTL_MS) {
+      this.optimisticOpens.delete(session.sessionId);
+      return session.mtime;
+    }
+    return Math.max(session.mtime, optimistic);
   }
 
   refresh(): void {
@@ -433,7 +469,9 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
 
   async getChildren(element?: SessionTreeItem): Promise<SessionTreeItem[]> {
     if (element instanceof WorktreeGroupItem) {
-      return element.sessions.map((s) => new SessionItem(s, { grouped: true }));
+      return element.sessions.map(
+        (s) => new SessionItem(s, { grouped: true, effectiveMtime: this.effectiveMtime(s) })
+      );
     }
     if (element instanceof SessionItem) {
       return [];
@@ -470,14 +508,18 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
     // Single worktree (or scope === 'current') → flat list
     if (worktreePaths.length <= 1) {
       const sessions = buckets.get(worktreePaths[0]) ?? [];
-      return sessions.map((s) => new SessionItem(s, { grouped: false }));
+      return sessions.map(
+        (s) => new SessionItem(s, { grouped: false, effectiveMtime: this.effectiveMtime(s) })
+      );
     }
 
-    // Multi-worktree → grouped, current first, others by most-recent activity
+    // Multi-worktree → grouped, current first, others by most-recent activity.
+    // The "most recent" mtime here uses effectiveMtime so an optimistically-
+    // touched session lifts its group's sort order too.
     const groups: Array<{ wt: string; sessions: SessionMetadata[]; mtime: number }> = [];
     for (const wt of worktreePaths) {
       const sessions = buckets.get(wt) ?? [];
-      const mtime = sessions[0]?.mtime ?? 0;
+      const mtime = sessions.reduce((max, s) => Math.max(max, this.effectiveMtime(s)), 0);
       groups.push({ wt, sessions, mtime });
     }
 

--- a/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
+++ b/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
@@ -125,11 +125,10 @@ export class WorktreeGroupItem extends vscode.TreeItem {
  * A leaf node representing one Claude Code session.
  *
  * Layout:
- *   - Label: `<time> · <message>` — time is INSIDE the label so it survives
- *     narrow panels. The message text is what gets truncated when there's no
- *     room, not the timestamp.
- *   - Description: branch when flat (single worktree); empty when grouped
- *     (branch is implicit from the parent group).
+ *   - Label: the message text only (truncated short — see MAX_TITLE_LEN).
+ *   - Description: relative time when grouped (branch is implicit); `branch ·
+ *     time` when flat. VS Code renders the description in muted/grey so the
+ *     timestamp visually subordinates to the message.
  *
  * Status is computed by the provider so it can layer terminal-open / closed
  * signals on top of the raw mtime heuristic.
@@ -139,12 +138,12 @@ export class SessionItem extends vscode.TreeItem {
     public readonly session: SessionMetadata,
     options: { grouped: boolean; status: SessionStatus }
   ) {
+    super(session.title, vscode.TreeItemCollapsibleState.None);
+
     const timeStr = formatTime(session.mtime);
     const branch = session.gitBranch ?? '?';
 
-    super(`${timeStr} · ${session.title}`, vscode.TreeItemCollapsibleState.None);
-
-    this.description = options.grouped ? '' : branch;
+    this.description = options.grouped ? timeStr : `${branch} · ${timeStr}`;
     this.iconPath = SessionItem.iconForStatus(options.status);
     this.tooltip = SessionItem.buildTooltip(session, timeStr, options.status, branch);
     this.contextValue = 'claudeSession';

--- a/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
+++ b/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
@@ -44,24 +44,24 @@ const MONTH_NAMES = [
 /**
  * Format a session mtime as a compact, human-readable timestamp.
  *
- * Uses relative time for recent activity ("just now", "5m ago", "3h ago",
- * "2d ago" up to 7 days), then switches to absolute "MMM D" so old sessions
- * don't read as "187d ago" — matches the UX writing guidance to use
- * relative-for-recent and absolute-for-older.
+ * Tight format: `now`, `5m`, `3h`, `2d` for recent activity (≤7 days), then
+ * absolute `MMM D` for older. The `ago` suffix is dropped — implicit from
+ * context in a recency-sorted list and saves 3–4 chars per row, which
+ * matters at sidebar widths.
  */
 function formatTime(mtimeMs: number, now = Date.now()): string {
   const ageMs = now - mtimeMs;
   const seconds = Math.floor(ageMs / 1000);
-  if (seconds < 60) return 'just now';
+  if (seconds < 60) return 'now';
 
   const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
+  if (minutes < 60) return `${minutes}m`;
 
   const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
+  if (hours < 24) return `${hours}h`;
 
   const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
+  if (days < 7) return `${days}d`;
 
   const d = new Date(mtimeMs);
   return `${MONTH_NAMES[d.getMonth()]} ${d.getDate()}`;
@@ -125,10 +125,12 @@ export class WorktreeGroupItem extends vscode.TreeItem {
  * A leaf node representing one Claude Code session.
  *
  * Layout:
- *   - Label: the message text only (truncated short — see MAX_TITLE_LEN).
- *   - Description: relative time when grouped (branch is implicit); `branch ·
- *     time` when flat. VS Code renders the description in muted/grey so the
- *     timestamp visually subordinates to the message.
+ *   - Label:       the message text (truncated short — see MAX_TITLE_LEN).
+ *   - Description: just the relative time, always (branch is in the tooltip).
+ *
+ * VS Code renders the description in muted/grey, so the timestamp visually
+ * subordinates to the message. Keeping description short — `5m`, `Apr 17` —
+ * means it survives narrow panels far more often than `branch · time` did.
  *
  * Status is computed by the provider so it can layer terminal-open / closed
  * signals on top of the raw mtime heuristic.
@@ -136,14 +138,14 @@ export class WorktreeGroupItem extends vscode.TreeItem {
 export class SessionItem extends vscode.TreeItem {
   constructor(
     public readonly session: SessionMetadata,
-    options: { grouped: boolean; status: SessionStatus }
+    options: { status: SessionStatus }
   ) {
     super(session.title, vscode.TreeItemCollapsibleState.None);
 
     const timeStr = formatTime(session.mtime);
     const branch = session.gitBranch ?? '?';
 
-    this.description = options.grouped ? timeStr : `${branch} · ${timeStr}`;
+    this.description = timeStr;
     this.iconPath = SessionItem.iconForStatus(options.status);
     this.tooltip = SessionItem.buildTooltip(session, timeStr, options.status, branch);
     this.contextValue = 'claudeSession';
@@ -490,7 +492,7 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
   async getChildren(element?: SessionTreeItem): Promise<SessionTreeItem[]> {
     if (element instanceof WorktreeGroupItem) {
       return element.sessions.map(
-        (s) => new SessionItem(s, { grouped: true, status: this.computeStatus(s) })
+        (s) => new SessionItem(s, { status: this.computeStatus(s) })
       );
     }
     if (element instanceof SessionItem) {
@@ -529,7 +531,7 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
     if (worktreePaths.length <= 1) {
       const sessions = buckets.get(worktreePaths[0]) ?? [];
       return sessions.map(
-        (s) => new SessionItem(s, { grouped: false, status: this.computeStatus(s) })
+        (s) => new SessionItem(s, { status: this.computeStatus(s) })
       );
     }
 

--- a/packages/vscode-agent-tasks/src/watchers/session-watcher.ts
+++ b/packages/vscode-agent-tasks/src/watchers/session-watcher.ts
@@ -28,7 +28,12 @@ export class SessionWatcher implements vscode.Disposable {
   private fsWatchers: fs.FSWatcher[] = [];
   private vscodeWatchers: vscode.FileSystemWatcher[] = [];
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  private static readonly DEBOUNCE_MS = 500;
+  /**
+   * Trailing debounce window. 150 ms is short enough that an icon flip from
+   * `idle` → `active` feels instant after the first JSONL write, while still
+   * coalescing the burst of writes Claude does at the start of a turn.
+   */
+  private static readonly DEBOUNCE_MS = 150;
 
   private _onSessionChanged = new vscode.EventEmitter<void>();
   /** Fires (debounced) when any watched JSONL file changes. */

--- a/packages/vscode-agent-tasks/src/watchers/session-watcher.ts
+++ b/packages/vscode-agent-tasks/src/watchers/session-watcher.ts
@@ -1,0 +1,136 @@
+/**
+ * File system watcher for Claude Code session JSONL directories.
+ *
+ * Watches one or more `~/.claude/projects/<encoded-cwd>/` directories and
+ * fires an `onSessionChanged` event when any `.jsonl` file is created,
+ * modified, or deleted. The SessionsProvider listens to this event and calls
+ * `refresh()`.
+ *
+ * Platform strategy (mirrors ArtifactWatcher):
+ *   macOS / Windows — `fs.watch(dir, { recursive: false }, …)`.
+ *     Non-recursive is sufficient: JSONL files are flat in the directory.
+ *     The session dirs live outside the VS Code workspace boundary so we use
+ *     native fs.watch rather than vscode.workspace.createFileSystemWatcher.
+ *   Linux — `vscode.workspace.createFileSystemWatcher` as best-effort fallback
+ *     (fs.watch recursive is unsupported on Linux; *.jsonl glob still fires for
+ *     files inside the watched dir).
+ *
+ * Debounce: 500 ms. JSONL files are written continuously during active
+ * sessions; a 500 ms window avoids thrashing the tree refresh while still
+ * providing near-realtime updates.
+ */
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as os from 'os';
+
+export class SessionWatcher implements vscode.Disposable {
+  private fsWatchers: fs.FSWatcher[] = [];
+  private vscodeWatchers: vscode.FileSystemWatcher[] = [];
+  private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private static readonly DEBOUNCE_MS = 500;
+
+  private _onSessionChanged = new vscode.EventEmitter<void>();
+  /** Fires (debounced) when any watched JSONL file changes. */
+  readonly onSessionChanged = this._onSessionChanged.event;
+
+  constructor(sessionDirs: string[] = []) {
+    this.buildWatchers(sessionDirs);
+  }
+
+  /**
+   * Replace the current set of watched directories with `newDirs`.
+   * Called when the workspace changes (e.g. new worktree added).
+   */
+  rebuild(newDirs: string[]): void {
+    this.disposeWatchers();
+    this.buildWatchers(newDirs);
+  }
+
+  private buildWatchers(dirs: string[]): void {
+    const platform = os.platform();
+    for (const dir of dirs) {
+      if (!dir) continue;
+      if (platform === 'darwin' || platform === 'win32') {
+        this.setupNativeWatcher(dir);
+      } else {
+        this.setupVscodeWatcher(dir);
+      }
+    }
+  }
+
+  private setupNativeWatcher(dir: string): void {
+    // Create the directory if it doesn't exist so we can attach a watcher.
+    // (Claude Code creates it on first session run; we want to watch even
+    // before that so the first session appears without a manual refresh.)
+    try {
+      if (!fs.existsSync(dir)) {
+        // Don't create it — just skip watching until it exists.
+        // The provider will show an empty state which is correct.
+        return;
+      }
+
+      const watcher = fs.watch(dir, { recursive: false }, (_eventType, filename) => {
+        if (!filename) return;
+        // Only react to .jsonl files
+        if (!filename.endsWith('.jsonl')) return;
+        this.emitDebounced(filename);
+      });
+
+      watcher.on('error', () => {
+        // Silently ignore — watcher stops but extension keeps running
+      });
+
+      this.fsWatchers.push(watcher);
+    } catch {
+      // fs.watch failed (permissions, etc.) — fall back to VS Code watcher
+      this.setupVscodeWatcher(dir);
+    }
+  }
+
+  private setupVscodeWatcher(dir: string): void {
+    try {
+      const base = vscode.Uri.file(dir);
+      const watcher = vscode.workspace.createFileSystemWatcher(
+        new vscode.RelativePattern(base, '*.jsonl')
+      );
+
+      watcher.onDidChange(() => this.emitDebounced('change'));
+      watcher.onDidCreate(() => this.emitDebounced('create'));
+      watcher.onDidDelete(() => this.emitDebounced('delete'));
+
+      this.vscodeWatchers.push(watcher);
+    } catch {
+      // If even VS Code watcher fails, silently degrade — live refresh
+      // won't work but manual refresh still works.
+    }
+  }
+
+  private emitDebounced(key: string): void {
+    const existing = this.debounceTimers.get(key);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      this.debounceTimers.delete(key);
+      this._onSessionChanged.fire();
+    }, SessionWatcher.DEBOUNCE_MS);
+
+    this.debounceTimers.set(key, timer);
+  }
+
+  private disposeWatchers(): void {
+    for (const timer of this.debounceTimers.values()) clearTimeout(timer);
+    this.debounceTimers.clear();
+
+    for (const w of this.fsWatchers) w.close();
+    this.fsWatchers = [];
+
+    for (const w of this.vscodeWatchers) w.dispose();
+    this.vscodeWatchers = [];
+  }
+
+  dispose(): void {
+    this.disposeWatchers();
+    this._onSessionChanged.dispose();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a **Sessions** view inside the existing `agentTasks` activity-bar container, alongside the existing Agent Tasks view
- Sessions are read from `~/.claude/projects/<encoded-cwd>/*.jsonl` and displayed newest-first with mtime-heuristic status icons (active/recent/idle)
- Clicking a session opens the JSONL transcript in the editor (default) or runs `claude --resume <id>` in a terminal (configurable via `agentTasks.sessions.openWith`)
- Sibling worktrees are auto-discovered via `.gw/config.json` (primary) or `git worktree list --porcelain` (fallback) for multi-worktree grouping
- Live-updates via a 500 ms-debounced `fs.watch` watcher (macOS/Windows) with VS Code file watcher fallback (Linux)

## New files

| File | Purpose |
|------|---------|
| `src/parsers/session-jsonl-parser.ts` | Pure TS parser (no VS Code dep), 32 vitest tests |
| `src/parsers/session-jsonl-parser.test.ts` | Full test coverage using real temp dirs |
| `src/providers/sessions-provider.ts` | `TreeDataProvider` with worktree grouping |
| `src/watchers/session-watcher.ts` | Cross-platform file watcher for session dirs |

## Modified files

| File | Change |
|------|--------|
| `src/extension.ts` | Wire provider, watcher, and two new commands |
| `package.json` | New view, commands, config, activation events; auto-bumped to v0.10.0 |
| `.gitignore` | Add `.agent` (was missing) |
| `README.md` | Full Sessions feature documentation |
| `CLAUDE.md` | Architecture, gotchas, and config namespace updated |

## Key design decisions

- **mtime-based status is a heuristic**: Claude Code writes no terminal markers. Status caveat is documented in code, README, and CLAUDE.md.
- **JSONL schema is undocumented**: All parsing centralised in `session-jsonl-parser.ts` — a schema bump is a one-file change. Unknown event types are silently skipped.
- **ESM testing limitation**: `vi.spyOn(fs)` does not work with ESM in vitest. Tests use real temp directories instead (created/removed per-test via `beforeEach`/`afterEach`).
- **`onStartupFinished` activation**: Added so the Sessions panel works in repos without `.agent/` or `.gw/`. Trade-off documented in README.

## Test plan

- [x] `nx test vscode-agent-tasks` — 65 tests pass (32 new, 33 existing)
- [x] `nx lint vscode-agent-tasks` — no warnings
- [x] `nx build vscode-agent-tasks` — TypeScript compiles without errors
- [ ] Manual: Sessions view appears in activity bar alongside Agent Tasks
- [ ] Manual: Sessions list populates from `~/.claude/projects/<encoded-cwd>/`
- [ ] Manual: Click opens JSONL in editor (default)
- [ ] Manual: `agentTasks.sessions.openWith = "resume"` runs `claude --resume` in terminal
- [ ] Manual: Tooltip shows session ID, message count, last activity, CWD, file path
- [ ] Manual: Live refresh when new JSONL events are written
- [ ] Manual: Multi-worktree grouping in gw bare-repo