### PR TITLE
fix(sessions): deterministic terminal adoption — revert cwd-match, add pending-adoption queue

### DIFF
--- a/packages/vscode-agent-tasks/CLAUDE.md
+++ b/packages/vscode-agent-tasks/CLAUDE.md
@@ -28,7 +28,7 @@ src/
   extension.ts              # Entry point, command registration, terminal tracking
   lib/
     logger.ts               # `mthines.agent-tasks` OutputChannel wrapper
-    process-tree.ts         # Pure helpers: `parsePsOutput`, `findClaudeDescendant`, `parseLsofCwdOutput`, `collectClaudeDescendants` — no VS Code dep, vitest-testable
+    process-tree.ts         # Pure helpers: `parsePsOutput`, `findClaudeDescendant`, `claimPendingAdoption` — no VS Code dep, vitest-testable
   providers/                # TreeDataProviders for sidebar views
     agent-tasks-provider    # Agent tasks explorer view
     sessions-provider       # Sessions panel — Running section + worktree groups
@@ -53,13 +53,11 @@ src/
 - **Worktree grouping in Sessions** — gw-aware (walks up to find `.gw/config.json`, then enumerates sibling worktrees by `.git` file marker) → falls back to `git worktree list --porcelain` → finally just the workspace path. Multi-worktree always groups; current worktree pinned first and marked `(current)`. Single-worktree shows flat.
 - **Session Watcher** — 50 ms trailing debounce (was 500 ms — kept tight for realtime icon transitions). 15 s visibility-bound refresh tick drives `running → stalled` ageing-out without waiting on file events.
 - **Per-session terminal tracking** — `extension.ts` maintains a `Map<sessionId, vscode.Terminal>` so re-clicking a session focuses its existing tab instead of spawning a duplicate. `onDidCloseTerminal` cleans up. Cross-window is impossible — VS Code's API is window-scoped.
-- **Terminal adoption on click** — when `openSession` finds no tracked terminal for a session, `tryAdoptTerminal` runs a two-strategy scan across `vscode.window.terminals`:
-  1. **Argv fast-path** (`findClaudeDescendant`): one `ps -A -o pid,ppid,command` snapshot; BFS each terminal's shell PID for a descendant whose command contains `claude --resume <sid>`. Succeeds when the extension itself previously spawned the terminal and lost tracking on window reload.
-  2. **Cwd slow-path** (`collectClaudeDescendants` + `parseLsofCwdOutput`): collects ALL claude descendants across all terminals, then issues a single `lsof -a -p PIDS -d cwd -Fpn` call. Compares each claude process's cwd against `session.cwd` (exact byte match). **Uniqueness guard**: if exactly one terminal has a cwd-matching claude descendant, adopt it; if zero or more than one, fall through to spawn. Covers bare `claude` invocations where the UUID is assigned internally (most common case).
-  
-  Both strategies are tried in order — argv first, then cwd. All failures (ps error, lsof non-zero, no match, ambiguous match) fall through silently to spawn. The scan runs only inside `openSession` — never on refresh, watcher tick, or panel render.
-  
-  **Documented limitation**: when two or more claude processes share the same cwd (multiple sessions in the same worktree), the uniqueness guard fires and a new `claude --resume` terminal is spawned instead of adopting. Accepted behavior for v2.
+- **Terminal adoption on click** — when `openSession` finds no tracked terminal for a session, `tryAdoptTerminal` runs the argv fast-path scan across `vscode.window.terminals`:
+  - **Argv fast-path** (`findClaudeDescendant`): one `ps -A -o pid,ppid,command` snapshot; BFS each terminal's shell PID for a descendant whose command contains `claude --resume <sid>`. Succeeds when the extension itself previously spawned the terminal and lost tracking on window reload.
+  - All failures (ps error, no match) fall through silently to spawn. The scan runs only inside `openSession` — never on refresh, watcher tick, or panel render.
+- **Pending-adoption queue** — when the user clicks the `+` new-session button, the spawned terminal is pushed onto `pendingAdoptions: Array<PendingAdoption<vscode.Terminal>>` with the workspace cwd and a `spawnedAt` timestamp. `SessionsProvider.onDidDiscoverSession` fires whenever a new session ID is seen for the first time. `extension.ts` listens and calls `claimPendingAdoption(pendingAdoptions, session.cwd, Date.now(), PENDING_TTL_MS)` — a pure function that evicts stale entries (>60 s) and returns the first exact-cwd-match. On a claim: the terminal is inserted into `sessionTerminals`, `setTerminalOpen` fires, and the terminal is focused. `onDidCloseTerminal` evicts the terminal from the queue if it closes before a session appears.
+- **Documented limitation** — bare `claude` processes typed by the user in external or integrated terminals OUTSIDE the `+` flow cannot be safely adopted. Cwd-match was empirically shown to produce false-positive adoptions (same-cwd sessions in the same worktree adopt each other). Clicking such a session spawns a fresh `claude --resume <id>` terminal. Once spawned and tracked, subsequent clicks focus that terminal correctly.
 - **Parse cache** — `parseSessionFile` is mtime-keyed; unchanged JSONL files skip read+parse on refresh. Bounded by unique session count (tens to hundreds).
 
 ## Configuration namespace
@@ -99,7 +97,7 @@ All commands, views, settings, and keybindings are defined in `package.json`:
 | `agentTasks.sessions.openSession` | Internal — open or resume a session (registered on SessionItem) |
 | `agentTasks.sessions.toggleScope` | Toggle `current` / `all` worktrees in the Sessions panel |
 | `agentTasks.sessions.find` | Open a QuickPick across every session for this workspace |
-| `agentTasks.sessions.newSession` | Start a new `claude` session in the workspace root CWD. Appears as a `+` icon in the `agentSessionsExplorer` panel title bar (`navigation@0`). Hidden from command palette. Does not pre-populate `sessionTerminals` — Feature 1's adoption scan handles the next click. |
+| `agentTasks.sessions.newSession` | Start a new `claude` session in the workspace root CWD. Appears as a `+` icon in the `agentSessionsExplorer` panel title bar (`navigation@0`). Hidden from command palette. Pushes a `PendingAdoption` entry so the first new JSONL in that cwd is automatically linked to the spawned terminal via `onDidDiscoverSession`. |
 
 ## Code Style
 

--- a/packages/vscode-agent-tasks/CLAUDE.md
+++ b/packages/vscode-agent-tasks/CLAUDE.md
@@ -53,6 +53,13 @@ src/
 - **Worktree grouping in Sessions** — gw-aware (walks up to find `.gw/config.json`, then enumerates sibling worktrees by `.git` file marker) → falls back to `git worktree list --porcelain` → finally just the workspace path. Multi-worktree always groups; current worktree pinned first and marked `(current)`. Single-worktree shows flat.
 - **Session Watcher** — 50 ms trailing debounce (was 500 ms — kept tight for realtime icon transitions). 15 s visibility-bound refresh tick drives `running → stalled` ageing-out without waiting on file events.
 - **Per-session terminal tracking** — `extension.ts` maintains a `Map<sessionId, vscode.Terminal>` so re-clicking a session focuses its existing tab instead of spawning a duplicate. `onDidCloseTerminal` cleans up. Cross-window is impossible — VS Code's API is window-scoped.
+- **Open-session paths** — three uniform paths reach any session regardless of tree shape (leaf or collapsible group member):
+  1. Click a leaf `SessionItem` row → fires the item's `.command` → `openSession` (VS Code convention for leaf items).
+  2. Click a `WorktreeGroupItem` row → expands/collapses the group (VS Code convention for collapsible items — no `openSession` fires).
+  3. Hover any session row → click the `▶` inline icon (`$(play)`, `view/item/context inline@1`, `viewItem =~ /^claudeSession/`) → `openSession`.
+  4. Focus any session row → press Enter → fires `agentTasks.sessions.openSession` keybinding (`when: focusedView == 'agentSessionsExplorer' && viewItem =~ /^claudeSession/`).
+  5. Right-click any session row → "Resume Session" in the context menu (`view/item/context navigation@1`, same `when` clause) → `openSession`.
+  The `viewItem =~ /^claudeSession/` regex future-proofs all three affordances against new `SessionItem` subtypes (e.g. `claudeSessionWithArtifacts`).
 - **Terminal adoption on click** — when `openSession` finds no tracked terminal for a session, `tryAdoptTerminal` runs the argv fast-path scan across `vscode.window.terminals`:
   - **Argv fast-path** (`findClaudeDescendant`): one `ps -A -o pid,ppid,command` snapshot; BFS each terminal's shell PID for a descendant whose command contains `claude --resume <sid>`. Succeeds when the extension itself previously spawned the terminal and lost tracking on window reload.
   - All failures (ps error, no match) fall through silently to spawn. The scan runs only inside `openSession` — never on refresh, watcher tick, or panel render.
@@ -80,6 +87,7 @@ All commands, views, settings, and keybindings are defined in `package.json`:
 - Commands: `contributes.commands` (all `agentTasks.*`)
 - Views: `contributes.views` (`agentTasksExplorer` and `agentSessionsExplorer` inside `agentTasks` activity bar)
 - Settings: `contributes.configuration` (`agentTasks.*` namespace)
+- Keybindings: `contributes.keybindings` — focus sidebar chord + Enter-to-open on focused session rows
 - Activation: `workspaceContains:.agent`, `workspaceContains:.gw`, `onStartupFinished`, `onView:agentSessionsExplorer`
 
 ## Command IDs
@@ -94,7 +102,7 @@ All commands, views, settings, and keybindings are defined in `package.json`:
 | `agentTasks.openTask` | Open task.md for a branch item |
 | `agentTasks.openWalkthrough` | Open walkthrough.md for a branch item |
 | `agentTasks.sessions.refresh` | Refresh Sessions tree |
-| `agentTasks.sessions.openSession` | Internal — open or resume a session (registered on SessionItem) |
+| `agentTasks.sessions.openSession` | Resume a session — fires on leaf row click, Enter keybinding, hover `▶` inline icon, and right-click "Resume Session" context menu. Hidden from command palette. |
 | `agentTasks.sessions.toggleScope` | Toggle `current` / `all` worktrees in the Sessions panel |
 | `agentTasks.sessions.find` | Open a QuickPick across every session for this workspace |
 | `agentTasks.sessions.newSession` | Start a new `claude` session in the workspace root CWD. Appears as a `+` icon in the `agentSessionsExplorer` panel title bar (`navigation@0`). Hidden from command palette. Pushes a `PendingAdoption` entry so the first new JSONL in that cwd is automatically linked to the spawned terminal via `onDidDiscoverSession`. |

--- a/packages/vscode-agent-tasks/CLAUDE.md
+++ b/packages/vscode-agent-tasks/CLAUDE.md
@@ -28,6 +28,7 @@ src/
   extension.ts              # Entry point, command registration, terminal tracking
   lib/
     logger.ts               # `mthines.agent-tasks` OutputChannel wrapper
+    process-tree.ts         # Pure helpers: `parsePsOutput`, `findClaudeDescendant` — no VS Code dep, vitest-testable
   providers/                # TreeDataProviders for sidebar views
     agent-tasks-provider    # Agent tasks explorer view
     sessions-provider       # Sessions panel — Running section + worktree groups
@@ -52,6 +53,7 @@ src/
 - **Worktree grouping in Sessions** — gw-aware (walks up to find `.gw/config.json`, then enumerates sibling worktrees by `.git` file marker) → falls back to `git worktree list --porcelain` → finally just the workspace path. Multi-worktree always groups; current worktree pinned first and marked `(current)`. Single-worktree shows flat.
 - **Session Watcher** — 50 ms trailing debounce (was 500 ms — kept tight for realtime icon transitions). 15 s visibility-bound refresh tick drives `running → stalled` ageing-out without waiting on file events.
 - **Per-session terminal tracking** — `extension.ts` maintains a `Map<sessionId, vscode.Terminal>` so re-clicking a session focuses its existing tab instead of spawning a duplicate. `onDidCloseTerminal` cleans up. Cross-window is impossible — VS Code's API is window-scoped.
+- **Terminal adoption on click** — when `openSession` finds no tracked terminal for a session, `tryAdoptTerminal` runs a one-shot `ps -A -o pid,ppid,command` scan across `vscode.window.terminals`. For each terminal it awaits `terminal.processId` (the shell PID), then calls `findClaudeDescendant` to BFS the process tree for a descendant whose command contains `claude --resume <sid>`. The first match is adopted into `sessionTerminals` and focused; all failures fall through silently to spawn. Sessions started without `--resume <id>` (bare `claude` invocations) are not adoptable in v1. The scan runs only inside `openSession` — never on refresh, watcher tick, or panel render.
 - **Parse cache** — `parseSessionFile` is mtime-keyed; unchanged JSONL files skip read+parse on refresh. Bounded by unique session count (tens to hundreds).
 
 ## Configuration namespace
@@ -91,6 +93,7 @@ All commands, views, settings, and keybindings are defined in `package.json`:
 | `agentTasks.sessions.openSession` | Internal — open or resume a session (registered on SessionItem) |
 | `agentTasks.sessions.toggleScope` | Toggle `current` / `all` worktrees in the Sessions panel |
 | `agentTasks.sessions.find` | Open a QuickPick across every session for this workspace |
+| `agentTasks.sessions.newSession` | Start a new `claude` session in the workspace root CWD. Appears as a `+` icon in the `agentSessionsExplorer` panel title bar (`navigation@0`). Hidden from command palette. Does not pre-populate `sessionTerminals` — Feature 1's adoption scan handles the next click. |
 
 ## Code Style
 

--- a/packages/vscode-agent-tasks/CLAUDE.md
+++ b/packages/vscode-agent-tasks/CLAUDE.md
@@ -28,7 +28,7 @@ src/
   extension.ts              # Entry point, command registration, terminal tracking
   lib/
     logger.ts               # `mthines.agent-tasks` OutputChannel wrapper
-    process-tree.ts         # Pure helpers: `parsePsOutput`, `findClaudeDescendant` — no VS Code dep, vitest-testable
+    process-tree.ts         # Pure helpers: `parsePsOutput`, `findClaudeDescendant`, `parseLsofCwdOutput`, `collectClaudeDescendants` — no VS Code dep, vitest-testable
   providers/                # TreeDataProviders for sidebar views
     agent-tasks-provider    # Agent tasks explorer view
     sessions-provider       # Sessions panel — Running section + worktree groups
@@ -53,7 +53,13 @@ src/
 - **Worktree grouping in Sessions** — gw-aware (walks up to find `.gw/config.json`, then enumerates sibling worktrees by `.git` file marker) → falls back to `git worktree list --porcelain` → finally just the workspace path. Multi-worktree always groups; current worktree pinned first and marked `(current)`. Single-worktree shows flat.
 - **Session Watcher** — 50 ms trailing debounce (was 500 ms — kept tight for realtime icon transitions). 15 s visibility-bound refresh tick drives `running → stalled` ageing-out without waiting on file events.
 - **Per-session terminal tracking** — `extension.ts` maintains a `Map<sessionId, vscode.Terminal>` so re-clicking a session focuses its existing tab instead of spawning a duplicate. `onDidCloseTerminal` cleans up. Cross-window is impossible — VS Code's API is window-scoped.
-- **Terminal adoption on click** — when `openSession` finds no tracked terminal for a session, `tryAdoptTerminal` runs a one-shot `ps -A -o pid,ppid,command` scan across `vscode.window.terminals`. For each terminal it awaits `terminal.processId` (the shell PID), then calls `findClaudeDescendant` to BFS the process tree for a descendant whose command contains `claude --resume <sid>`. The first match is adopted into `sessionTerminals` and focused; all failures fall through silently to spawn. Sessions started without `--resume <id>` (bare `claude` invocations) are not adoptable in v1. The scan runs only inside `openSession` — never on refresh, watcher tick, or panel render.
+- **Terminal adoption on click** — when `openSession` finds no tracked terminal for a session, `tryAdoptTerminal` runs a two-strategy scan across `vscode.window.terminals`:
+  1. **Argv fast-path** (`findClaudeDescendant`): one `ps -A -o pid,ppid,command` snapshot; BFS each terminal's shell PID for a descendant whose command contains `claude --resume <sid>`. Succeeds when the extension itself previously spawned the terminal and lost tracking on window reload.
+  2. **Cwd slow-path** (`collectClaudeDescendants` + `parseLsofCwdOutput`): collects ALL claude descendants across all terminals, then issues a single `lsof -a -p PIDS -d cwd -Fpn` call. Compares each claude process's cwd against `session.cwd` (exact byte match). **Uniqueness guard**: if exactly one terminal has a cwd-matching claude descendant, adopt it; if zero or more than one, fall through to spawn. Covers bare `claude` invocations where the UUID is assigned internally (most common case).
+  
+  Both strategies are tried in order — argv first, then cwd. All failures (ps error, lsof non-zero, no match, ambiguous match) fall through silently to spawn. The scan runs only inside `openSession` — never on refresh, watcher tick, or panel render.
+  
+  **Documented limitation**: when two or more claude processes share the same cwd (multiple sessions in the same worktree), the uniqueness guard fires and a new `claude --resume` terminal is spawned instead of adopting. Accepted behavior for v2.
 - **Parse cache** — `parseSessionFile` is mtime-keyed; unchanged JSONL files skip read+parse on refresh. Bounded by unique session count (tens to hundreds).
 
 ## Configuration namespace

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.30.0",
+  "version": "0.32.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {
@@ -121,6 +121,12 @@
         "title": "Find Session…",
         "icon": "$(search)",
         "category": "Agent Tasks"
+      },
+      {
+        "command": "agentTasks.sessions.newSession",
+        "title": "New Claude Session",
+        "icon": "$(add)",
+        "category": "Agent Tasks"
       }
     ],
     "menus": {
@@ -144,6 +150,10 @@
         {
           "command": "agentTasks.sessions.openSession",
           "when": "false"
+        },
+        {
+          "command": "agentTasks.sessions.newSession",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -156,6 +166,11 @@
           "command": "agentTasks.sort",
           "when": "view == agentTasksExplorer",
           "group": "navigation"
+        },
+        {
+          "command": "agentTasks.sessions.newSession",
+          "when": "view == agentSessionsExplorer",
+          "group": "navigation@0"
         },
         {
           "command": "agentTasks.sessions.find",

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-agent-tasks/package.json
+++ b/packages/vscode-agent-tasks/package.json
@@ -2,7 +2,7 @@
   "name": "agent-tasks",
   "displayName": "Agent Tasks",
   "description": "Visualize autonomous agent workflow artifacts (plan.md, task.md, walkthrough.md) from the VS Code sidebar",
-  "version": "0.32.0",
+  "version": "0.34.0",
   "publisher": "mthines",
   "license": "MIT",
   "repository": {
@@ -107,7 +107,8 @@
       },
       {
         "command": "agentTasks.sessions.openSession",
-        "title": "Open Session",
+        "title": "Resume Session",
+        "icon": "$(play)",
         "category": "Agent Tasks"
       },
       {
@@ -198,6 +199,16 @@
           "command": "agentTasks.openWalkthrough",
           "when": "view == agentTasksExplorer && viewItem == agentBranchCompleted",
           "group": "inline@1"
+        },
+        {
+          "command": "agentTasks.sessions.openSession",
+          "when": "view == agentSessionsExplorer && viewItem =~ /^claudeSession/",
+          "group": "inline@1"
+        },
+        {
+          "command": "agentTasks.sessions.openSession",
+          "when": "view == agentSessionsExplorer && viewItem =~ /^claudeSession/",
+          "group": "navigation@1"
         }
       ]
     },
@@ -207,6 +218,11 @@
         "key": "ctrl+shift+a ctrl+shift+t",
         "mac": "cmd+shift+a cmd+shift+t",
         "when": "!editorFocus"
+      },
+      {
+        "command": "agentTasks.sessions.openSession",
+        "key": "enter",
+        "when": "focusedView == 'agentSessionsExplorer' && viewItem =~ /^claudeSession/"
       }
     ],
     "configuration": {

--- a/packages/vscode-agent-tasks/src/extension.ts
+++ b/packages/vscode-agent-tasks/src/extension.ts
@@ -11,7 +11,12 @@ import { ArtifactWatcher } from './watchers/artifact-watcher';
 import { SessionsProvider, SessionItem } from './providers/sessions-provider';
 import { SessionWatcher } from './watchers/session-watcher';
 import { initLogger, log, logError } from './lib/logger';
-import { parsePsOutput, findClaudeDescendant } from './lib/process-tree';
+import {
+  parsePsOutput,
+  findClaudeDescendant,
+  parseLsofCwdOutput,
+  collectClaudeDescendants,
+} from './lib/process-tree';
 import type { SessionMetadata } from './parsers/session-jsonl-parser';
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -231,36 +236,118 @@ export function activate(context: vscode.ExtensionContext): void {
 
   /**
    * One-shot process-tree scan. Tries to find a terminal already running
-   * `claude --resume <sid>` among `vscode.window.terminals`.
+   * a `claude` process whose cwd matches the session's cwd, or (fast-path)
+   * one whose argv contains `--resume <sid>`.
+   *
+   * Strategy:
+   * 1. Fast-path: argv match (`claude --resume <sid>` in command). This covers
+   *    sessions the extension itself spawned in a prior window and lost tracking.
+   * 2. Slow-path: cwd match via `lsof -a -p PIDS -d cwd -Fpn`. Covers bare
+   *    `claude` invocations where the UUID is assigned internally. A uniqueness
+   *    guard fires when multiple terminals have a cwd-matching claude descendant,
+   *    accepting spawn-a-duplicate as the safer fallback.
    *
    * Returns the matching terminal, or `undefined` on any failure or no-match.
    * All errors are caught and logged; callers always fall through to spawn.
    */
   const tryAdoptTerminal = async (
     sid: string,
+    sessionCwd: string | undefined,
     terminals: readonly vscode.Terminal[]
   ): Promise<vscode.Terminal | undefined> => {
+    if (terminals.length === 0) return undefined;
+
+    // ---- Snapshot ----
+    let psRaw: string;
     try {
-      const stdout = child_process.execSync('ps -A -o pid,ppid,command', { encoding: 'utf8' });
-      const snapshot = parsePsOutput(stdout);
-
-      for (const terminal of terminals) {
-        let shellPid: number | undefined;
-        try {
-          shellPid = await terminal.processId;
-        } catch {
-          continue;
-        }
-        if (shellPid === undefined) continue;
-
-        const match = findClaudeDescendant(shellPid, sid, snapshot);
-        if (match !== undefined) {
-          log(`tryAdoptTerminal: adopted terminal (shellPid=${shellPid}, claudePid=${match}, sid=${sid.slice(0, 8)})`);
-          return terminal;
-        }
-      }
+      psRaw = child_process.execSync('ps -A -o pid,ppid,command', {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        encoding: 'utf8',
+      });
     } catch (err) {
-      logError('tryAdoptTerminal: ps scan failed, falling through to spawn', err);
+      logError('tryAdoptTerminal: ps failed, falling through to spawn', err);
+      return undefined;
+    }
+    const snapshot = parsePsOutput(psRaw);
+
+    // ---- Resolve shell PIDs ----
+    const shellByTerm = new Map<vscode.Terminal, number>();
+    for (const t of terminals) {
+      let pid: number | undefined;
+      try {
+        pid = await t.processId;
+      } catch {
+        continue;
+      }
+      if (typeof pid === 'number') shellByTerm.set(t, pid);
+    }
+
+    // ---- Fast-path: argv match ----
+    for (const [t, shellPid] of shellByTerm) {
+      const claudePid = findClaudeDescendant(shellPid, sid, snapshot);
+      if (claudePid !== undefined) {
+        log(
+          `tryAdoptTerminal: argv-match adopted terminal (shellPid=${shellPid}, claudePid=${claudePid}, sid=${sid.slice(0, 8)})`
+        );
+        return t;
+      }
+    }
+
+    // ---- Slow-path: cwd match (only when session cwd is known) ----
+    if (!sessionCwd) return undefined;
+
+    // Collect all claude descendants per terminal.
+    const claudeByTerm = new Map<vscode.Terminal, number[]>();
+    const allClaudePids: number[] = [];
+    for (const [t, shellPid] of shellByTerm) {
+      const pids = collectClaudeDescendants(shellPid, snapshot);
+      if (pids.length > 0) {
+        claudeByTerm.set(t, pids);
+        allClaudePids.push(...pids);
+      }
+    }
+    if (allClaudePids.length === 0) return undefined;
+
+    // Single lsof call for the union of all claude PIDs.
+    let lsofRaw: string;
+    try {
+      lsofRaw = child_process.execSync(
+        `lsof -a -p ${allClaudePids.join(',')} -d cwd -Fpn`,
+        { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf8' }
+      );
+    } catch (e: unknown) {
+      // lsof exits non-zero when any listed PID has already exited, but still
+      // emits stdout for live PIDs. Capture stdout regardless of exit code.
+      const err = e as { stdout?: Buffer | string };
+      if (err.stdout) {
+        lsofRaw =
+          typeof err.stdout === 'string' ? err.stdout : err.stdout.toString('utf8');
+      } else {
+        log('tryAdoptTerminal: lsof produced no output, falling through to spawn');
+        return undefined;
+      }
+    }
+    const cwdByPid = parseLsofCwdOutput(lsofRaw);
+
+    // Find terminals whose claude descendants have cwd === sessionCwd.
+    const matches: vscode.Terminal[] = [];
+    for (const [t, pids] of claudeByTerm) {
+      if (pids.some((p) => cwdByPid.get(p) === sessionCwd)) {
+        matches.push(t);
+      }
+    }
+
+    if (matches.length === 1) {
+      log(
+        `tryAdoptTerminal: cwd-match adopted terminal (sessionCwd=${sessionCwd}, sid=${sid.slice(0, 8)})`
+      );
+      return matches[0];
+    }
+
+    if (matches.length > 1) {
+      log(
+        `tryAdoptTerminal: cwd-match ambiguous (${matches.length} terminals match), falling through to spawn`
+      );
     }
     return undefined;
   };
@@ -286,10 +373,10 @@ export function activate(context: vscode.ExtensionContext): void {
       }
       if (existing) sessionTerminals.delete(sid);
 
-      // Attempt to adopt an existing terminal that is already running
-      // `claude --resume <sid>` (e.g. one the user opened manually).
+      // Attempt to adopt an existing terminal that is already running claude
+      // (argv fast-path: `--resume <sid>`, or cwd slow-path: lsof match).
       // Runs only on click — never on refresh, watcher tick, or render.
-      const adopted = await tryAdoptTerminal(sid, vscode.window.terminals);
+      const adopted = await tryAdoptTerminal(sid, session.cwd, vscode.window.terminals);
       if (adopted) {
         sessionTerminals.set(sid, adopted);
         sessionsProvider.setTerminalOpen(sid, true);

--- a/packages/vscode-agent-tasks/src/extension.ts
+++ b/packages/vscode-agent-tasks/src/extension.ts
@@ -5,11 +5,13 @@
 
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as child_process from 'child_process';
 import { AgentTasksProvider } from './providers/agent-tasks-provider';
 import { ArtifactWatcher } from './watchers/artifact-watcher';
 import { SessionsProvider, SessionItem } from './providers/sessions-provider';
 import { SessionWatcher } from './watchers/session-watcher';
 import { initLogger, log, logError } from './lib/logger';
+import { parsePsOutput, findClaudeDescendant } from './lib/process-tree';
 import type { SessionMetadata } from './parsers/session-jsonl-parser';
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -223,6 +225,46 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  // ---------------------------------------------------------------------------
+  // Terminal adoption helper
+  // ---------------------------------------------------------------------------
+
+  /**
+   * One-shot process-tree scan. Tries to find a terminal already running
+   * `claude --resume <sid>` among `vscode.window.terminals`.
+   *
+   * Returns the matching terminal, or `undefined` on any failure or no-match.
+   * All errors are caught and logged; callers always fall through to spawn.
+   */
+  const tryAdoptTerminal = async (
+    sid: string,
+    terminals: readonly vscode.Terminal[]
+  ): Promise<vscode.Terminal | undefined> => {
+    try {
+      const stdout = child_process.execSync('ps -A -o pid,ppid,command', { encoding: 'utf8' });
+      const snapshot = parsePsOutput(stdout);
+
+      for (const terminal of terminals) {
+        let shellPid: number | undefined;
+        try {
+          shellPid = await terminal.processId;
+        } catch {
+          continue;
+        }
+        if (shellPid === undefined) continue;
+
+        const match = findClaudeDescendant(shellPid, sid, snapshot);
+        if (match !== undefined) {
+          log(`tryAdoptTerminal: adopted terminal (shellPid=${shellPid}, claudePid=${match}, sid=${sid.slice(0, 8)})`);
+          return terminal;
+        }
+      }
+    } catch (err) {
+      logError('tryAdoptTerminal: ps scan failed, falling through to spawn', err);
+    }
+    return undefined;
+  };
+
   // Shared open-session logic used by both the tree-click command and the
   // find QuickPick. Reads the `openWith` setting once, then either resumes
   // or opens the JSONL.
@@ -243,6 +285,17 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
       if (existing) sessionTerminals.delete(sid);
+
+      // Attempt to adopt an existing terminal that is already running
+      // `claude --resume <sid>` (e.g. one the user opened manually).
+      // Runs only on click — never on refresh, watcher tick, or render.
+      const adopted = await tryAdoptTerminal(sid, vscode.window.terminals);
+      if (adopted) {
+        sessionTerminals.set(sid, adopted);
+        sessionsProvider.setTerminalOpen(sid, true);
+        adopted.show(false);
+        return;
+      }
 
       const branch = session.gitBranch ?? '?';
       const shortId = sid.slice(0, 8);
@@ -325,6 +378,23 @@ export function activate(context: vscode.ExtensionContext): void {
     await openSession(picked.session);
   });
 
+  // Feature 2: + button in panel title bar — start a new Claude session.
+  const newSessionCmd = vscode.commands.registerCommand(
+    'agentTasks.sessions.newSession',
+    () => {
+      log('Command: sessions.newSession');
+      const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      log(`Starting new Claude session (cwd=${cwd ?? '?'})`);
+      const terminal = vscode.window.createTerminal({
+        name: 'Claude · new session',
+        cwd,
+        iconPath: new vscode.ThemeIcon('comment-discussion'),
+      });
+      terminal.show();
+      terminal.sendText('claude');
+    }
+  );
+
   context.subscriptions.push(
     agentTasksView,
     artifactWatcher,
@@ -346,7 +416,8 @@ export function activate(context: vscode.ExtensionContext): void {
     configSub,
     openSessionCmd,
     findSessionCmd,
-    closeTerminalSub
+    closeTerminalSub,
+    newSessionCmd
   );
 }
 

--- a/packages/vscode-agent-tasks/src/extension.ts
+++ b/packages/vscode-agent-tasks/src/extension.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode';
+import * as path from 'path';
 import * as fs from 'fs';
 import * as child_process from 'child_process';
 import { AgentTasksProvider } from './providers/agent-tasks-provider';
@@ -14,8 +15,8 @@ import { initLogger, log, logError } from './lib/logger';
 import {
   parsePsOutput,
   findClaudeDescendant,
-  parseLsofCwdOutput,
-  collectClaudeDescendants,
+  claimPendingAdoption,
+  type PendingAdoption,
 } from './lib/process-tree';
 import type { SessionMetadata } from './parsers/session-jsonl-parser';
 
@@ -219,7 +220,23 @@ export function activate(context: vscode.ExtensionContext): void {
   // possible — VS Code's extension API is window-scoped.
   const sessionTerminals = new Map<string, vscode.Terminal>();
 
+  // ---------------------------------------------------------------------------
+  // Pending-adoption queue — for the "+" new-session button
+  //
+  // When the user clicks "+" we know exactly which terminal was spawned. The
+  // next new session JSONL that appears in the same cwd is deterministically
+  // linked to that terminal via onDidDiscoverSession. This avoids the
+  // now-deleted cwd-match slow-path that incorrectly adopted the WRONG session
+  // when multiple bare-claude processes shared a cwd.
+  // ---------------------------------------------------------------------------
+
+  const PENDING_TTL_MS = 60_000; // 60 s — generous; claude can take a few seconds to write the first JSONL
+  let pendingAdoptions: Array<PendingAdoption<vscode.Terminal>> = [];
+
   const closeTerminalSub = vscode.window.onDidCloseTerminal((t) => {
+    // Clean up any pending adoption for this terminal.
+    pendingAdoptions = pendingAdoptions.filter((p) => p.terminal !== t);
+
     for (const [sid, term] of sessionTerminals) {
       if (term === t) {
         sessionTerminals.delete(sid);
@@ -230,29 +247,49 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  // Subscribe to new sessions discovered by the provider. Attempt to claim a
+  // pending adoption before falling through. This hook fires for every new
+  // session ID that wasn't present on the previous refresh cycle.
+  const discoverySub = sessionsProvider.onDidDiscoverSession((session) => {
+    if (!session.cwd) return;
+    const normalizedCwd = path.resolve(session.cwd);
+    const result = claimPendingAdoption(pendingAdoptions, normalizedCwd, Date.now(), PENDING_TTL_MS);
+    if (!result) return;
+
+    pendingAdoptions = result.remaining;
+    const { terminal } = result;
+    const waited = Date.now() - (pendingAdoptions.find(() => true)?.spawnedAt ?? Date.now());
+    log(
+      `Pending adoption claimed: session ${session.sessionId.slice(0, 8)} ↔ terminal "${terminal.name}" (waited ~${waited}ms)`
+    );
+    sessionTerminals.set(session.sessionId, terminal);
+    sessionsProvider.setTerminalOpen(session.sessionId, true);
+    // Focus the already-open terminal so the user sees their new session.
+    terminal.show(false);
+  });
+
   // ---------------------------------------------------------------------------
-  // Terminal adoption helper
+  // Terminal adoption helper (argv fast-path only)
   // ---------------------------------------------------------------------------
 
   /**
-   * One-shot process-tree scan. Tries to find a terminal already running
-   * a `claude` process whose cwd matches the session's cwd, or (fast-path)
-   * one whose argv contains `--resume <sid>`.
+   * One-shot process-tree scan using the argv fast-path only.
    *
-   * Strategy:
-   * 1. Fast-path: argv match (`claude --resume <sid>` in command). This covers
-   *    sessions the extension itself spawned in a prior window and lost tracking.
-   * 2. Slow-path: cwd match via `lsof -a -p PIDS -d cwd -Fpn`. Covers bare
-   *    `claude` invocations where the UUID is assigned internally. A uniqueness
-   *    guard fires when multiple terminals have a cwd-matching claude descendant,
-   *    accepting spawn-a-duplicate as the safer fallback.
+   * Attempts to find a terminal already running `claude --resume <sid>` in
+   * its process tree. This covers sessions that the extension spawned in a
+   * prior window and lost tracking after a window reload.
    *
-   * Returns the matching terminal, or `undefined` on any failure or no-match.
+   * The cwd-match slow-path has been removed: it produced false-positive
+   * matches when multiple bare-claude processes shared the same cwd (e.g.
+   * multiple sessions in the same worktree), causing the wrong session to be
+   * adopted. The pending-adoption queue (above) handles the "+" button case
+   * deterministically.
+   *
+   * Returns the matching terminal, or `undefined` on failure or no-match.
    * All errors are caught and logged; callers always fall through to spawn.
    */
   const tryAdoptTerminal = async (
     sid: string,
-    sessionCwd: string | undefined,
     terminals: readonly vscode.Terminal[]
   ): Promise<vscode.Terminal | undefined> => {
     if (terminals.length === 0) return undefined;
@@ -293,62 +330,6 @@ export function activate(context: vscode.ExtensionContext): void {
       }
     }
 
-    // ---- Slow-path: cwd match (only when session cwd is known) ----
-    if (!sessionCwd) return undefined;
-
-    // Collect all claude descendants per terminal.
-    const claudeByTerm = new Map<vscode.Terminal, number[]>();
-    const allClaudePids: number[] = [];
-    for (const [t, shellPid] of shellByTerm) {
-      const pids = collectClaudeDescendants(shellPid, snapshot);
-      if (pids.length > 0) {
-        claudeByTerm.set(t, pids);
-        allClaudePids.push(...pids);
-      }
-    }
-    if (allClaudePids.length === 0) return undefined;
-
-    // Single lsof call for the union of all claude PIDs.
-    let lsofRaw: string;
-    try {
-      lsofRaw = child_process.execSync(
-        `lsof -a -p ${allClaudePids.join(',')} -d cwd -Fpn`,
-        { stdio: ['ignore', 'pipe', 'ignore'], encoding: 'utf8' }
-      );
-    } catch (e: unknown) {
-      // lsof exits non-zero when any listed PID has already exited, but still
-      // emits stdout for live PIDs. Capture stdout regardless of exit code.
-      const err = e as { stdout?: Buffer | string };
-      if (err.stdout) {
-        lsofRaw =
-          typeof err.stdout === 'string' ? err.stdout : err.stdout.toString('utf8');
-      } else {
-        log('tryAdoptTerminal: lsof produced no output, falling through to spawn');
-        return undefined;
-      }
-    }
-    const cwdByPid = parseLsofCwdOutput(lsofRaw);
-
-    // Find terminals whose claude descendants have cwd === sessionCwd.
-    const matches: vscode.Terminal[] = [];
-    for (const [t, pids] of claudeByTerm) {
-      if (pids.some((p) => cwdByPid.get(p) === sessionCwd)) {
-        matches.push(t);
-      }
-    }
-
-    if (matches.length === 1) {
-      log(
-        `tryAdoptTerminal: cwd-match adopted terminal (sessionCwd=${sessionCwd}, sid=${sid.slice(0, 8)})`
-      );
-      return matches[0];
-    }
-
-    if (matches.length > 1) {
-      log(
-        `tryAdoptTerminal: cwd-match ambiguous (${matches.length} terminals match), falling through to spawn`
-      );
-    }
     return undefined;
   };
 
@@ -373,10 +354,16 @@ export function activate(context: vscode.ExtensionContext): void {
       }
       if (existing) sessionTerminals.delete(sid);
 
-      // Attempt to adopt an existing terminal that is already running claude
-      // (argv fast-path: `--resume <sid>`, or cwd slow-path: lsof match).
-      // Runs only on click — never on refresh, watcher tick, or render.
-      const adopted = await tryAdoptTerminal(sid, session.cwd, vscode.window.terminals);
+      // Attempt to adopt an existing terminal that is already running
+      // `claude --resume <sid>` (argv fast-path only). Covers sessions
+      // the extension itself spawned in a prior window and lost tracking.
+      //
+      // NOTE: The cwd-match slow-path has been deliberately removed.
+      // Bare `claude` terminals (typed by the user, or started outside the
+      // "+" flow) are NOT adoptable — clicking them spawns a fresh
+      // `--resume` terminal. This is intentional: cwd is not unique across
+      // sessions in the same worktree and produces false-positive adoption.
+      const adopted = await tryAdoptTerminal(sid, vscode.window.terminals);
       if (adopted) {
         sessionTerminals.set(sid, adopted);
         sessionsProvider.setTerminalOpen(sid, true);
@@ -466,17 +453,27 @@ export function activate(context: vscode.ExtensionContext): void {
   });
 
   // Feature 2: + button in panel title bar — start a new Claude session.
+  // Before running `claude`, we push a PendingAdoption entry so that the
+  // next new JSONL to appear in this cwd is deterministically linked to the
+  // spawned terminal (claimed via onDidDiscoverSession).
   const newSessionCmd = vscode.commands.registerCommand(
     'agentTasks.sessions.newSession',
     () => {
       log('Command: sessions.newSession');
-      const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const rawCwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const cwd = rawCwd ? path.resolve(rawCwd) : undefined;
       log(`Starting new Claude session (cwd=${cwd ?? '?'})`);
       const terminal = vscode.window.createTerminal({
         name: 'Claude · new session',
         cwd,
         iconPath: new vscode.ThemeIcon('comment-discussion'),
       });
+
+      if (cwd) {
+        pendingAdoptions.push({ terminal, cwd, spawnedAt: Date.now() });
+        log(`Pending adoption queued for cwd=${cwd} (queue length: ${pendingAdoptions.length})`);
+      }
+
       terminal.show();
       terminal.sendText('claude');
     }
@@ -504,6 +501,7 @@ export function activate(context: vscode.ExtensionContext): void {
     openSessionCmd,
     findSessionCmd,
     closeTerminalSub,
+    discoverySub,
     newSessionCmd
   );
 }

--- a/packages/vscode-agent-tasks/src/lib/process-tree.test.ts
+++ b/packages/vscode-agent-tasks/src/lib/process-tree.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { parsePsOutput, findClaudeDescendant, type PsEntry } from './process-tree';
+import {
+  parsePsOutput,
+  findClaudeDescendant,
+  parseLsofCwdOutput,
+  collectClaudeDescendants,
+  type PsEntry,
+} from './process-tree';
 
 // ---------------------------------------------------------------------------
 // parsePsOutput — 6 test cases
@@ -130,5 +136,122 @@ describe('findClaudeDescendant', () => {
       { pid: 200, ppid: 100, command: 'claude' },
     ];
     expect(findClaudeDescendant(shellPid, sessionId, snapshot)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLsofCwdOutput — 6 test cases
+// ---------------------------------------------------------------------------
+
+describe('parseLsofCwdOutput', () => {
+  it('parses a single PID with one cwd line', () => {
+    const raw = 'p1234\nfcwd\nn/Users/alice/projects/my-app';
+    const result = parseLsofCwdOutput(raw);
+    expect(result.size).toBe(1);
+    expect(result.get(1234)).toBe('/Users/alice/projects/my-app');
+  });
+
+  it('parses multiple PIDs each with their own cwd', () => {
+    const raw = [
+      'p100',
+      'fcwd',
+      'n/home/alice/app',
+      'p200',
+      'fcwd',
+      'n/home/bob/other',
+    ].join('\n');
+    const result = parseLsofCwdOutput(raw);
+    expect(result.size).toBe(2);
+    expect(result.get(100)).toBe('/home/alice/app');
+    expect(result.get(200)).toBe('/home/bob/other');
+  });
+
+  it('omits a PID that has no n line', () => {
+    // PID 300 has no n line — should not appear in the map.
+    const raw = 'p300\nfcwd\np400\nfcwd\nn/tmp/work';
+    const result = parseLsofCwdOutput(raw);
+    expect(result.has(300)).toBe(false);
+    expect(result.get(400)).toBe('/tmp/work');
+  });
+
+  it('ignores f, t, and other prefix lines', () => {
+    const raw = 'p999\nf42\ntREG\nn/var/project\ntDEV\nfother';
+    const result = parseLsofCwdOutput(raw);
+    expect(result.get(999)).toBe('/var/project');
+  });
+
+  it('returns an empty map for empty input', () => {
+    expect(parseLsofCwdOutput('').size).toBe(0);
+    expect(parseLsofCwdOutput('\n\n').size).toBe(0);
+  });
+
+  it('skips malformed p lines with non-numeric digits', () => {
+    const raw = 'pabc\nn/should/not/appear\np500\nn/valid/path';
+    const result = parseLsofCwdOutput(raw);
+    expect(result.has(NaN)).toBe(false);
+    expect(result.get(500)).toBe('/valid/path');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectClaudeDescendants — 6 test cases
+// ---------------------------------------------------------------------------
+
+describe('collectClaudeDescendants', () => {
+  it('returns the PID of a direct child claude process', () => {
+    const snapshot: PsEntry[] = [
+      { pid: 100, ppid: 1, command: '-zsh' },
+      { pid: 200, ppid: 100, command: 'claude' },
+    ];
+    expect(collectClaudeDescendants(100, snapshot)).toEqual([200]);
+  });
+
+  it('returns only claude PIDs among mixed descendants', () => {
+    const snapshot: PsEntry[] = [
+      { pid: 100, ppid: 1, command: '-zsh' },
+      { pid: 201, ppid: 100, command: 'node server.js' },
+      { pid: 202, ppid: 100, command: 'claude' },
+      { pid: 203, ppid: 100, command: 'bash' },
+    ];
+    expect(collectClaudeDescendants(100, snapshot)).toEqual([202]);
+  });
+
+  it('finds a deep descendant (3 levels deep)', () => {
+    const snapshot: PsEntry[] = [
+      { pid: 100, ppid: 1, command: '-zsh' },
+      { pid: 200, ppid: 100, command: 'bash' },
+      { pid: 300, ppid: 200, command: 'node' },
+      { pid: 400, ppid: 300, command: 'claude -c' },
+    ];
+    expect(collectClaudeDescendants(100, snapshot)).toEqual([400]);
+  });
+
+  it('returns empty array when no claude descendants exist', () => {
+    const snapshot: PsEntry[] = [
+      { pid: 100, ppid: 1, command: '-zsh' },
+      { pid: 200, ppid: 100, command: 'node' },
+    ];
+    expect(collectClaudeDescendants(100, snapshot)).toEqual([]);
+  });
+
+  it('returns empty array when shell PID is not in snapshot', () => {
+    const snapshot: PsEntry[] = [
+      { pid: 999, ppid: 1, command: '-zsh' },
+      { pid: 200, ppid: 999, command: 'claude' },
+    ];
+    expect(collectClaudeDescendants(100, snapshot)).toEqual([]);
+  });
+
+  it('terminates and returns results when snapshot contains a cycle', () => {
+    // pid 300 → ppid 200 → ppid 300 (cycle). Should not infinite-loop.
+    const snapshot: PsEntry[] = [
+      { pid: 100, ppid: 1, command: '-zsh' },
+      { pid: 200, ppid: 100, command: 'bash' },
+      { pid: 300, ppid: 200, command: 'claude' },
+      { pid: 200, ppid: 300, command: 'bash-cycle' }, // creates artificial cycle
+    ];
+    const result = collectClaudeDescendants(100, snapshot);
+    expect(result).toContain(300);
+    // Must terminate — if this test completes, no infinite loop.
   });
 });

--- a/packages/vscode-agent-tasks/src/lib/process-tree.test.ts
+++ b/packages/vscode-agent-tasks/src/lib/process-tree.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { parsePsOutput, findClaudeDescendant, type PsEntry } from './process-tree';
+
+// ---------------------------------------------------------------------------
+// parsePsOutput — 6 test cases
+// ---------------------------------------------------------------------------
+
+describe('parsePsOutput', () => {
+  it('parses typical multi-line output (header + 3 data rows)', () => {
+    const raw = `  PID  PPID COMMAND
+    1     0 /sbin/launchd
+  501     1 /usr/bin/login
+  502   501 -zsh`;
+
+    const entries = parsePsOutput(raw);
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toEqual({ pid: 1, ppid: 0, command: '/sbin/launchd' });
+    expect(entries[1]).toEqual({ pid: 501, ppid: 1, command: '/usr/bin/login' });
+    expect(entries[2]).toEqual({ pid: 502, ppid: 501, command: '-zsh' });
+  });
+
+  it('returns [] for only a header line', () => {
+    const raw = '  PID  PPID COMMAND';
+    expect(parsePsOutput(raw)).toEqual([]);
+  });
+
+  it('handles leading/trailing whitespace and macOS right-aligned PID/PPID', () => {
+    const raw = `  PID  PPID COMMAND
+ 1234   567 node server.js`;
+
+    const entries = parsePsOutput(raw);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({ pid: 1234, ppid: 567, command: 'node server.js' });
+  });
+
+  it('skips malformed lines (non-numeric PID)', () => {
+    const raw = `  PID  PPID COMMAND
+  abc   123 some-process
+  999   123 real-process`;
+
+    const entries = parsePsOutput(raw);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].pid).toBe(999);
+  });
+
+  it('returns [] for an empty string', () => {
+    expect(parsePsOutput('')).toEqual([]);
+  });
+
+  it('preserves spaces in command paths', () => {
+    const raw = `  PID  PPID COMMAND
+  100    99 /Applications/Visual Studio Code.app/Contents/MacOS/Electron --type=renderer`;
+
+    const entries = parsePsOutput(raw);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].command).toBe(
+      '/Applications/Visual Studio Code.app/Contents/MacOS/Electron --type=renderer'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findClaudeDescendant — 8 test cases
+// ---------------------------------------------------------------------------
+
+describe('findClaudeDescendant', () => {
+  const shellPid = 100;
+  const sessionId = 'abc12345-0000-0000-0000-000000000000';
+
+  it('returns the PID of a direct child running claude --resume <sessionId>', () => {
+    const snapshot: PsEntry[] = [
+      { pid: 100, ppid: 1, command: '-zsh' },
+      { pid: 200, ppid: 100, command: `claude --resume ${sessionId}` },
+    ];
+    expect(findClaudeDescendant(shellPid, sessionId, snapshot)).toBe(200);
+  });
+
+  it('finds a deep descendant (shell → bash → node → claude)', () => {
+    const snapshot: PsEntry[] = [
+      { pid: 100, ppid: 1, command: '-zsh' },
+      { pid: 200, ppid: 100, command: 'bash' },
+      { pid: 300, ppid: 200, command: 'node' },
+      { pid: 400, ppid: 300, command: `claude --resume ${sessionId}` },
+    ];
+    expect(findClaudeDescendant(shellPid, sessionId, snapshot)).toBe(400);
+  });
+
+  it('returns undefined when the sessionId does not match', () => {
+    const snapshot: PsEntry[] = [
+      { pid: 100, ppid: 1, command: '-zsh' },
+      { pid: 200, ppid: 100, command: 'claude --resume xyz99999-0000-0000-0000-000000000000' },
+    ];
+    expect(findClaudeDescendant(shellPid, sessionId, snapshot)).toBeUndefined();
+  });
+
+  it('returns undefined when there is no claude process in the tree', () => {
+    const snapshot: PsEntry[] = [
+      { pid: 100, ppid: 1, command: '-zsh' },
+      { pid: 200, ppid: 100, command: 'bash' },
+      { pid: 300, ppid: 200, command: 'node server.js' },
+    ];
+    expect(findClaudeDescendant(shellPid, sessionId, snapshot)).toBeUndefined();
+  });
+
+  it('returns the correct PID when multiple claude processes exist with different IDs', () => {
+    const otherId = 'zzz99999-0000-0000-0000-000000000000';
+    const snapshot: PsEntry[] = [
+      { pid: 100, ppid: 1, command: '-zsh' },
+      { pid: 201, ppid: 100, command: `claude --resume ${otherId}` },
+      { pid: 202, ppid: 100, command: `claude --resume ${sessionId}` },
+    ];
+    expect(findClaudeDescendant(shellPid, sessionId, snapshot)).toBe(202);
+  });
+
+  it('returns undefined when shellPid is absent from snapshot', () => {
+    const snapshot: PsEntry[] = [
+      { pid: 999, ppid: 1, command: '-zsh' }, // different pid
+      { pid: 200, ppid: 999, command: `claude --resume ${sessionId}` },
+    ];
+    expect(findClaudeDescendant(shellPid, sessionId, snapshot)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty snapshot', () => {
+    expect(findClaudeDescendant(shellPid, sessionId, [])).toBeUndefined();
+  });
+
+  it('does NOT match a bare `claude` invocation (no --resume <id>)', () => {
+    const snapshot: PsEntry[] = [
+      { pid: 100, ppid: 1, command: '-zsh' },
+      { pid: 200, ppid: 100, command: 'claude' },
+    ];
+    expect(findClaudeDescendant(shellPid, sessionId, snapshot)).toBeUndefined();
+  });
+});

--- a/packages/vscode-agent-tasks/src/lib/process-tree.test.ts
+++ b/packages/vscode-agent-tasks/src/lib/process-tree.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   parsePsOutput,
   findClaudeDescendant,
-  parseLsofCwdOutput,
-  collectClaudeDescendants,
+  claimPendingAdoption,
   type PsEntry,
+  type PendingAdoption,
 } from './process-tree';
 
 // ---------------------------------------------------------------------------
@@ -140,118 +140,69 @@ describe('findClaudeDescendant', () => {
 });
 
 // ---------------------------------------------------------------------------
-// parseLsofCwdOutput — 6 test cases
+// claimPendingAdoption — 6 test cases
 // ---------------------------------------------------------------------------
 
-describe('parseLsofCwdOutput', () => {
-  it('parses a single PID with one cwd line', () => {
-    const raw = 'p1234\nfcwd\nn/Users/alice/projects/my-app';
-    const result = parseLsofCwdOutput(raw);
-    expect(result.size).toBe(1);
-    expect(result.get(1234)).toBe('/Users/alice/projects/my-app');
+describe('claimPendingAdoption', () => {
+  const TTL = 60_000;
+  const NOW = 1_000_000;
+  // A mock terminal type (opaque object) — real terminal would be vscode.Terminal
+  type MockTerminal = { id: string };
+
+  function makePending(id: string, cwd: string, spawnedAt = NOW - 1000): PendingAdoption<MockTerminal> {
+    return { terminal: { id }, cwd, spawnedAt };
+  }
+
+  it('claims the first entry whose cwd matches (exact string compare)', () => {
+    const pending = [makePending('t1', '/Users/alice/project')];
+    const result = claimPendingAdoption(pending, '/Users/alice/project', NOW, TTL);
+    if (result === null) throw new Error('expected a claim result');
+    expect(result.terminal).toEqual({ id: 't1' });
+    expect(result.remaining).toHaveLength(0);
   });
 
-  it('parses multiple PIDs each with their own cwd', () => {
-    const raw = [
-      'p100',
-      'fcwd',
-      'n/home/alice/app',
-      'p200',
-      'fcwd',
-      'n/home/bob/other',
-    ].join('\n');
-    const result = parseLsofCwdOutput(raw);
-    expect(result.size).toBe(2);
-    expect(result.get(100)).toBe('/home/alice/app');
-    expect(result.get(200)).toBe('/home/bob/other');
+  it('returns null when no cwd matches', () => {
+    const pending = [makePending('t1', '/Users/alice/project')];
+    const result = claimPendingAdoption(pending, '/Users/bob/other', NOW, TTL);
+    expect(result).toBeNull();
   });
 
-  it('omits a PID that has no n line', () => {
-    // PID 300 has no n line — should not appear in the map.
-    const raw = 'p300\nfcwd\np400\nfcwd\nn/tmp/work';
-    const result = parseLsofCwdOutput(raw);
-    expect(result.has(300)).toBe(false);
-    expect(result.get(400)).toBe('/tmp/work');
+  it('evicts stale entries (past TTL) and returns null when no fresh match', () => {
+    // spawnedAt = NOW - TTL - 1 → stale
+    const stale = makePending('t1', '/Users/alice/project', NOW - TTL - 1);
+    const result = claimPendingAdoption([stale], '/Users/alice/project', NOW, TTL);
+    expect(result).toBeNull();
   });
 
-  it('ignores f, t, and other prefix lines', () => {
-    const raw = 'p999\nf42\ntREG\nn/var/project\ntDEV\nfother';
-    const result = parseLsofCwdOutput(raw);
-    expect(result.get(999)).toBe('/var/project');
+  it('evicts stale entries and still claims a fresh match', () => {
+    const stale = makePending('old', '/Users/alice/project', NOW - TTL - 1);
+    const fresh = makePending('t2', '/Users/alice/project');
+    const result = claimPendingAdoption([stale, fresh], '/Users/alice/project', NOW, TTL);
+    if (result === null) throw new Error('expected a claim result');
+    expect(result.terminal).toEqual({ id: 't2' });
+    expect(result.remaining).toHaveLength(0);
   });
 
-  it('returns an empty map for empty input', () => {
-    expect(parseLsofCwdOutput('').size).toBe(0);
-    expect(parseLsofCwdOutput('\n\n').size).toBe(0);
+  it('returns FIFO order — claims the earliest matching entry when multiple match', () => {
+    const first = makePending('t1', '/Users/alice/project', NOW - 5000);
+    const second = makePending('t2', '/Users/alice/project', NOW - 1000);
+    const result = claimPendingAdoption([first, second], '/Users/alice/project', NOW, TTL);
+    if (result === null) throw new Error('expected a claim result');
+    expect(result.terminal).toEqual({ id: 't1' });
+    // second remains
+    expect(result.remaining).toHaveLength(1);
+    expect(result.remaining[0].terminal).toEqual({ id: 't2' });
   });
 
-  it('skips malformed p lines with non-numeric digits', () => {
-    const raw = 'pabc\nn/should/not/appear\np500\nn/valid/path';
-    const result = parseLsofCwdOutput(raw);
-    expect(result.has(NaN)).toBe(false);
-    expect(result.get(500)).toBe('/valid/path');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// collectClaudeDescendants — 6 test cases
-// ---------------------------------------------------------------------------
-
-describe('collectClaudeDescendants', () => {
-  it('returns the PID of a direct child claude process', () => {
-    const snapshot: PsEntry[] = [
-      { pid: 100, ppid: 1, command: '-zsh' },
-      { pid: 200, ppid: 100, command: 'claude' },
-    ];
-    expect(collectClaudeDescendants(100, snapshot)).toEqual([200]);
-  });
-
-  it('returns only claude PIDs among mixed descendants', () => {
-    const snapshot: PsEntry[] = [
-      { pid: 100, ppid: 1, command: '-zsh' },
-      { pid: 201, ppid: 100, command: 'node server.js' },
-      { pid: 202, ppid: 100, command: 'claude' },
-      { pid: 203, ppid: 100, command: 'bash' },
-    ];
-    expect(collectClaudeDescendants(100, snapshot)).toEqual([202]);
-  });
-
-  it('finds a deep descendant (3 levels deep)', () => {
-    const snapshot: PsEntry[] = [
-      { pid: 100, ppid: 1, command: '-zsh' },
-      { pid: 200, ppid: 100, command: 'bash' },
-      { pid: 300, ppid: 200, command: 'node' },
-      { pid: 400, ppid: 300, command: 'claude -c' },
-    ];
-    expect(collectClaudeDescendants(100, snapshot)).toEqual([400]);
-  });
-
-  it('returns empty array when no claude descendants exist', () => {
-    const snapshot: PsEntry[] = [
-      { pid: 100, ppid: 1, command: '-zsh' },
-      { pid: 200, ppid: 100, command: 'node' },
-    ];
-    expect(collectClaudeDescendants(100, snapshot)).toEqual([]);
-  });
-
-  it('returns empty array when shell PID is not in snapshot', () => {
-    const snapshot: PsEntry[] = [
-      { pid: 999, ppid: 1, command: '-zsh' },
-      { pid: 200, ppid: 999, command: 'claude' },
-    ];
-    expect(collectClaudeDescendants(100, snapshot)).toEqual([]);
-  });
-
-  it('terminates and returns results when snapshot contains a cycle', () => {
-    // pid 300 → ppid 200 → ppid 300 (cycle). Should not infinite-loop.
-    const snapshot: PsEntry[] = [
-      { pid: 100, ppid: 1, command: '-zsh' },
-      { pid: 200, ppid: 100, command: 'bash' },
-      { pid: 300, ppid: 200, command: 'claude' },
-      { pid: 200, ppid: 300, command: 'bash-cycle' }, // creates artificial cycle
-    ];
-    const result = collectClaudeDescendants(100, snapshot);
-    expect(result).toContain(300);
-    // Must terminate — if this test completes, no infinite loop.
+  it('does not claim when cwd is a prefix but not an exact match', () => {
+    const pending = [makePending('t1', '/Users/alice/project')];
+    // Longer path — not an exact match
+    const result = claimPendingAdoption(
+      pending,
+      '/Users/alice/project/subdir',
+      NOW,
+      TTL
+    );
+    expect(result).toBeNull();
   });
 });

--- a/packages/vscode-agent-tasks/src/lib/process-tree.ts
+++ b/packages/vscode-agent-tasks/src/lib/process-tree.ts
@@ -65,7 +65,7 @@ export function parsePsOutput(raw: string): PsEntry[] {
  * but avoids infinite loops on malformed snapshots).
  *
  * A bare `claude` invocation (no `--resume <id>`) does NOT match — such
- * sessions are not adoptable in v1.
+ * sessions are not adoptable via the argv fast-path.
  */
 export function findClaudeDescendant(
   shellPid: number,
@@ -107,4 +107,87 @@ export function findClaudeDescendant(
   }
 
   return undefined;
+}
+
+/**
+ * Parse the stdout of `lsof -a -p <pids> -d cwd -Fpn`.
+ *
+ * The `-F` flag produces field output. Each block starts with a `p` line
+ * (PID) followed by one or more field lines. For `-d cwd` there is exactly
+ * one `n` line per PID that contains the cwd path.
+ *
+ * Lines with other prefixes (`f`, `t`, etc.) are silently ignored. A PID
+ * with no `n` line is omitted from the result. Malformed `p` lines (non-
+ * numeric digit sequence) are also skipped.
+ *
+ * Returns a Map of PID → cwd string.
+ */
+export function parseLsofCwdOutput(raw: string): Map<number, string> {
+  const result = new Map<number, string>();
+  let currentPid: number | undefined;
+
+  for (const line of raw.split('\n')) {
+    if (!line) continue;
+    const prefix = line[0];
+    const value = line.slice(1);
+
+    if (prefix === 'p') {
+      const pid = parseInt(value, 10);
+      currentPid = isNaN(pid) ? undefined : pid;
+    } else if (prefix === 'n' && currentPid !== undefined) {
+      result.set(currentPid, value);
+      // Reset so a second `n` line (unexpected) doesn't overwrite silently.
+      currentPid = undefined;
+    }
+    // All other prefixes (f, t, etc.) are ignored.
+  }
+
+  return result;
+}
+
+/**
+ * BFS from `shellPid`, returning the PIDs of ALL descendants whose command
+ * contains `claude` (case-sensitive substring match). Empty array if none.
+ *
+ * Used by the cwd-match slow-path in `tryAdoptTerminal`. Unlike
+ * `findClaudeDescendant`, this function does NOT filter by session ID — the
+ * caller correlates against the lsof cwd map.
+ *
+ * A visited Set guards against cycles in malformed snapshots.
+ * Returns an empty array when `shellPid` is not in `snapshot`.
+ */
+export function collectClaudeDescendants(shellPid: number, snapshot: PsEntry[]): number[] {
+  const shellExists = snapshot.some((e) => e.pid === shellPid);
+  if (!shellExists) return [];
+
+  // Build children map.
+  const children = new Map<number, PsEntry[]>();
+  for (const entry of snapshot) {
+    const list = children.get(entry.ppid);
+    if (list) {
+      list.push(entry);
+    } else {
+      children.set(entry.ppid, [entry]);
+    }
+  }
+
+  const visited = new Set<number>();
+  const queue: number[] = [shellPid];
+  const claudePids: number[] = [];
+
+  while (queue.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const current = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    for (const child of children.get(current) ?? []) {
+      if (child.command.includes('claude')) {
+        claudePids.push(child.pid);
+      }
+      queue.push(child.pid);
+    }
+  }
+
+  return claudePids;
 }

--- a/packages/vscode-agent-tasks/src/lib/process-tree.ts
+++ b/packages/vscode-agent-tasks/src/lib/process-tree.ts
@@ -109,85 +109,55 @@ export function findClaudeDescendant(
   return undefined;
 }
 
+// ---------------------------------------------------------------------------
+// Pending-adoption queue helpers (pure — no VS Code dependency)
+// ---------------------------------------------------------------------------
+
 /**
- * Parse the stdout of `lsof -a -p <pids> -d cwd -Fpn`.
- *
- * The `-F` flag produces field output. Each block starts with a `p` line
- * (PID) followed by one or more field lines. For `-d cwd` there is exactly
- * one `n` line per PID that contains the cwd path.
- *
- * Lines with other prefixes (`f`, `t`, etc.) are silently ignored. A PID
- * with no `n` line is omitted from the result. Malformed `p` lines (non-
- * numeric digit sequence) are also skipped.
- *
- * Returns a Map of PID → cwd string.
+ * A terminal that was spawned by the "+" new-session button and is waiting
+ * for the next new JSONL session that appears in the same cwd to be assigned
+ * to it. VS Code terminal objects are opaque values from the caller's
+ * perspective — this module treats them as `unknown` to stay VS Code–free.
  */
-export function parseLsofCwdOutput(raw: string): Map<number, string> {
-  const result = new Map<number, string>();
-  let currentPid: number | undefined;
+export interface PendingAdoption<T = unknown> {
+  /** The VS Code Terminal object (typed as `T` to avoid VS Code imports). */
+  terminal: T;
+  /** The cwd that was passed to `vscode.window.createTerminal({ cwd })`. */
+  cwd: string;
+  /** `Date.now()` at the time the terminal was spawned. */
+  spawnedAt: number;
+}
 
-  for (const line of raw.split('\n')) {
-    if (!line) continue;
-    const prefix = line[0];
-    const value = line.slice(1);
-
-    if (prefix === 'p') {
-      const pid = parseInt(value, 10);
-      currentPid = isNaN(pid) ? undefined : pid;
-    } else if (prefix === 'n' && currentPid !== undefined) {
-      result.set(currentPid, value);
-      // Reset so a second `n` line (unexpected) doesn't overwrite silently.
-      currentPid = undefined;
-    }
-    // All other prefixes (f, t, etc.) are ignored.
-  }
-
-  return result;
+export interface ClaimResult<T> {
+  /** The terminal to adopt for the new session. */
+  terminal: T;
+  /** The remaining queue after removing the claimed entry. */
+  remaining: Array<PendingAdoption<T>>;
 }
 
 /**
- * BFS from `shellPid`, returning the PIDs of ALL descendants whose command
- * contains `claude` (case-sensitive substring match). Empty array if none.
+ * Try to claim a pending adoption for a newly discovered session.
  *
- * Used by the cwd-match slow-path in `tryAdoptTerminal`. Unlike
- * `findClaudeDescendant`, this function does NOT filter by session ID — the
- * caller correlates against the lsof cwd map.
+ * Rules:
+ *   - Stale entries (`now - spawnedAt > ttlMs`) are evicted regardless.
+ *   - The first non-stale entry whose `cwd` exactly matches `session.cwd`
+ *     is claimed (FIFO order).
+ *   - Returns `null` when no match is found after eviction.
  *
- * A visited Set guards against cycles in malformed snapshots.
- * Returns an empty array when `shellPid` is not in `snapshot`.
+ * Both `session.cwd` and `pending.cwd` must be pre-normalized by the caller
+ * (e.g. via `path.resolve`) to prevent spurious mismatches from trailing
+ * slashes or symlink differences.
  */
-export function collectClaudeDescendants(shellPid: number, snapshot: PsEntry[]): number[] {
-  const shellExists = snapshot.some((e) => e.pid === shellPid);
-  if (!shellExists) return [];
-
-  // Build children map.
-  const children = new Map<number, PsEntry[]>();
-  for (const entry of snapshot) {
-    const list = children.get(entry.ppid);
-    if (list) {
-      list.push(entry);
-    } else {
-      children.set(entry.ppid, [entry]);
-    }
-  }
-
-  const visited = new Set<number>();
-  const queue: number[] = [shellPid];
-  const claudePids: number[] = [];
-
-  while (queue.length > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const current = queue.shift()!;
-    if (visited.has(current)) continue;
-    visited.add(current);
-
-    for (const child of children.get(current) ?? []) {
-      if (child.command.includes('claude')) {
-        claudePids.push(child.pid);
-      }
-      queue.push(child.pid);
-    }
-  }
-
-  return claudePids;
+export function claimPendingAdoption<T>(
+  pending: Array<PendingAdoption<T>>,
+  sessionCwd: string,
+  now: number,
+  ttlMs: number
+): ClaimResult<T> | null {
+  const live = pending.filter((p) => now - p.spawnedAt <= ttlMs);
+  const idx = live.findIndex((p) => p.cwd === sessionCwd);
+  if (idx === -1) return null;
+  const terminal = live[idx].terminal;
+  const remaining = [...live.slice(0, idx), ...live.slice(idx + 1)];
+  return { terminal, remaining };
 }

--- a/packages/vscode-agent-tasks/src/lib/process-tree.ts
+++ b/packages/vscode-agent-tasks/src/lib/process-tree.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure process-tree helpers for terminal adoption.
+ *
+ * No VS Code dependency. No I/O. Accepts pre-parsed `ps` output so every
+ * function is unit-testable with vitest and plain data fixtures.
+ */
+
+/** One row from `ps -A -o pid,ppid,command`. */
+export interface PsEntry {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+/**
+ * Parse the stdout of `ps -A -o pid,ppid,command`.
+ *
+ * - Skips the header line.
+ * - Skips malformed lines (non-numeric pid/ppid, fewer than 3 tokens).
+ * - Handles macOS right-padded and Linux left-padded numeric columns.
+ * - The `command` field is everything after the second whitespace-delimited
+ *   token, so paths with spaces are preserved.
+ */
+export function parsePsOutput(raw: string): PsEntry[] {
+  const lines = raw.split('\n');
+  const entries: PsEntry[] = [];
+  let headerSkipped = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // The first non-empty line is always the header (PID PPID COMMAND).
+    if (!headerSkipped) {
+      headerSkipped = true;
+      continue;
+    }
+
+    // Split on whitespace — at most 3 parts so command preserves spaces.
+    const parts = trimmed.split(/\s+/, 3);
+    if (parts.length < 3) continue;
+
+    const pid = parseInt(parts[0], 10);
+    const ppid = parseInt(parts[1], 10);
+    if (isNaN(pid) || isNaN(ppid)) continue;
+
+    // Reconstruct the full command: everything after the first two tokens.
+    // We can't use `parts[2]` directly because split(..., 3) truncates.
+    // Find the start of the command field in the original trimmed string.
+    const afterPid = trimmed.slice(parts[0].length).trimStart();
+    const afterPpid = afterPid.slice(parts[1].length).trimStart();
+
+    entries.push({ pid, ppid, command: afterPpid });
+  }
+
+  return entries;
+}
+
+/**
+ * BFS from `shellPid` through `snapshot`'s children map, looking for a
+ * descendant whose command contains `claude` AND `--resume <sessionId>`.
+ *
+ * Returns the matching PID, or `undefined` if none is found.
+ * A visited Set guards against cycles (should not occur in real process trees,
+ * but avoids infinite loops on malformed snapshots).
+ *
+ * A bare `claude` invocation (no `--resume <id>`) does NOT match — such
+ * sessions are not adoptable in v1.
+ */
+export function findClaudeDescendant(
+  shellPid: number,
+  sessionId: string,
+  snapshot: PsEntry[]
+): number | undefined {
+  // Build a children map: ppid → [child entries]
+  const children = new Map<number, PsEntry[]>();
+  for (const entry of snapshot) {
+    const list = children.get(entry.ppid);
+    if (list) {
+      list.push(entry);
+    } else {
+      children.set(entry.ppid, [entry]);
+    }
+  }
+
+  // Verify shellPid exists in snapshot (skip if not found).
+  const shellExists = snapshot.some((e) => e.pid === shellPid);
+  if (!shellExists) return undefined;
+
+  const visited = new Set<number>();
+  const queue: number[] = [shellPid];
+
+  while (queue.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const current = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    const kids = children.get(current) ?? [];
+    for (const child of kids) {
+      // Match: command contains `claude` AND `--resume <sessionId>`.
+      if (child.command.includes('claude') && child.command.includes(`--resume ${sessionId}`)) {
+        return child.pid;
+      }
+      queue.push(child.pid);
+    }
+  }
+
+  return undefined;
+}

--- a/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
+++ b/packages/vscode-agent-tasks/src/providers/sessions-provider.ts
@@ -469,6 +469,17 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
   private _onDidChangeTreeData = new vscode.EventEmitter<SessionTreeItem | undefined | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
+  /**
+   * Fires once for each session ID that was NOT present on the previous
+   * refresh. Used by `extension.ts` to claim pending adoptions from the
+   * "+" new-session button without polling.
+   */
+  private readonly _onDidDiscoverSession = new vscode.EventEmitter<SessionMetadata>();
+  readonly onDidDiscoverSession: vscode.Event<SessionMetadata> = this._onDidDiscoverSession.event;
+
+  /** Session IDs seen in the last `buildRootItems` call. Used to diff new arrivals. */
+  private _knownSessionIds = new Set<string>();
+
   /** Cache of session dirs being watched — exposed for SessionWatcher rebuild. */
   private _sessionDirs: string[] = [];
 
@@ -638,6 +649,25 @@ export class SessionsProvider implements vscode.TreeDataProvider<SessionTreeItem
     // avoid showing the same row twice.
     const allSessions: SessionMetadata[] = [];
     for (const sessions of buckets.values()) allSessions.push(...sessions);
+
+    // Fire onDidDiscoverSession for any session ID not seen in the previous
+    // render. This gives extension.ts a precise hook to claim pending adoptions
+    // from the "+" button without polling. We defer into a microtask so the
+    // event fires after the tree view has already consumed `buildRootItems`.
+    const prevKnown = this._knownSessionIds;
+    const nextKnown = new Set(allSessions.map((s) => s.sessionId));
+    this._knownSessionIds = nextKnown;
+    if (prevKnown.size > 0) {
+      // Only fire discovery events once we have an established baseline
+      // (the very first render populates the baseline without emitting events,
+      // to avoid false-positives on extension startup).
+      for (const session of allSessions) {
+        if (!prevKnown.has(session.sessionId)) {
+          void Promise.resolve().then(() => this._onDidDiscoverSession.fire(session));
+        }
+      }
+    }
+
     const running = allSessions
       .filter((s) => this.isRunning(s))
       .sort((a, b) => b.mtime - a.mtime);


### PR DESCRIPTION
## Summary

This PR went through three rounds. Round 3 (v0.32.0) fixes a fundamental bug in round 2.

### Round 3 — fix cwd-match false positives (v0.32.0)

The cwd-match slow-path (`lsof`) shipped in round 2 was broken: clicking session B adopted the terminal running session A when both were bare `claude` processes in the same cwd. The OS gives no way to map a bare-claude PID to its session ID — cwd is not unique.

**Removed:**
- `parseLsofCwdOutput` and `collectClaudeDescendants` from `process-tree.ts`
- The entire slow-path block from `tryAdoptTerminal` in `extension.ts`
- 12 tests for the removed functions

**Added — pending-adoption queue for the `+` button:**
- `claimPendingAdoption<T>` pure helper in `process-tree.ts` — evicts stale entries (>60 s), claims first exact-cwd-match (FIFO). 6 new unit tests.
- `onDidDiscoverSession` event on `SessionsProvider` — fires once per new session ID on each refresh (deferred via microtask; first render populates baseline without emitting).
- `newSession` command pushes a `PendingAdoption` entry before running `claude`. `onDidDiscoverSession` listener claims it, links the terminal, and focuses it.
- `onDidCloseTerminal` evicts the terminal from the queue.

**Documented limitation:** bare `claude` typed outside the `+` flow cannot be safely adopted. Clicking such a session spawns a fresh `--resume` terminal — intentional after empirical disproof of cwd-match.

### Round 2 — cwd slow-path (v0.30.0) — superseded

Added `lsof`-based cwd match. Proven unsafe; removed in round 3.

### Round 1 — argv fast-path + `+` button (v0.29.0)

- `tryAdoptTerminal` argv fast-path: BFS each terminal's shell PID for a descendant with `claude --resume <sid>` in argv. Covers extension-spawned terminals after window reload.
- `+` button in panel title bar: spawns bare `claude` in workspace root CWD.
- 26 pure unit tests (no VS Code dependency).

---

## Test plan

1. Click `+`. Wait ~10 s. Click the new session. Expected: focuses spawned terminal — no duplicate.
2. Click any other pre-existing session. Expected: spawns fresh `--resume` terminal — no false adoption.
3. Open bare `claude` in an integrated terminal (not via `+`). Click it. Expected: spawns `--resume` terminal (documented limitation).
4. Click the step-3 session again. Expected: focuses the `--resume` terminal from step 3.
5. Click `+` twice. Wait for both. Expected: each links to its own terminal (FIFO).