### PR TITLE
feat(code-quality): add maintainability dimension and reuse-first authoring

### DIFF
--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -5,10 +5,11 @@ description: >
   complexity, readability, and long-term maintainability. Applies guard clauses,
   early returns, clear naming, single-responsibility functions, reuse of
   existing utilities, single source of truth for union-type metadata (one map
-  instead of N parallel maps), small change footprints, and pragmatic
-  performance choices grounded in research from SonarSource (Cognitive
-  Complexity), Robert C. Martin's Clean Code, and Knuth's guidance on
-  optimization. Use this skill whenever writing, refactoring, or reviewing code
+  instead of N parallel maps), schema-first validation with type inference
+  (Zod / Pydantic / valibot — define the schema once, infer the type from it),
+  small change footprints, and pragmatic performance choices grounded in
+  research from SonarSource (Cognitive Complexity), Robert C. Martin's Clean
+  Code, and Knuth's guidance on optimization. Use this skill whenever writing, refactoring, or reviewing code
   — especially during the GREEN and REFACTOR phases of TDD, code reviews, or
   whenever the user asks to "improve quality", "make this readable", "reduce
   complexity", "make this easier to maintain", "deduplicate", "clean this up",
@@ -100,6 +101,9 @@ before adding the variant. See `rules/maintainability.md`.
 | `if/else if` chain dispatching on a value | Lookup table or single source-of-truth record | Data structure beats control flow; easy to extend |
 | Same constant (`MAX_RETRIES`, status strings) duplicated across files | Hoist to one shared module | One concept, one home |
 | Adding a new variant requires editing 4+ files | Consolidate before adding the variant | Shotgun surgery compounds with every variant |
+| Separate `type User = {...}` and `userSchema = z.object({...})` for the same shape | One schema; `type User = z.infer<typeof UserSchema>` | Two declarations drift; one cannot |
+| Re-validating an already-parsed value deep in the stack | Parse once at the boundary; trust the type internally | Validation is a boundary concern, not a per-call concern |
+| Splitting every nested object into its own sub-schema "for cleanliness" | Keep flat unless the sub-shape is reused or has its own boundary | Premature decomposition; over-engineering |
 
 ---
 
@@ -182,7 +186,7 @@ file every time is wasted context.
 | Variable, function, class names | `rules/naming.md` |
 | Comments, docstrings, doc | `rules/comments.md` |
 | Performance concerns or hot paths | `rules/performance.md` |
-| Error handling, validation, defensive code | `rules/error-handling.md` |
+| Error handling, validation, defensive code, schema-first validation, Zod / Pydantic, inferring types from schemas | `rules/error-handling.md` |
 | Reviewing existing code | `rules/review-checklist.md` |
 | Cognitive complexity scoring | `rules/cognitive-complexity.md` |
 | Union types with associated data, parallel maps, duplicated constants, "where should this live", reuse decisions | `rules/maintainability.md` |

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -2,19 +2,22 @@
 name: code-quality
 description: >
   Code quality skill for writing and reviewing code optimized for low cognitive
-  complexity, readability, and maintainability. Applies guard clauses, early
-  returns, clear naming, single-responsibility functions, and pragmatic
+  complexity, readability, and long-term maintainability. Applies guard clauses,
+  early returns, clear naming, single-responsibility functions, reuse of
+  existing utilities, single source of truth for union-type metadata (one map
+  instead of N parallel maps), small change footprints, and pragmatic
   performance choices grounded in research from SonarSource (Cognitive
   Complexity), Robert C. Martin's Clean Code, and Knuth's guidance on
   optimization. Use this skill whenever writing, refactoring, or reviewing code
   — especially during the GREEN and REFACTOR phases of TDD, code reviews, or
   whenever the user asks to "improve quality", "make this readable", "reduce
-  complexity", "clean this up", "refactor for clarity", or "/code-quality".
+  complexity", "make this easier to maintain", "deduplicate", "clean this up",
+  "refactor for clarity", or "/code-quality".
 disable-model-invocation: true
 license: MIT
 metadata:
   author: mthines
-  version: '1.0.0'
+  version: '1.1.0'
   workflow_type: advisory-and-applied
   tags:
     - code-quality
@@ -24,14 +27,25 @@ metadata:
     - refactoring
     - guard-clauses
     - maintainability
+    - reuse
+    - single-source-of-truth
 ---
 
 # Code Quality Skill
 
-Write code that is easy to understand on first read. Optimize for the next
-developer's mental load before optimizing for machine performance, because
+Write code that is easy to **review, understand, and change**. Optimize for the
+next developer's mental load before optimizing for machine performance, because
 readable code is cheaper to change, debug, and trust — and most performance
 wins come from algorithmic choices and profiling, not micro-optimizations.
+
+The three quality axes this skill targets, in priority order:
+
+1. **Readability** — a reader understands the code top-to-bottom on first pass.
+2. **Maintainability** — the next variant of a concept is a one-file, one-edit
+   change; existing utilities are reused rather than re-invented; one concept
+   has one canonical home.
+3. **Pragmatic performance** — algorithmic wins by default, micro-optimizations
+   only when a profiler points at them.
 
 This skill applies in two modes:
 
@@ -59,6 +73,12 @@ When in doubt, the heuristic is: **can a reader understand this function
 top-to-bottom on one pass without backtracking?** If yes, ship it. If they
 have to scroll, jump, or hold a stack of conditions in their head, fix it.
 
+The maintainability counterpart: **if I add the next obvious variant of this
+concept, how many files do I have to edit, and will the type system catch me
+if I miss one?** One file with full type coverage is excellent; four
+hand-synchronised maps in four files is shotgun surgery — fix the structure
+before adding the variant. See `rules/maintainability.md`.
+
 ---
 
 ## Quick Reference (load these patterns into working memory)
@@ -75,6 +95,11 @@ have to scroll, jump, or hold a stack of conditions in their head, fix it.
 | Flag/option cluster (4+ params) | Object parameter or builder | Working memory holds ~4 chunks |
 | `else` after `return`/`throw` | Drop the `else` | Linear flow beats branching |
 | Magic number/string | Named constant | Future-you will not remember what `7` meant |
+| Parallel maps over the same union (`LABELS`, `COLORS`, `ICONS` keyed by `Status`) | One `Record<Status, { label, color, icon }>` | Adding a variant becomes one edit, not N |
+| Reimplementing a helper that already exists | Search first; use the existing one | Two implementations drift; bugs get fixed in one copy only |
+| `if/else if` chain dispatching on a value | Lookup table or single source-of-truth record | Data structure beats control flow; easy to extend |
+| Same constant (`MAX_RETRIES`, status strings) duplicated across files | Hoist to one shared module | One concept, one home |
+| Adding a new variant requires editing 4+ files | Consolidate before adding the variant | Shotgun surgery compounds with every variant |
 
 ---
 
@@ -84,26 +109,39 @@ have to scroll, jump, or hold a stack of conditions in their head, fix it.
 
 While writing code, apply these in order of impact:
 
-1. **Naming first** — before writing the body, name the function and its
+1. **Reuse before creating** — before writing a helper, type, constant,
+   formatter, or hook, search the codebase for one that already exists.
+   Grep the domain noun and a synonym; check neighbour files; check the
+   standard library and existing dependencies. A second implementation of
+   the same concept is worse than the first — behaviour drifts and bugs
+   get fixed in only one copy. See `rules/maintainability.md` §1.
+2. **Naming first** — before writing the body, name the function and its
    parameters so they describe *what* it does and *what* it returns. If you
    can't name it crisply, the responsibility is unclear; rethink the
    boundary, not the implementation.
-2. **Guard clauses up top** — handle errors, edge cases, and early-exit
+3. **Guard clauses up top** — handle errors, edge cases, and early-exit
    conditions at the start of the function. Reserve the indented body for
    the happy path.
-3. **One job per function** — if you find yourself writing "and" in a
+4. **One job per function** — if you find yourself writing "and" in a
    docstring or commit message ("validates and persists"), split it.
-4. **Limit nesting to 2 levels** — beyond that, extract a helper or invert a
+5. **Limit nesting to 2 levels** — beyond that, extract a helper or invert a
    condition. SonarQube's research uses nesting as the primary cognitive
    load multiplier.
-5. **Keep parameter count low (≤3 ideally, ≤5 hard cap)** — past that, group
+6. **Keep parameter count low (≤3 ideally, ≤5 hard cap)** — past that, group
    into an object/struct so callers don't need to memorize positional order.
-6. **Defer abstraction** — three similar lines is fine. Wait for a third
-   real use case before extracting a generic helper.
+7. **One source of truth for union-type metadata** — when a union has
+   associated data (labels, colours, icons, flags), use one record keyed by
+   the union with all metadata as the value, not N parallel maps. Adding a
+   variant must be a single edit. See `rules/maintainability.md` §2.
+8. **Defer *generic* abstraction, not reuse** — wait for a third real use
+   case before extracting a flag-driven generic helper. But always reuse
+   utilities that already exist, and always consolidate parallel maps over
+   the same union the moment they appear — those are not "premature".
 
 See `rules/cognitive-complexity.md` and `rules/control-flow.md` for the
-mechanics behind 2 and 4. See `rules/naming.md` for 1. See
-`rules/functions.md` for 3 and 5.
+mechanics behind 3 and 5. See `rules/naming.md` for 2. See
+`rules/functions.md` for 4 and 6. See `rules/maintainability.md` for 1, 7,
+and 8.
 
 ### Review Mode
 
@@ -113,13 +151,20 @@ When asked to review or refactor:
    read.
 2. **Score by cognitive load, not style** — pick the function that took you
    the longest to understand, that's your highest-priority refactor.
-3. **Suggest changes with the diff inline** — don't just say "this is
+3. **Score by change footprint** — for each new concept (a union, a
+   constant, a piece of metadata), count how many files would need to
+   change if a new variant were added. Anything beyond ~3 files, or that
+   the type system cannot enforce, is a maintainability finding.
+4. **Check for existing utilities** — grep for similar helpers, formatters,
+   or constants that the new code could have reused instead of duplicating.
+5. **Suggest changes with the diff inline** — don't just say "this is
    complex"; show the before/after.
-4. **Prioritize by impact** — fix the thing that hurts readers most, not
-   the thing that's easiest to nitpick. Ignore stylistic preferences if a
-   linter would catch them.
-5. **Stop when good enough** — perfect is a moving target. If the function
-   reads top-to-bottom and the names match the domain, leave it.
+6. **Prioritize by impact** — fix the thing that hurts readers and future
+   maintainers most, not the thing that's easiest to nitpick. Ignore
+   stylistic preferences if a linter would catch them.
+7. **Stop when good enough** — perfect is a moving target. If the function
+   reads top-to-bottom, names match the domain, and the change footprint
+   for the next variant is small, leave it.
 
 Load `rules/review-checklist.md` for the structured review pass.
 
@@ -140,6 +185,7 @@ file every time is wasted context.
 | Error handling, validation, defensive code | `rules/error-handling.md` |
 | Reviewing existing code | `rules/review-checklist.md` |
 | Cognitive complexity scoring | `rules/cognitive-complexity.md` |
+| Union types with associated data, parallel maps, duplicated constants, "where should this live", reuse decisions | `rules/maintainability.md` |
 
 ---
 
@@ -186,6 +232,28 @@ edge. Don't add defensive null checks throughout internal code — they hide
 real bugs by silently swallowing impossible states. If a value can't be
 null at this point in the code, don't pretend it can.
 
+### 8. Reuse before creating
+Before writing a helper, type, constant, or formatter, search the codebase
+for one that already exists. A second implementation of the same concept
+is worse than the first — behaviours drift, bugs get fixed in only one
+copy, and the next reader does not know which one is canonical. Reusing
+existing code is never premature.
+
+### 9. One source of truth for union-type metadata
+When a union or enum has associated data (labels, colours, icons, flags,
+defaults), put it in one record keyed by the union with structured values
+— not in N parallel maps. Adding a new variant must be a single edit, and
+the type system must catch you if you miss a field. Four hand-synchronised
+maps over `OrderStatus` are a bug waiting to ship.
+
+### 10. Minimise the change footprint
+A maintainable change touches few files, all type-checked. Before adding a
+new variant of a concept, ask: "if I add the next one, how many places do
+I need to edit, and will the compiler tell me if I miss one?" If the
+answer is "many" or "no", restructure first — usually by consolidating
+parallel maps, hoisting a duplicated constant, or co-locating data with
+the operations on it. See `rules/maintainability.md` §3.
+
 ---
 
 ## When Things Conflict
@@ -194,13 +262,26 @@ These principles will sometimes pull against each other. Defaults:
 
 - **Readability vs. performance** → readability wins until a profile says
   otherwise.
-- **DRY vs. clarity** → clarity wins. Two slightly-different 5-line blocks
-  beat one 12-line generic helper that takes flags.
+- **DRY vs. clarity** → clarity wins **for code shapes that happen to look
+  alike**: two slightly-different 5-line blocks beat one 12-line generic
+  helper that takes flags. But DRY wins **for the same concept** —
+  duplicated constants, parallel maps over the same union, and
+  re-implementations of an existing utility must be consolidated. The test
+  is *meaning*, not *appearance*: if the two pieces must always change
+  together to stay correct, they are one thing; if they merely share a
+  shape, they are two.
+- **Reuse vs. premature abstraction** → reuse existing utilities always;
+  extract a *new* generic helper only on the third real caller. See the
+  decision tree in `rules/maintainability.md` §4.
 - **Short name vs. clear name** → clear name. `userPendingApproval` beats
   `usr`.
 - **Guard clause vs. single-return-style** → guard clauses, unless the
   language/team strongly enforces single-return (e.g., some functional
   styles).
+- **Co-location vs. layered folders** → co-locate the type, its metadata,
+  and the functions that operate on it. A reader who lands on a union
+  should not have to grep across `types/`, `constants/`, and `utils/` to
+  understand it.
 
 ---
 
@@ -220,9 +301,18 @@ When invoked in review mode, structure findings as:
 ### Low Impact / Style (optional)
 - [file:line] [issue]
 
+### Maintainability findings
+- [file:line] [duplicated concept / parallel maps / shotgun-surgery risk] → [proposed consolidation]
+- [estimated change footprint for the next obvious variant: N files, type-checked? yes/no]
+
 ### What's already good
 - [brief notes on what to preserve]
 ```
+
+The Maintainability findings section is required when the reviewed code
+introduces or extends union types, enums, shared constants, or new
+utilities. Skip it only when the change is purely local (a single
+function's internals).
 
 When invoked in authoring mode, just write the code. Apply the principles
 silently. Don't narrate every guard clause — the user will see clean code

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -3,13 +3,22 @@ name: code-quality
 description: >
   Code quality skill for writing and reviewing code optimized for low cognitive
   complexity, readability, and long-term maintainability. Applies guard clauses,
-  early returns, clear naming, single-responsibility functions, reuse of
-  existing utilities, single source of truth for union-type metadata (one map
-  instead of N parallel maps), schema-first validation with type inference
-  (Zod / Pydantic / valibot — define the schema once, infer the type from it),
-  small change footprints, and pragmatic performance choices grounded in
-  research from SonarSource (Cognitive Complexity), Robert C. Martin's Clean
-  Code, and Knuth's guidance on optimization. Use this skill whenever writing, refactoring, or reviewing code
+  early returns, clear naming, single-responsibility functions, single level of
+  abstraction per function, type-driven design (make illegal states
+  unrepresentable, branded primitives, discriminated unions), reuse of existing
+  utilities, single source of truth for union-type metadata (one map instead of
+  N parallel maps), schema-first validation with type inference (Zod /
+  Pydantic / valibot — define the schema once, infer the type from it), total
+  functions and structured error type design, functional core + imperative
+  shell, DTO / domain / persistence separation, dependency injection of clock
+  / RNG / IDs for testability, idempotency for retryable operations, money in
+  minor units, small change footprints, neighbour-pattern symmetry, and
+  pragmatic performance choices. Pairs with the `tdd` skill: when authoring
+  new functions, invoke `tdd` to drive the implementation through
+  RED-GREEN-REFACTOR while applying these rules. Grounded in research from
+  SonarSource (Cognitive Complexity), Robert C. Martin's Clean Code, Knuth's
+  guidance on optimization, Alexis King ("Parse, Don't Validate"), and Gary
+  Bernhardt ("Functional Core, Imperative Shell"). Use this skill whenever writing, refactoring, or reviewing code
   — especially during the GREEN and REFACTOR phases of TDD, code reviews, or
   whenever the user asks to "improve quality", "make this readable", "reduce
   complexity", "make this easier to maintain", "deduplicate", "clean this up",
@@ -18,7 +27,7 @@ disable-model-invocation: true
 license: MIT
 metadata:
   author: mthines
-  version: '1.1.0'
+  version: '1.2.0'
   workflow_type: advisory-and-applied
   tags:
     - code-quality
@@ -30,6 +39,12 @@ metadata:
     - maintainability
     - reuse
     - single-source-of-truth
+    - type-driven-design
+    - functional-core
+    - testability
+    - idempotency
+    - api-design
+    - tdd-companion
 ---
 
 # Code Quality Skill
@@ -104,6 +119,23 @@ before adding the variant. See `rules/maintainability.md`.
 | Separate `type User = {...}` and `userSchema = z.object({...})` for the same shape | One schema; `type User = z.infer<typeof UserSchema>` | Two declarations drift; one cannot |
 | Re-validating an already-parsed value deep in the stack | Parse once at the boundary; trust the type internally | Validation is a boundary concern, not a per-call concern |
 | Splitting every nested object into its own sub-schema "for cleanliness" | Keep flat unless the sub-shape is reused or has its own boundary | Premature decomposition; over-engineering |
+| Function mixes orchestration sentences with low-level mechanics | Extract by abstraction level (R16) | Readers stop at the level they care about |
+| Runtime check enforcing "these two fields can't both be set" | Discriminated union (R15) | Compiler enforces the invariant; runtime check disappears |
+| Raw `string` for `Email`, `UserId`, `OrderId` | Brand the type via the schema (R11) | Mixing IDs becomes a compile error |
+| `any` or unjustified cast silencing the type checker | Schema parse, narrowed `unknown`, or `// because:` comment (R17) | Unjustified `any` is the shape most type bugs take |
+| Function calls `Date.now()` / `Math.random()` directly | Inject the clock / RNG (R9) | Pure functions are testable; impure functions are flaky |
+| Function throws for "not found" or returns sentinels (`-1`, `""`) | Total-ise: return `null` or `Result<T, E>` (R10) | Total functions are testable exhaustively |
+| Every error throws the same `Error` with a parsed message | Discriminated `AppError` union (R12) | Structured fields beat string parsing |
+| Importing a module triggers a side effect | Factory: `createX(...)` (R20) | Tests stop being accidentally integration tests |
+| Operation that may be retried is not safe to invoke twice | Idempotency key, upsert, or right HTTP method (R18) | Retries corrupt state otherwise |
+| Money stored as `number` | Integer minor units or decimal library (R19) | Floats cannot represent decimal currency exactly |
+| Floats compared with `===` | Compare with epsilon, or use integer ticks | `0.1 + 0.2 !== 0.3` |
+| `await` in a `for` loop where `Promise.all` was meant | Choose serial or parallel consciously | Accidental serialisation is a perf bug |
+| Every `open` without a paired `close` | `try/finally` or `using` | Resource leaks compound silently |
+| New file does not match neighbouring files' patterns | Read 2–3 neighbours and mimic them | Outlier code forces context-switching for every reader |
+| Refactor PR mixed with feature PR | Split into two PRs | Mixed PRs get rubber-stamped or rejected on the wrong grounds |
+| Helpers at the top of the file, public function 200 lines down | Public surface first; helpers below in call order | Files read top to bottom |
+| Reaching `a.b.c.d.method()` to act on `a` | Tell, don't ask: put the operation on `a` | Callers shouldn't walk private structure |
 
 ---
 
@@ -113,62 +145,92 @@ before adding the variant. See `rules/maintainability.md`.
 
 While writing code, apply these in order of impact:
 
-1. **Reuse before creating** — before writing a helper, type, constant,
+1. **Compose with the `tdd` skill for new code** — when authoring a new
+   function, module, or behaviour from scratch, invoke the `tdd` skill
+   (`Skill('tdd')`) to drive the implementation through a strict
+   RED → GREEN → REFACTOR cycle. Apply the rules below in GREEN and
+   REFACTOR. Skip the handoff for trivial edits (typos, config tweaks),
+   refactors of existing code (no new behaviour), or when the user
+   explicitly opts out. See `rules/testability.md` for the integration.
+2. **Match the neighbours** — before writing a new file in an existing
+   module, read 2–3 sibling files and mimic their structure (folder
+   layout, error shape, import order, test style, naming convention).
+   Outlier code forces every reader to context-switch. See
+   `rules/collaboration.md` §1.
+3. **Reuse before creating** — before writing a helper, type, constant,
    formatter, or hook, search the codebase for one that already exists.
    Grep the domain noun and a synonym; check neighbour files; check the
    standard library and existing dependencies. A second implementation of
-   the same concept is worse than the first — behaviour drifts and bugs
-   get fixed in only one copy. See `rules/maintainability.md` §1.
-2. **Naming first** — before writing the body, name the function and its
-   parameters so they describe *what* it does and *what* it returns. If you
-   can't name it crisply, the responsibility is unclear; rethink the
+   the same concept is worse than the first. See
+   `rules/maintainability.md` §1.
+4. **Naming first** — before writing the body, name the function and its
+   parameters so they describe *what* it does and *what* it returns. If
+   you can't name it crisply, the responsibility is unclear; rethink the
    boundary, not the implementation.
-3. **Guard clauses up top** — handle errors, edge cases, and early-exit
+5. **Design the type before the body** — model the inputs and outputs so
+   illegal states cannot be represented (discriminated unions, branded
+   primitives, total return types, `Result<T, E>` for expected failures).
+   The cheapest place to catch a bug is the place the bug cannot exist.
+   See `rules/abstraction.md` §2 and `rules/api-design.md` §4–§5.
+6. **Guard clauses up top** — handle errors, edge cases, and early-exit
    conditions at the start of the function. Reserve the indented body for
    the happy path.
-4. **One job per function** — if you find yourself writing "and" in a
-   docstring or commit message ("validates and persists"), split it.
-5. **Limit nesting to 2 levels** — beyond that, extract a helper or invert a
-   condition. SonarQube's research uses nesting as the primary cognitive
-   load multiplier.
-6. **Keep parameter count low (≤3 ideally, ≤5 hard cap)** — past that, group
-   into an object/struct so callers don't need to memorize positional order.
-7. **One source of truth for union-type metadata** — when a union has
-   associated data (labels, colours, icons, flags), use one record keyed by
-   the union with all metadata as the value, not N parallel maps. Adding a
-   variant must be a single edit. See `rules/maintainability.md` §2.
-8. **Defer *generic* abstraction, not reuse** — wait for a third real use
-   case before extracting a flag-driven generic helper. But always reuse
-   utilities that already exist, and always consolidate parallel maps over
-   the same union the moment they appear — those are not "premature".
+7. **One job per function, one level of abstraction per body** — if you
+   find yourself writing "and" in a docstring or mixing orchestration
+   sentences with low-level mechanics, split. See
+   `rules/abstraction.md` §1.
+8. **Limit nesting to 2 levels** — beyond that, extract a helper or
+   invert a condition.
+9. **Keep parameter count low (≤3 ideally, ≤5 hard cap)** — past that,
+   group into an object/struct.
+10. **One source of truth for union-type metadata** — when a union has
+    associated data (labels, colours, icons, flags), use one record keyed
+    by the union with structured values, not N parallel maps. Adding a
+    variant must be a single edit. See `rules/maintainability.md` §2.
+11. **Push impurity outward** — keep decision logic pure; push I/O, time,
+    randomness, and ID generation to the edges. Inject the clock / RNG /
+    fetcher; do not call them directly from core logic. See
+    `rules/architecture.md` §3 and `rules/correctness.md` §7.
+12. **Defer *generic* abstraction, not reuse** — wait for a third real
+    use case before extracting a flag-driven generic helper. Always reuse
+    utilities that already exist, and always consolidate parallel maps
+    over the same union the moment they appear — those are not
+    "premature".
 
-See `rules/cognitive-complexity.md` and `rules/control-flow.md` for the
-mechanics behind 3 and 5. See `rules/naming.md` for 2. See
-`rules/functions.md` for 4 and 6. See `rules/maintainability.md` for 1, 7,
-and 8.
+Cross-references: `rules/cognitive-complexity.md` and
+`rules/control-flow.md` for 6 and 8; `rules/naming.md` for 4;
+`rules/functions.md` for 7 and 9; `rules/maintainability.md` for 3, 10,
+and 12; `rules/abstraction.md`, `rules/architecture.md`,
+`rules/api-design.md`, `rules/correctness.md`, `rules/testability.md`,
+`rules/collaboration.md`, and `rules/refactor-recipes.md` for the deeper
+patterns.
 
 ### Review Mode
 
 When asked to review or refactor:
 
-1. **Read all of the target code first** — don't critique what you haven't
-   read.
-2. **Score by cognitive load, not style** — pick the function that took you
-   the longest to understand, that's your highest-priority refactor.
+1. **Read all of the target code first** — don't critique what you
+   haven't read.
+2. **Score by cognitive load, not style** — pick the function that took
+   you the longest to understand, that's your highest-priority refactor.
 3. **Score by change footprint** — for each new concept (a union, a
    constant, a piece of metadata), count how many files would need to
-   change if a new variant were added. Anything beyond ~3 files, or that
-   the type system cannot enforce, is a maintainability finding.
-4. **Check for existing utilities** — grep for similar helpers, formatters,
-   or constants that the new code could have reused instead of duplicating.
-5. **Suggest changes with the diff inline** — don't just say "this is
+   change if a new variant were added. Anything beyond ~3 files, or
+   that the type system cannot enforce, is a maintainability finding.
+4. **Check for existing utilities** — grep for similar helpers,
+   formatters, or constants that the new code could have reused instead
+   of duplicating.
+5. **Cite recipes by name** — use `rules/refactor-recipes.md` so reviews
+   read as "apply R1 (Consolidate Parallel Maps)" rather than free-form
+   prose.
+6. **Suggest changes with the diff inline** — don't just say "this is
    complex"; show the before/after.
-6. **Prioritize by impact** — fix the thing that hurts readers and future
-   maintainers most, not the thing that's easiest to nitpick. Ignore
-   stylistic preferences if a linter would catch them.
-7. **Stop when good enough** — perfect is a moving target. If the function
-   reads top-to-bottom, names match the domain, and the change footprint
-   for the next variant is small, leave it.
+7. **Prioritize by impact** — fix the thing that hurts readers and
+   future maintainers most, not the thing that's easiest to nitpick.
+   Ignore stylistic preferences if a linter would catch them.
+8. **Stop when good enough** — perfect is a moving target. If the
+   function reads top-to-bottom, names match the domain, and the change
+   footprint for the next variant is small, leave it.
 
 Load `rules/review-checklist.md` for the structured review pass.
 
@@ -190,6 +252,13 @@ file every time is wasted context.
 | Reviewing existing code | `rules/review-checklist.md` |
 | Cognitive complexity scoring | `rules/cognitive-complexity.md` |
 | Union types with associated data, parallel maps, duplicated constants, "where should this live", reuse decisions | `rules/maintainability.md` |
+| Abstraction levels, type-driven design, illegal states unrepresentable, branded primitives, generics, `any`/cast discipline | `rules/abstraction.md` |
+| Module boundaries, public surface, dependency direction, functional core / imperative shell, DTO ↔ domain ↔ persistence, immutability defaults, side-effecting imports | `rules/architecture.md` |
+| Function signatures, parameter ordering, total functions, modeling absence, designing the error type system, tell-don't-ask, file reading order | `rules/api-design.md` |
+| Idempotency, money / decimals / floats, dates and time, identifiers, encoding, determinism, assertions, async / concurrency, resource management | `rules/correctness.md` |
+| Hard-to-test code, dependency injection of clock / RNG / IDs, when to invoke the `tdd` skill | `rules/testability.md` |
+| PR scope, neighbour-pattern symmetry, migration & evolution, working with legacy code, diff hygiene | `rules/collaboration.md` |
+| Naming a refactor in review output (R1 Consolidate Parallel Maps, R6 Replace Type Declaration with Inferred Type, etc.) | `rules/refactor-recipes.md` |
 
 ---
 
@@ -258,6 +327,36 @@ answer is "many" or "no", restructure first — usually by consolidating
 parallel maps, hoisting a duplicated constant, or co-locating data with
 the operations on it. See `rules/maintainability.md` §3.
 
+### 11. Make illegal states unrepresentable
+The cheapest place to catch a bug is the place the bug cannot exist. Lift
+constraints into the type system: discriminated unions for state machines,
+exhaustive `switch` with `assertNever`, branded primitives, refined types
+(`NonEmptyArray<T>`). Runtime guards that the type system could enforce
+are noise that drifts. See `rules/abstraction.md` §2.
+
+### 12. Pure core, impure shell
+Decision logic is pure: no I/O, no time, no randomness, no global state.
+Side effects live in a thin shell at the edges. Pure code is the cheapest
+to test and reason about; impure code is unavoidable but should be small
+enough to verify by integration tests. Inject the clock, RNG, fetcher,
+and ID generator rather than calling them directly. See
+`rules/architecture.md` §3 and `rules/correctness.md` §7.
+
+### 13. Total functions over throw-for-missing
+A function is total when every input has a defined output. Return `null`
+for absent-by-design and `Result<T, E>` for expected failures; reserve
+`throw` for programmer errors and unexpected I/O failures. Sentinels
+(`-1`, `""`, `0`) lie — every sentinel collides with a real value the
+next caller will hit. See `rules/api-design.md` §4.
+
+### 14. Test-first for new code
+When authoring a new function, module, or behaviour, invoke the `tdd`
+skill (`Skill('tdd')`) to drive the implementation through a strict
+RED → GREEN → REFACTOR cycle. Apply the rules in this skill silently in
+GREEN; apply them explicitly in REFACTOR. Skip the handoff only for
+trivial edits, refactors of existing code, or when the user opts out.
+See `rules/testability.md`.
+
 ---
 
 ## When Things Conflict
@@ -297,7 +396,7 @@ When invoked in review mode, structure findings as:
 ## Code Quality Review: [target]
 
 ### High Impact (fix these)
-- [file:line] [issue] → [proposed change]
+- [file:line] [issue] → [proposed change, citing recipe ID where applicable: R1, R6, etc.]
 
 ### Medium Impact (consider)
 - [file:line] [issue] → [proposed change]
@@ -306,8 +405,16 @@ When invoked in review mode, structure findings as:
 - [file:line] [issue]
 
 ### Maintainability findings
-- [file:line] [duplicated concept / parallel maps / shotgun-surgery risk] → [proposed consolidation]
+- [file:line] [duplicated concept / parallel maps / shotgun-surgery risk] → [proposed consolidation, e.g., R1 Consolidate Parallel Maps]
 - [estimated change footprint for the next obvious variant: N files, type-checked? yes/no]
+
+### Correctness findings (when relevant)
+- [file:line] [idempotency / money / dates / determinism / async / resources]
+- [proposed fix, citing recipe ID]
+
+### Testability findings (when relevant)
+- [file:line] [hard-to-test surface, missing injection, coupled to global state]
+- [proposed fix, e.g., R9 Inject the Clock / RNG / IDs]
 
 ### What's already good
 - [brief notes on what to preserve]
@@ -315,9 +422,11 @@ When invoked in review mode, structure findings as:
 
 The Maintainability findings section is required when the reviewed code
 introduces or extends union types, enums, shared constants, or new
-utilities. Skip it only when the change is purely local (a single
-function's internals).
+utilities. Correctness and Testability sections are required when the
+reviewed code involves retryable operations, money, dates, async I/O,
+resource handles, or non-trivial pure logic. Skip them when not
+applicable — do not manufacture findings to look thorough.
 
-When invoked in authoring mode, just write the code. Apply the principles
-silently. Don't narrate every guard clause — the user will see clean code
-in the diff.
+When invoked in authoring mode, just write the code (or hand off to the
+`tdd` skill first for new code). Apply the principles silently. Don't
+narrate every guard clause — the user will see clean code in the diff.

--- a/skills/code-quality/rules/abstraction.md
+++ b/skills/code-quality/rules/abstraction.md
@@ -1,0 +1,211 @@
+---
+title: 'Abstraction — Levels, Types, Generics, Escape Hatches'
+impact: HIGH
+tags:
+  - abstraction
+  - type-driven-design
+  - generics
+  - any
+---
+
+# Abstraction
+
+Abstractions earn their keep when they make code easier to understand and easier to change.
+Premature, mis-levelled, or over-generic abstractions make code harder.
+This rule covers the four abstraction decisions that come up while writing code: levels within a function, the type system as a design surface, generics, and type escape hatches.
+
+## 1. One Level of Abstraction Per Function
+
+A function should mix instructions at one level of detail.
+A body that goes "validate the order, then notify the user, then `for (let i = 0; i < items.length; i++)`" forces the reader to context-switch from orchestration to mechanics inside one mental frame.
+
+### Heuristic
+
+Read the function aloud.
+If some lines sound like sentences ("validate the order", "send the receipt") and others sound like mechanics ("increment the counter", "iterate the array"), they belong in different functions.
+
+### Anti-pattern
+
+```typescript
+async function processOrder(order: Order) {
+  if (!order.items?.length) throw new Error('empty order');
+  await db.beginTransaction();
+  for (let i = 0; i < order.items.length; i++) {
+    const item = order.items[i];
+    const stock = await db.query('SELECT qty FROM stock WHERE id = ?', [item.id]);
+    if (stock.qty < item.qty) throw new Error(`out of stock: ${item.id}`);
+    await db.query('UPDATE stock SET qty = qty - ? WHERE id = ?', [item.qty, item.id]);
+  }
+  await sendgrid.send({ to: order.user.email, template: 'order-confirmation', data: order });
+  await db.commit();
+}
+```
+
+The function reads at three levels at once: business orchestration, SQL mechanics, and email transport detail.
+
+### Pattern
+
+```typescript
+async function processOrder(order: Order) {
+  guardNonEmpty(order);
+  await withTransaction(async () => {
+    await reserveStock(order.items);
+    await sendConfirmation(order);
+  });
+}
+```
+
+Each helper lives at one level.
+The reader who wants the high-level story stops at `processOrder`; the reader debugging stock subtraction goes straight to `reserveStock` and stays there.
+
+## 2. Type-Driven Design — Make Illegal States Unrepresentable
+
+The cheapest place to catch a bug is the place the bug cannot exist.
+Lift constraints into the type system so the compiler enforces them; runtime checks become unnecessary.
+
+### Discriminated unions for state machines
+
+```typescript
+type Order =
+  | { status: 'draft';     items: Item[] }
+  | { status: 'submitted'; items: Item[]; submittedAt: Date }
+  | { status: 'paid';      items: Item[]; submittedAt: Date; paidAt: Date }
+  | { status: 'shipped';   items: Item[]; submittedAt: Date; paidAt: Date; trackingId: string };
+```
+
+`order.trackingId` is unreachable on a `'draft'` order — the type system enforces "you cannot read a tracking id off an unshipped order".
+No runtime guard is needed.
+
+### Exhaustive matching with `assertNever`
+
+```typescript
+function label(order: Order): string {
+  switch (order.status) {
+    case 'draft':     return 'Draft';
+    case 'submitted': return 'Awaiting payment';
+    case 'paid':      return 'Paid';
+    case 'shipped':   return `Shipped — ${order.trackingId}`;
+    default:          return assertNever(order);
+  }
+}
+
+function assertNever(x: never): never {
+  throw new Error(`unhandled variant: ${JSON.stringify(x)}`);
+}
+```
+
+Adding a new status the compiler immediately fails the build at every `switch` until each is updated — `assertNever` turns "missed a case" from a bug class into a compile error.
+
+### Branded primitives
+
+A raw `string` cannot tell `Email`, `UserId`, and `OrderId` apart.
+Brand the type at the validating boundary so the compiler does:
+
+```typescript
+const EmailSchema = z.string().email().brand<'Email'>();
+type Email = z.infer<typeof EmailSchema>;
+
+function sendWelcome(to: Email) { /* ... */ }
+
+sendWelcome('not-validated@x.com');                  // compile error
+sendWelcome(EmailSchema.parse('user@example.com'));  // ok
+```
+
+See `error-handling.md` Schema-First Validation for the broader pattern.
+
+### Refined types beat runtime guards
+
+```typescript
+type NonEmptyArray<T> = readonly [T, ...T[]];
+
+function head<T>(xs: NonEmptyArray<T>): T {
+  return xs[0];   // no runtime check needed; the type proves length ≥ 1
+}
+```
+
+If the input cannot be empty, encode it.
+The "empty array" branch never has to be written.
+
+## 3. Generics — Parameterise Behaviour, Not Data Shapes
+
+Generic code is justified when **the same algorithm operates over different types**.
+Adding type parameters to make a function look "flexible" without a real second caller is the type-level version of premature abstraction.
+
+### When to be generic
+
+```typescript
+// Justified — same algorithm, many T
+function keyBy<T, K extends string>(items: T[], pick: (t: T) => K): Record<K, T> {
+  const out = {} as Record<K, T>;
+  for (const item of items) out[pick(item)] = item;
+  return out;
+}
+```
+
+### When not to be generic
+
+```typescript
+// Not justified — one concrete type
+function logUser<T extends { id: string; email: string }>(user: T): void {
+  console.log(user.id, user.email);
+}
+
+// Better — say what you mean
+function logUser(user: User): void {
+  console.log(user.id, user.email);
+}
+```
+
+### Conditional types are write-only
+
+`type X<T> = T extends Foo ? T extends Bar ? ... : ... : ...` is unreadable in six months.
+If you need it, leave a comment explaining the shape and a test pinning the inferred result.
+Most domain code does not need conditional types.
+
+## 4. Type Escape Hatches: `any`, `unknown`, and Casts
+
+Every codebase needs escape hatches at FFI boundaries, parser internals, and dynamic-shape glue.
+The discipline is making escapes deliberate, not accidental.
+
+### `unknown` is the safe escape
+
+`unknown` says "I do not know the shape; force me to narrow before use".
+Use it freely at boundaries; pair with a schema parse to widen safely.
+
+### `any` is a smell
+
+`any` silences the type checker.
+Every `any` carries a one-line `// because:` comment justifying the escape.
+Without justification, the next reader cannot tell whether the `any` is load-bearing or a leftover.
+
+```typescript
+// because: third-party SDK ships no types and the shape is documented in the README
+const handle = (sdk as any).createHandle({ ... });
+```
+
+### Casts (`as Foo`) follow the same rule
+
+A cast asserts a fact the checker cannot prove.
+Justify it, or replace it with a parse:
+
+```typescript
+// Avoid
+const user = JSON.parse(raw) as User;
+
+// Prefer — actually verifies the shape
+const user = UserSchema.parse(JSON.parse(raw));
+```
+
+### Legitimate uses of `any` / casts
+
+- Generic infrastructure where the type really is "anything the caller passes" (and the caller has its own typing).
+- Parser internals that produce typed values from untyped input.
+- IPC / FFI / postMessage boundaries that the language cannot type.
+
+### What never justifies `any` / a cast
+
+- "It made the type error go away".
+- "TypeScript was being annoying".
+- "I will fix it later".
+
+These are the `any`s that ship bugs.

--- a/skills/code-quality/rules/api-design.md
+++ b/skills/code-quality/rules/api-design.md
@@ -1,0 +1,189 @@
+---
+title: 'API Design — Function Signatures as a UI'
+impact: HIGH
+tags:
+  - api-design
+  - signatures
+  - total-functions
+  - error-types
+  - tell-dont-ask
+---
+
+# API Design
+
+A function signature is the UI for every caller — including future you and the agent reading this code in six months.
+Bad ergonomics here cost callers forever; good ergonomics make the call site read like prose.
+
+## 1. Parameter Order
+
+Decidable rules:
+
+- **Subject first.** The thing the function operates on goes before the things it operates with: `parseDate(input, options)`, not `parseDate(options, input)`.
+- **Required before optional.** Optionals at the end so callers do not pass `undefined` placeholders.
+- **Data before configuration.** `format(value, opts)`, not `format(opts, value)`.
+- **Once you have 4+ parameters, switch to an options object.**
+  See `functions.md` "Parameter Object Pattern".
+
+## 2. Defaults at the Right Layer
+
+A default belongs where the decision lives.
+
+- A *business* default (e.g., "trial period is 14 days") lives in business code where the policy is owned.
+- A *transport* default (e.g., "HTTP timeout is 5 s") lives in the transport layer, not at every call site.
+- Avoid leaking transport details into call sites: `client.get(url, { timeout: 5000, retries: 3 })` repeated everywhere is a signal the wrapper does not own its own defaults.
+
+## 3. Sync vs. Async Consistency
+
+Within a module or family of related functions, all related operations should be synchronous or all asynchronous.
+Do not mix.
+
+- A function that is "sometimes async" — returns `T | Promise<T>` depending on whether a cache is warm — is a usability trap.
+  Pick one shape and pay the (tiny) cost of the unnecessary `await`.
+- If most callers await, the function is async.
+
+## 4. Total Functions: Every Input Has a Defined Output
+
+A *total* function is defined for every value of its input type.
+Make functions total wherever practical.
+
+### Pick one representation for "absent" per codebase
+
+The four common representations are:
+
+- `null`
+- `undefined`
+- An empty value (`""`, `[]`, `0`)
+- An exception
+
+Pick **one** for "the value may legitimately not exist" and use it everywhere.
+Recommended default for TS/JS:
+
+- `null` for "may not exist by design" (`getUserById` on a missing id).
+- `undefined` for "not provided by the caller" (optional parameter).
+- Never both for the same field.
+
+### Do not throw for expected absence
+
+```typescript
+// Avoid — "not found" is a normal outcome
+function getUser(id: string): User {
+  const user = db.find(id);
+  if (!user) throw new NotFoundError(id);
+  return user;
+}
+
+// Prefer — caller decides what "not found" means
+function getUser(id: string): User | null {
+  return db.find(id) ?? null;
+}
+```
+
+Throwing is reserved for **programmer errors** (an invariant is violated) and **unexpected I/O failures**.
+
+### Sentinels lie
+
+`-1` for "not found", `""` for "absent", `0` for "no result" — every sentinel collides with a real value the next caller will hit.
+Use `null` / `undefined` / a `Result` type.
+
+## 5. Designing the Error Type System
+
+Errors are a type system, not a category of strings.
+Design the error space the same way you design the success space.
+
+### Discriminated error union
+
+```typescript
+type AppError =
+  | { kind: 'not_found';   resource: string; id: string }
+  | { kind: 'validation';  issues: ZodIssue[] }
+  | { kind: 'conflict';    reason: string }
+  | { kind: 'unauthorised'; subject: string };
+```
+
+Each variant carries the structured data the handler needs.
+The `kind` discriminator drives exhaustive matching at every site that translates an error to an HTTP status, a UI message, or a retry decision.
+
+### `Result<T, E>` for expected failures
+
+```typescript
+type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
+
+async function chargeCard(req: ChargeRequest): Promise<Result<Charge, AppError>> {
+  // ...
+}
+```
+
+`Result` makes failure paths explicit at the call site.
+`throw` makes them invisible.
+For *expected* failure modes (validation, conflict, not found), use `Result`.
+For *programmer errors* and *unexpected* I/O failures, throw.
+
+### Preserve causes with `Error.cause`
+
+```typescript
+try { /* ... */ }
+catch (e) {
+  throw new ChargeFailedError('payment processor rejected', { cause: e });
+}
+```
+
+`Error.cause` (ES2022) preserves the original stack and message through transformations.
+Do not concatenate `e.message` into a new string and lose the original.
+
+### Custom error classes
+
+Per-category subclasses make `instanceof` narrowing trivial:
+
+```typescript
+class ValidationError extends Error { /* ... */ }
+class NotFoundError extends Error { /* ... */ }
+
+if (e instanceof ValidationError) return 400;
+if (e instanceof NotFoundError) return 404;
+```
+
+## 6. Tell, Don't Ask (and Demeter-Light)
+
+If you reach `a.b.c.d.method()` to do something, the operation belongs *on* `a` or `b`, not at the call site.
+
+```typescript
+// Avoid — caller walks into the object's internals
+if (user.subscription.plan.tier.code === 'enterprise') { ... }
+
+// Prefer — caller asks the object
+if (user.isOnEnterprisePlan()) { ... }
+```
+
+### When the rule applies
+
+- For **behaviour** (methods that act on the data), apply strictly.
+- For **plain data records** (DTOs, configuration objects, rows from a query), walking the structure is fine — that is what records are for.
+
+The test: am I asking the object to *make a decision*, or am I just reading a *value*?
+Decisions belong on the object; values are public.
+
+## 7. Reading Order Within a File
+
+Files are read top to bottom.
+Order the contents so a reader landing on the file can build understanding linearly.
+
+- **Public surface first.**
+  Exports the file is named for sit at the top.
+  Helpers used by them sit below, in roughly the order they are first called.
+- **Types and constants near their primary user.**
+  A `Status` type defined two scrolls before its first use forces the reader to remember it.
+- **One main concept per file.**
+  If two equally-prominent exports exist, the file is two files.
+
+### Anti-pattern: helpers-first
+
+```typescript
+function _formatPrice(...) { ... }
+function _normaliseLineItem(...) { ... }
+function _validateTotals(...) { ... }
+// 200 lines later:
+export function renderInvoice(...) { ... }
+```
+
+The reader has to read three helpers without context to discover the function the file actually exports.
+Put `renderInvoice` at the top.

--- a/skills/code-quality/rules/architecture.md
+++ b/skills/code-quality/rules/architecture.md
@@ -1,0 +1,176 @@
+---
+title: 'Architecture — Module Boundaries, Dependency Direction, Functional Core'
+impact: HIGH
+tags:
+  - architecture
+  - modules
+  - functional-core
+  - immutability
+  - state
+---
+
+# Architecture
+
+The shape of code at the file and module level determines how easy it is to find things, change things, and test things.
+This rule covers the structural decisions that single-function-level guidance does not reach.
+
+## 1. Module Boundaries and Public Surface
+
+Each module exposes a small, intentional public surface.
+Internal helpers are not exported.
+A module whose `index.ts` re-exports everything has no boundary — every internal change is a potential breaking change to consumers.
+
+### Rules
+
+- Default exports are `export`-private; promote to `export` only when a caller outside the module needs them.
+- If a helper is needed in a sibling module, that is a signal: extract it to a shared utility module rather than reaching across.
+- Avoid barrel files (`index.ts` re-exporting everything in the directory).
+  They defeat tree-shaking, mask circular imports, and create the illusion of structure where there is none.
+- Prefer explicit imports from the source file: `import { x } from './module/x'` over `import { x } from './module'`.
+
+## 2. Dependency Direction
+
+Dependencies point toward stable, abstract things — not toward concrete, volatile things.
+Domain code does not import infrastructure; infrastructure imports domain.
+
+```
+        ┌────────────────┐
+        │     Domain     │   pure types, business rules
+        └────────▲───────┘
+                 │ imports
+        ┌────────┴───────┐
+        │   Application  │   use cases, orchestration
+        └────────▲───────┘
+                 │ imports
+        ┌────────┴───────┐
+        │ Infrastructure │   DB, HTTP, queues, vendors
+        └────────────────┘
+```
+
+Reading direction is bottom-up: infrastructure depends on application, application depends on domain, domain depends on nothing.
+
+A circular import is a structural bug — split the shared piece into a third module instead of papering over with lazy `require` or dynamic `import()`.
+
+## 3. Functional Core, Imperative Shell
+
+Push pure decision logic into a core module that has no I/O, no time, no randomness.
+Push side effects (DB, network, file system, time, randomness) to a thin shell at the edges.
+
+### Why
+
+- Pure code is the cheapest to test (no setup, no mocks).
+- Pure code is the cheapest to reason about (no hidden state).
+- Side-effecting code is unavoidable but should be small enough to verify by integration tests.
+
+### Pattern
+
+```typescript
+// Core — pure, easy to test
+function nextOrderState(current: OrderState, event: OrderEvent, now: Date): OrderState {
+  // ...decisions only
+}
+
+// Shell — handles I/O around the pure call
+async function handleOrderEvent(event: OrderEvent) {
+  const current = await orderRepo.load(event.orderId);
+  const next = nextOrderState(current, event, new Date());
+  await orderRepo.save(next);
+  await eventBus.publish({ type: 'OrderStateChanged', from: current.status, to: next.status });
+}
+```
+
+The shell is dull glue; the interesting logic is testable without any infrastructure.
+
+## 4. DTO ↔ Domain ↔ Persistence — Three Shapes, One per Boundary
+
+A single concept usually has three runtime shapes:
+
+| Shape | Lives at | Concerns |
+|---|---|---|
+| **DTO** | The wire (HTTP body, queue message, file format) | Validated by a schema; strings, ISO dates, snake_case |
+| **Domain** | The runtime model | Rich types, value objects, invariants, branded primitives |
+| **Persistence** | The storage row | Coupled to the database schema; nullable columns, FKs |
+
+Map between them at the boundary; never let one leak into another's territory.
+
+### Anti-pattern: leaking shapes
+
+```typescript
+// Wire DTO leaking into domain
+function applyDiscount(user: { created_at: string; tier: string }) {
+  if (Date.parse(user.created_at) < ...) /* ... */
+}
+```
+
+`created_at: string` is a wire detail.
+The domain should see `createdAt: Date` and `tier: UserTier`.
+
+### Pattern
+
+```typescript
+// At the boundary
+const user = UserSchema.parse(req.body).into Domain();   // map DTO → Domain
+// ... internal code uses User (domain shape) only ...
+return res.json(toDto(user));                             // map Domain → DTO at egress
+```
+
+Schemas (see `error-handling.md`) enforce the wire shape.
+Domain types enforce the runtime shape.
+Persistence types live next to the repository that owns the table.
+
+## 5. Immutability Defaults
+
+Mutation is allowed but never the default.
+
+- `const` over `let`. `let` requires a reason and the reason is rarely "I will reassign later".
+- `readonly` on public fields.
+- Update via copy-on-write (`{ ...prev, status: 'paid' }`), not in-place mutation, when the value crosses a function boundary.
+- Local mutation inside a single function body is fine and often clearer than functional acrobatics — but the value escaping the function should be immutable from the caller's perspective.
+
+### Why this matters
+
+Shared mutable state is the source of "spooky action at a distance" — code in one file changes behaviour in another file because they hold the same reference.
+Immutability eliminates the bug class entirely.
+
+## 6. State Management Discipline
+
+State has an owner.
+Every piece of mutable state belongs to one module that decides when it changes; everyone else reads.
+
+### Rules
+
+- Local state lives where it is used.
+- Shared state has a single explicit owner (a store, a service, a context).
+- A consumer that needs to mutate shared state asks the owner; it does not write directly.
+- Module-scope `let` variables are global state in disguise — avoid.
+
+### Spooky action test
+
+If mutating an object in `featureA.ts` could change behaviour in `featureB.ts` you didn't expect, the design is wrong.
+Either the state is shared and should have a single owner, or the modules should hold separate copies.
+
+## 7. No Side-Effecting Imports
+
+Importing a module must not cause anything to happen.
+No network calls, no file writes, no registry pushes, no singleton creation, no top-level `await` that initialises a database.
+
+### Why
+
+Side-effecting imports make import order significant.
+They turn unit tests into integration tests by accident.
+They create initialisation hazards in tools (bundlers, type checkers, REPLs) that import modules speculatively.
+
+### Pattern: export factories
+
+```typescript
+// Avoid — runs on import
+export const db = new Database(process.env.DATABASE_URL!);
+
+// Prefer — runs when the caller is ready
+export function createDatabase(config: DbConfig): Database {
+  return new Database(config.url);
+}
+```
+
+The application's composition root (one place near the entry point) calls the factories and wires the graph.
+Everywhere else imports types and pure functions.

--- a/skills/code-quality/rules/collaboration.md
+++ b/skills/code-quality/rules/collaboration.md
@@ -1,0 +1,158 @@
+---
+title: 'Collaboration — Code as Something Other People Maintain'
+impact: MEDIUM
+tags:
+  - collaboration
+  - pr-scope
+  - migration
+  - symmetry
+  - legacy
+---
+
+# Collaboration
+
+Code is read and changed by other people, including future you.
+This rule covers the practices that keep the collaboration loop fast: matching neighbours, keeping changes reviewable, evolving safely, and working with code you did not write.
+
+## 1. Symmetry with Neighbours
+
+Before writing a new file in an existing module, **read 2–3 neighbour files** and match their structure.
+New code that looks like a stranger forces every reader to context-switch.
+
+### What to match
+
+- Folder layout and file naming convention.
+- Import order (external first, then internal, then relative — or whatever the convention is).
+- Error shape (`Result<T, E>` vs. throw; custom error class names).
+- Test framework, test file location, test naming pattern.
+- Logging / telemetry shape.
+- Default export vs. named exports.
+- Function declaration vs. arrow expression for top-level functions.
+
+### When to deviate
+
+Deviation requires a reason that holds up in code review.
+"I prefer X" is not a reason.
+"The existing pattern blocks the type system from catching Y" is.
+
+If the surrounding pattern is genuinely worse, the right move is usually a separate refactor PR that updates the neighbours, then the new code matches the new pattern.
+
+## 2. PR Scope: One Logical Change Per PR
+
+A PR that mixes "rename `UserService` to `AccountService`" and "add billing reminder" gets either rubber-stamped or rejected on the wrong grounds.
+
+### Rules
+
+- **Refactor PR ≠ feature PR.**
+  A refactor that changes structure but not behaviour is reviewable in its own right.
+  A feature that builds on the refactor is reviewable in its own right.
+  Mixed, neither is.
+- **Cap diffs.**
+  Above ~500 lines, the review quality drops sharply.
+  Split into smaller PRs that each make sense independently.
+- **One concept per commit.**
+  Squash noise; keep meaningful commits.
+- **Format / whitespace changes go in their own commit** if unavoidable, so the substantive review surface is clean.
+
+### Splitting strategies
+
+- Refactor → tests still green → ship.
+- Add the new code path behind a flag → tests for both → ship.
+- Migrate callers in batches → ship each batch.
+
+## 3. Migration & Evolution Discipline
+
+Code lives longer than the people who write it.
+Changes that break callers must be planned to ship safely.
+
+### Two-phase rule for breaking changes
+
+1. **Add** the new shape; both old and new work.
+2. **Remove** the old shape after callers migrate.
+
+Never break-and-remove in the same release.
+
+### Deprecation path
+
+```typescript
+/**
+ * @deprecated Use {@link parseOrderV2} — this signature loses currency information.
+ * Will be removed in v3.0.
+ */
+export function parseOrder(input: string): OrderV1 { /* ... */ }
+```
+
+- Mark with `@deprecated` JSDoc so editors warn the caller.
+- Provide the replacement and a clear migration note.
+- Optionally `console.warn` once per process — do not warn per call.
+- Set a removal target (version or date) and stick to it.
+
+### Schema evolution
+
+- **Additive changes** (new optional field, new enum variant) are usually safe.
+- **Subtractive changes** (removing a field, narrowing a type) require a deprecation pass first.
+- Every consumer of a wire schema must validate (`Schema.parse`) — otherwise schema evolution silently breaks consumers.
+  See `error-handling.md` Schema-First Validation.
+
+## 4. Working with Legacy Code
+
+Different rules apply when modifying code you did not write.
+A clean-code rewrite of a 5-year-old module is rarely the right move.
+
+### Order of operations
+
+1. **Characterise.**
+   Add tests that capture what the code currently does — bugs included.
+   Without these, refactoring is gambling.
+2. **Make it safe to change.**
+   Extract small seams (a function, a parameter, an interface) that let you test the part you need to touch.
+3. **Make the change.**
+   Apply the rules in this skill to the part you are touching.
+4. **Stop.**
+   Out-of-scope cleanup belongs in a separate PR.
+
+### Boy Scout Rule (with limits)
+
+Leave the file slightly better than you found it — but do not rewrite it.
+A renamed variable, a deleted dead branch, a guard clause unstacked — these are fine.
+A wholesale restructure mid-feature-PR is not.
+
+### Anti-patterns
+
+- "While I'm here, let me also..." — scope creep that makes review impossible.
+- "The whole module is bad; let me start over" — usually loses behavioural details that turn into bug reports.
+- Deleting tests because they "look outdated" — the tests are the only documentation of the prior behaviour.
+
+## 5. Diff Hygiene
+
+Make the review easier on the reviewer.
+
+- **Logical commits.**
+  Each commit makes sense on its own and could be reverted independently.
+- **Self-explanatory commit messages.**
+  The first line summarises *why*; the body fills in the *how* if non-obvious.
+  See the repo's existing commit style.
+- **Do not reformat files you are touching for substance.**
+  Reformat in a separate, label-only commit (or PR) so the substantive diff is reviewable.
+- **One concern per file change.**
+  If a file change touches three concerns, the PR probably should have been three PRs.
+
+## 6. Communication in Reviews
+
+Lifted from `review-checklist.md` "Tone" — repeated here because reviewing is collaboration:
+
+- Lead with the *why*, not the prescription.
+- Show the change with a concrete diff, not a paragraph.
+- Acknowledge what is working.
+- Match severity to impact — do not mark stylistic preferences "high priority".
+
+## 7. Future-Proofing Smell (Cross-Reference)
+
+The collaboration counterpart to "do not pre-build for futures that haven't arrived":
+
+- Unused parameters / options "for future use" → delete.
+- Abstractions with one concrete implementation → inline.
+- Feature flags wrapping non-released code paths → justified or removed.
+- Backwards-compatibility shims for code nobody calls → delete.
+
+Code that lives forever despite no caller is a maintainability tax compounding silently.

--- a/skills/code-quality/rules/correctness.md
+++ b/skills/code-quality/rules/correctness.md
@@ -1,0 +1,240 @@
+---
+title: 'Correctness — Bug-Class Hotspots'
+impact: HIGH
+tags:
+  - correctness
+  - idempotency
+  - money
+  - dates
+  - determinism
+  - async
+  - resources
+---
+
+# Correctness
+
+Categories of bugs that no general principle catches but that disproportionately ship.
+Each section is short on theory and long on rules — these are the things to enforce, not debate.
+
+## 1. Idempotency
+
+Any operation that may be retried — HTTP POST, queue handler, RPC, file write, payment — must be safe to invoke twice.
+
+### Rules
+
+- **HTTP semantics.** PUT and DELETE are idempotent by spec; POST is not.
+  If a POST creates, accept an `Idempotency-Key` header and dedupe server-side.
+- **Queue handlers.** Dedupe by message ID before side-effecting.
+  At-least-once delivery is the default in every real queue.
+- **Create-or-return-existing beats create-then-409.**
+  ```typescript
+  // Avoid — the second retry crashes the caller
+  await db.users.insert({ id, email });
+
+  // Prefer — second call is a no-op
+  await db.users.upsert({ id, email });
+  ```
+- **External calls** (payments, emails, webhooks) should carry an idempotency token the provider supports.
+  If the provider does not, log enough to dedupe yourself.
+
+### What is not idempotent
+
+- "Increment counter by 1".
+- "Append to log".
+- "Send email" (without a dedupe key).
+
+These need explicit dedupe layers if they sit behind a retryable boundary.
+
+## 2. Money — Never `number`
+
+Floating point cannot represent decimal currency exactly:
+
+```typescript
+0.1 + 0.2 === 0.3   // false
+```
+
+### Rules
+
+- Store money as **integer minor units** (cents, satoshis) or use a decimal library (`big.js`, `decimal.js`, `Money` types).
+- Only convert to a display string at the rendering boundary (`Intl.NumberFormat`).
+- Rounding mode is a deliberate choice:
+  - **Half-to-even (banker's rounding)** for accounting totals — avoids systemic bias.
+  - **Half-up** for user-facing display.
+  Do not use the default rounding for both.
+- Currency is part of the type: `{ amount: 1500, currency: 'USD' }`, not bare numbers.
+  Mixed-currency arithmetic is a bug — branded types prevent it (see `abstraction.md` §2).
+
+## 3. Floats: Equality Needs Epsilon
+
+```typescript
+// Almost always wrong
+if (a === b) { ... }
+
+// For floats, use a tolerance
+if (Math.abs(a - b) < EPS) { ... }
+```
+
+For exact comparisons (prices, scores, indices), convert to integers (basis points, ticks) and compare exactly.
+
+## 4. Dates and Time
+
+Date bugs ship constantly because `Date` is mutable, timezone-sensitive, and conflates instants with calendar dates.
+
+### Rules
+
+- **Store UTC, render in local.**
+  The wire and the database hold UTC; the UI converts at render.
+- **Distinguish instant from calendar date.**
+  "When did the event happen?" is an instant.
+  "What is the user's birthday?" is a calendar date with no time.
+  Use different types (`Date` for instant; `LocalDate` / a string `YYYY-MM-DD` for calendar dates).
+- **Durations are not dates.**
+  `Duration` (an interval) and `Instant` (a moment) are different types.
+  Adding two `Date`s is meaningless.
+- **Do not mutate `Date` objects.**
+  `setHours`, `setDate`, etc. mutate in place.
+  Create new instances or use a date library (`date-fns`, `temporal`, `luxon`).
+- **ISO 8601 on the wire**, rich types in domain code.
+  Parse at the boundary, render at the egress.
+
+## 5. Identifiers
+
+IDs are opaque: they identify, they do not measure or order.
+
+### Rules
+
+- **Brand the type.**
+  ```typescript
+  type UserId = string & { readonly __brand: 'UserId' };
+  ```
+  Mixing `UserId` and `OrderId` becomes a compile error.
+- **Do not infer business rules from sequential IDs.**
+  "User 1000 was created before user 999" is true today and false tomorrow.
+- **Prefer UUIDs / ULIDs / KSUIDs** over auto-increment for any ID exposed externally.
+  Sequential IDs leak business volume and are guessable.
+
+## 6. Encoding
+
+Encoding bugs (XSS, double-encoding, mojibake) come from escaping at the wrong layer or not at all.
+
+### Rules
+
+- UTF-8 in, UTF-8 out, unless explicitly otherwise.
+- **Escape at the layer that interprets**:
+  - HTML escape at the renderer (the templating engine usually does this).
+  - SQL parameterise at the query (never string-concatenate values into SQL).
+  - URL-encode at URL construction.
+  - Shell-escape never — use `spawn` with an argv array, not `exec` with a string.
+- Do not pre-escape for downstream layers — they will escape again.
+
+## 7. Determinism
+
+A function that calls `Date.now()`, `Math.random()`, or reads `process.env` directly is not pure.
+It cannot be tested deterministically.
+
+### Inject the dependencies
+
+```typescript
+// Avoid — flaky test waiting to happen
+function expiresAt(ttlMs: number): Date {
+  return new Date(Date.now() + ttlMs);
+}
+
+// Prefer — pure, trivially testable
+function expiresAt(now: Date, ttlMs: number): Date {
+  return new Date(now.getTime() + ttlMs);
+}
+```
+
+The same applies to:
+
+- `Math.random()` → inject an RNG.
+- ID generation → inject an `IdGenerator`.
+- `process.env` reads → read once at the composition root, pass config in.
+
+The shell at the edge resolves the real clock / RNG / env; the core sees parameters.
+This pairs with `architecture.md` §3 (Functional Core, Imperative Shell).
+
+## 8. Pre/Post Conditions, Invariants, Assertions
+
+Use assertions to encode constraints the type system cannot:
+
+```typescript
+function dequeue<T>(q: Queue<T>): T {
+  assert(q.length > 0, 'dequeue from empty queue');
+  return q.items.shift()!;
+}
+
+function assertNever(x: never): never {
+  throw new Error(`unhandled variant: ${JSON.stringify(x)}`);
+}
+```
+
+- Keep invariants on at runtime in non-perf-critical code.
+- Strip them only after measuring that they are a bottleneck.
+- Use `assertNever` in exhaustive switches; the compiler turns missed cases into build failures.
+
+## 9. Async and Concurrency
+
+### Serial vs. parallel `await`
+
+```typescript
+// Serial — each iteration waits
+for (const id of ids) {
+  await fetchUser(id);
+}
+
+// Parallel — all in flight at once
+const users = await Promise.all(ids.map(fetchUser));
+```
+
+Pick one consciously.
+A `for await` loop iterating I/O sequentially is almost always a performance bug.
+
+### Cancellation
+
+I/O that may outlive its caller (HTTP request, DB query, file read) accepts an `AbortSignal`.
+Long-running handlers in a request should pass `req.signal` through so cancellation is observed.
+
+### Race conditions
+
+If two concurrent operations can interleave on the same state, you need a lock or an atomic operation.
+"It probably will not happen" is a heisenbug waiting for production.
+
+### `Promise.race` is dangerous when losers have side effects
+
+Losing branches keep running.
+Use `AbortController` to actually cancel them.
+
+## 10. Resource Management
+
+Every `open` has a `close`.
+Leaked handles, connections, sockets, subscriptions, timers, and listeners compound until something falls over.
+
+### Patterns
+
+```typescript
+// JS / TS — try/finally
+const handle = await open(path);
+try {
+  await use(handle);
+} finally {
+  await handle.close();
+}
+
+// TS 5.2+ — `using`
+{
+  using handle = await openWithDispose(path);
+  await use(handle);
+}   // close runs automatically
+```
+
+### Common leaks to watch for
+
+- Event listeners added in a setup function with no teardown.
+- Timers (`setInterval`) without a paired `clearInterval`.
+- DB transactions that bail out without rollback on error.
+- Streaming responses that hold the connection open after the consumer disconnects.
+- Subscriptions in long-lived contexts (workers, daemons) that accumulate per request.
+
+For long-lived resources, prefer RAII-style wrappers that own the lifecycle.

--- a/skills/code-quality/rules/error-handling.md
+++ b/skills/code-quality/rules/error-handling.md
@@ -28,6 +28,7 @@ These are untrusted; validate everything:
 
 Use schema validation (Zod, Pydantic, JSON Schema) at these boundaries
 so the rest of the code can assume valid input.
+See `Schema-First Validation` below for the recommended pattern.
 
 ### Inside the System (trust)
 
@@ -53,6 +54,187 @@ function calculateTotal(order) {
 
 If `order` could legitimately be `null`, that's a guard at the entry
 point — but only one, not five.
+
+## Schema-First Validation (Parse, Don't Validate)
+
+Define **one** schema for each external shape, then **infer the type from
+the schema**. The schema is the single source of truth for both the
+runtime check and the static type — the two cannot drift because there is
+only one declaration.
+
+This is the typed-language counterpart to the Single Source of Truth
+pattern in `maintainability.md` §2: one source, two consumers (the type
+checker and the runtime parser).
+
+The TypeScript-with-Zod recipe below applies almost identically to
+Pydantic (Python), valibot/ArkType (TS), and Ecto changesets (Elixir) —
+the principle is what matters, not the library.
+
+### Pattern
+
+```typescript
+import { z } from 'zod';
+
+// 1. Define the schema once, at module scope.
+export const UserSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  displayName: z.string().min(1).max(80),
+  createdAt: z.coerce.date(),
+});
+
+// 2. Infer the type from the schema. Do NOT also declare `type User = {...}`
+//    — that creates two declarations that will drift.
+export type User = z.infer<typeof UserSchema>;
+
+// 3. Parse at the boundary. After this line, the value is typed as `User`
+//    and the rest of the code can trust it.
+export function loadUser(raw: unknown): User {
+  return UserSchema.parse(raw);
+}
+```
+
+After `parse`, every internal function takes `User` and never re-validates.
+The defensive null checks in the previous section become unnecessary
+because the type system has already proven the shape.
+
+### Anti-pattern: separate type and schema
+
+```typescript
+// Avoid: two declarations of the same shape — they will drift
+type User = {
+  id: string;
+  email: string;
+  displayName: string;
+  createdAt: Date;
+};
+
+const userSchema = z.object({
+  id: z.string(),       // missing .uuid() — drift
+  email: z.string(),    // missing .email() — drift
+  displayName: z.string(),
+  // missing createdAt entirely — drift
+});
+```
+
+This is the most common drift bug in TypeScript codebases. The type says
+one thing, the validator checks another, and bugs ship through the gap.
+
+### Modular Composition (when, and only when, it pays)
+
+Schemas compose, so reusable sub-shapes can become their own schemas:
+
+```typescript
+export const AddressSchema = z.object({
+  street: z.string(),
+  city: z.string(),
+  countryCode: z.string().length(2),
+});
+export type Address = z.infer<typeof AddressSchema>;
+
+export const UserSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().email(),
+  shippingAddress: AddressSchema,
+  billingAddress: AddressSchema,
+});
+```
+
+`AddressSchema` is now the single source of truth for what an address is.
+Both fields share the validation, both share the inferred type, and a
+new field added to addresses propagates to every consumer in one edit.
+
+### When to split out a sub-schema
+
+Split only when at least one of these is true:
+
+- The sub-shape is **reused** across two or more parent schemas (the
+  rule of three: be willing to extract on the second real use).
+- The sub-shape has **its own boundary** — its own API endpoint, its own
+  form, its own DB table — where it must be validated in isolation.
+- The sub-shape is independently **versioned or evolved** (e.g., shared
+  with another service).
+- A **partial slice** of the parent must be parsed on its own (e.g.,
+  PATCH endpoints accepting just `AddressSchema.partial()`).
+
+### When NOT to split — keep it inline
+
+Default to a flat, inline schema. Do not split when:
+
+- The sub-shape exists in exactly one parent and has no separate boundary.
+- The split would only "feel cleaner" — that is over-engineering.
+  A 30-line nested `z.object` is fine if the shape is used once.
+- The split would create a sub-schema with the same name suffix as its
+  parent (`UserMetadataSchema` used only inside `UserSchema`) — that is a
+  naming smell signalling the abstraction has no second consumer.
+
+The same trade-off as the maintainability decision tree: **wait for a real
+second consumer before extracting a sub-schema**.
+
+### `parse` vs. `safeParse`
+
+- **`parse(input)`** throws on invalid data. Use this when invalid input
+  is a programming bug or an upstream system contract violation —
+  internal API boundaries, config files you control, deserialised state.
+- **`safeParse(input)`** returns `{ success, data | error }`. Use this for
+  user-facing input where you need to render the error back to the user
+  (forms, public APIs, CLI arguments).
+
+```typescript
+// Public API — return structured errors
+const result = UserSchema.safeParse(req.body);
+if (!result.success) {
+  return res.status(400).json({ errors: result.error.flatten() });
+}
+const user = result.data;
+
+// Internal trusted boundary — throw is fine
+const config = ConfigSchema.parse(loadConfigFile());
+```
+
+### Refinements and Branded Types
+
+When a primitive carries a constraint that the type `string` cannot
+express (a UUID, a non-empty trimmed string, a valid email), bake it
+into the schema once and brand the type so it cannot be confused with a
+raw string at call sites.
+
+```typescript
+export const EmailSchema = z.string().email().brand<'Email'>();
+export type Email = z.infer<typeof EmailSchema>;
+
+function sendWelcome(to: Email) { /* ... */ }
+
+// Compile error — raw string cannot be passed where Email is required
+sendWelcome('not-validated@example.com');
+
+// OK — must go through the schema
+sendWelcome(EmailSchema.parse('user@example.com'));
+```
+
+This pushes "is this validated?" from a runtime question to a compile-time
+one, removing whole classes of "I forgot to validate" bugs.
+
+### Schemas as Documentation
+
+A schema doubles as a runtime-checkable spec for the shape. Prefer it to
+a separate JSDoc/Markdown description that will rot. If an external
+client needs the schema documented, generate it (`zod-to-openapi`,
+`zod-to-json-schema`) — do not hand-maintain a second description.
+
+### Common Mistakes
+
+- **Defining the schema inside a request handler.** Schemas are constants;
+  hoist to module scope so they are not rebuilt per request.
+- **Using `z.any()` or `z.unknown()` to silence a type error.** That
+  defeats the whole pattern. If a field's shape is not yet known, model
+  the unknown explicitly (`z.record(z.unknown())`) and refine it as the
+  contract clarifies.
+- **Re-validating internally.** Once parsed at the boundary, the value is
+  typed; do not call `UserSchema.parse(user)` again deeper in the stack.
+- **Using `transform` to hide business logic.** `transform` is for shape
+  normalisation (trim strings, coerce dates), not for computing derived
+  domain values — those belong in named functions on the parsed type.
 
 ## Fail Fast and Loudly
 

--- a/skills/code-quality/rules/maintainability.md
+++ b/skills/code-quality/rules/maintainability.md
@@ -1,0 +1,256 @@
+---
+title: 'Maintainability — Reuse, Single Source of Truth, Locality of Change'
+impact: HIGH
+tags:
+  - maintainability
+  - reuse
+  - dry
+  - single-source-of-truth
+  - shotgun-surgery
+---
+
+# Maintainability
+
+Code is read many times and changed many times.
+The cost of a feature is dominated by how many places you must touch — and remember to keep in sync — when something evolves.
+This rule covers three levers that move that cost the most: reuse, single source of truth, and locality of change.
+
+It sits in deliberate tension with `functions.md` ("avoid premature generalization") and the "DRY vs. clarity" default in `SKILL.md`.
+The resolution is in **When to reuse vs. when to duplicate** below — read it before extracting or consolidating.
+
+## 1. Reuse Before Creating
+
+Before writing a helper, formatter, validator, type, constant, or hook, **search the codebase for one that already exists**.
+A second implementation of the same concept is worse than no implementation at all: behaviour drifts, bugs get fixed in one copy and not the other, and the next reader does not know which one is canonical.
+
+### The search-first procedure (authoring mode)
+
+Run this before writing a new utility:
+
+1. **Grep for the domain noun.**
+   `formatCurrency`, `parseDate`, `slugify`, `userIdSchema`.
+   Try the obvious name and one synonym.
+2. **Grep for the operation shape.**
+   If you are about to write `arr.reduce((acc, x) => ...)`, search for that reduce body — the project may have a `sumBy`, `groupBy`, or `keyBy` already.
+3. **Look at neighbour files.**
+   Files in the same module/package usually expose the helpers used in that domain.
+   New code should look like its neighbours.
+4. **Check the standard library and existing dependencies.**
+   `Object.groupBy`, `structuredClone`, `Array.prototype.flatMap`, `Intl.NumberFormat`, lodash, date-fns, the framework's own utilities — do not reimplement what ships in the runtime or a dependency you already have.
+5. **Only if nothing fits, write a new one — and put it where the next person will find it.**
+   Co-locate with the existing utilities of the same domain.
+
+### What to do when you find a near-match
+
+| Situation | Action |
+|---|---|
+| Exact match | Use it. Do not write a parallel one. |
+| Close match, your need is one parameter / option away | Extend the existing helper if the new option makes sense for all callers; otherwise compose around it. |
+| Close match, but the existing helper is wrong (buggy, unclear, untyped) | Fix the existing helper and migrate callers. Do not add a "v2" alongside it. |
+| Different domain, similar shape | Leave them separate. Two functions that happen to look alike are not duplication if they describe different concepts. |
+
+### Anti-patterns
+
+- **Parallel utilities with slightly different names**: `formatPrice`, `formatMoney`, `toCurrency`, `displayAmount` all in the same codebase.
+  Pick one, delete the rest.
+- **Re-deriving constants**: `MAX_RETRIES = 3` defined in five files.
+  Hoist to one module.
+- **Re-implementing a framework primitive**: writing your own debounce when the framework's hook is already imported elsewhere.
+
+## 2. Single Source of Truth for Union-Type Data
+
+When a union type (string literal union, enum, discriminated union, status set) has associated metadata — labels, icons, colours, permissions, sort order, default values — **store it in one record keyed by the union, not in N parallel maps**.
+
+Parallel maps over the same union are the most common form of shotgun surgery: adding a new variant means hunting down every map and updating it, and the type system cannot tell you which ones you missed.
+
+### Anti-pattern: parallel maps
+
+```typescript
+type OrderStatus = 'draft' | 'pending' | 'paid' | 'shipped' | 'delivered';
+
+const STATUS_LABELS: Record<OrderStatus, string> = {
+  draft: 'Draft',
+  pending: 'Awaiting payment',
+  paid: 'Paid',
+  shipped: 'Shipped',
+  delivered: 'Delivered',
+};
+
+const STATUS_COLORS: Record<OrderStatus, string> = {
+  draft: 'gray',
+  pending: 'yellow',
+  paid: 'blue',
+  shipped: 'purple',
+  delivered: 'green',
+};
+
+const STATUS_ICONS: Record<OrderStatus, string> = {
+  draft: 'pencil',
+  pending: 'clock',
+  paid: 'credit-card',
+  shipped: 'truck',
+  delivered: 'check',
+};
+
+const STATUS_IS_TERMINAL: Record<OrderStatus, boolean> = {
+  draft: false,
+  pending: false,
+  paid: false,
+  shipped: false,
+  delivered: true,
+};
+```
+
+Adding a new status (`'cancelled'`) means updating four maps in four locations.
+Miss one and TypeScript will complain — but only if every map is `Record<OrderStatus, …>`; lose that constraint anywhere and the bug ships.
+
+### Pattern: one record, structured value
+
+```typescript
+type OrderStatus = 'draft' | 'pending' | 'paid' | 'shipped' | 'delivered';
+
+type OrderStatusMeta = {
+  label: string;
+  color: string;
+  icon: string;
+  isTerminal: boolean;
+};
+
+const ORDER_STATUS: Record<OrderStatus, OrderStatusMeta> = {
+  draft:     { label: 'Draft',             color: 'gray',   icon: 'pencil',      isTerminal: false },
+  pending:   { label: 'Awaiting payment',  color: 'yellow', icon: 'clock',       isTerminal: false },
+  paid:      { label: 'Paid',              color: 'blue',   icon: 'credit-card', isTerminal: false },
+  shipped:   { label: 'Shipped',           color: 'purple', icon: 'truck',       isTerminal: false },
+  delivered: { label: 'Delivered',         color: 'green',  icon: 'check',       isTerminal: true  },
+};
+```
+
+Adding `'cancelled'` is a single edit in a single place, and TypeScript's exhaustiveness check fails the build if any field is missing.
+Accessors stay trivial: `ORDER_STATUS[status].label`.
+
+### When to apply this consolidation
+
+- The keys are the same union, **and**
+- The maps are conceptually about *the same concept* (status, role, kind, type), **and**
+- The values are independent metadata fields, not large unrelated payloads.
+
+If two maps happen to share a key set but model different concepts (e.g., `USER_PERMISSIONS` and `USER_AVATAR_URLS` both keyed by user id), keep them separate — they are different domains that just happen to share an index.
+
+### Functions over records
+
+If the value depends on runtime data, replace `STATUS_X` lookup with a function that takes the structured record:
+
+```typescript
+function nextActionFor(order: Order): string | null {
+  const meta = ORDER_STATUS[order.status];
+  if (meta.isTerminal) return null;
+  return order.paid ? 'Ship order' : 'Take payment';
+}
+```
+
+The union still has one source of truth (`ORDER_STATUS`); the logic that *uses* it lives next to the type.
+
+## 3. Locality of Change
+
+The "shotgun surgery" smell: a single conceptual change forces edits in many unrelated files.
+Maintainable code minimises the **change footprint** — the number of files and lines you must touch when a single concept evolves.
+
+### The footprint test
+
+Before merging a change, ask: **"If we add the next obvious variant of this concept, how many files do we have to edit, and is the type system going to catch us if we miss one?"**
+
+| Footprint | Verdict |
+|---|---|
+| 1 file, type-checked | Excellent. Ship. |
+| 2–3 files, type-checked | Acceptable, especially across architectural layers (schema, API, UI). |
+| 4+ files, or any of them not type-checked | Refactor. Consolidate before adding the next variant. |
+
+### Common shotgun-surgery shapes
+
+- Parallel maps over a union (see section 2).
+- Switch statements on the same union scattered across files instead of a single `match` co-located with the union.
+- Constants duplicated in `frontend/`, `backend/`, and `shared/` instead of one shared module.
+- Validation rules redeclared at every API endpoint instead of one schema reused.
+- Feature flags read in many places instead of one capability-check function.
+
+### Co-locate data with the operations on it
+
+A union type and the metadata + functions that operate on it should live in the same file (or same small module).
+A reader who lands on `OrderStatus` should not have to grep across the project to find what each status *means* and *does*.
+
+```
+order-status.ts
+├── type OrderStatus
+├── const ORDER_STATUS (the metadata record)
+├── function isTerminal(status)
+├── function nextStatus(status)
+└── function statusLabel(status)
+```
+
+This is also where new variants get added, so the change footprint stays at one file.
+
+## 4. When to Reuse vs. When to Duplicate
+
+This is the rule that resolves the tension with `functions.md`'s "avoid premature generalization" and the "DRY vs. clarity" default.
+
+### Reuse (consolidate, extract, or de-duplicate) when
+
+- The same concept is represented in two places.
+  Same domain noun, same business meaning.
+- The two places must always change together to stay correct.
+  If fixing a bug in one means fixing it in the other, they are one thing wearing two hats.
+- The shared shape is over a closed set (a union type, an enum, a fixed schema).
+  Closed sets benefit hugely from a single source of truth — the type system enforces completeness.
+- A utility already exists.
+  Reusing existing code is never "premature"; it is the cheap path.
+
+### Duplicate (keep separate, do not extract) when
+
+- Two pieces of code look alike but model different concepts.
+  Coincidental similarity is not duplication.
+- The shared abstraction would need 3+ flag/option parameters to satisfy both callers.
+  That is a sign you are forcing two different things through one shape.
+- You only have two examples and no third on the horizon.
+  The "rule of three": wait for the third real caller before extracting a generic helper.
+  Two slightly-different 5-line blocks beat one 12-line generic helper that takes flags.
+- The duplication is in test code where each test is meant to read independently.
+
+### The decision tree
+
+```
+Is there an existing utility that fits?
+├── Yes → use it. Stop.
+└── No
+    ├── Is this the same concept appearing in 2+ places?
+    │   ├── Yes, and they must change together → consolidate now.
+    │   └── No → write the concrete version. Revisit when a 3rd caller appears.
+    └── Are you tempted to add option flags to make a helper "flexible"?
+        └── Stop. Write the concrete version. Generalise when a real second caller exists.
+```
+
+## 5. Quick Maintainability Heuristics
+
+Apply these while writing or reviewing:
+
+1. **One concept, one home.**
+   A status, role, or feature flag has one canonical declaration; everything else imports it.
+2. **Adding the next variant should be one edit.**
+   If it is not, the structure is wrong — fix the structure before adding the variant.
+3. **Imports tell a story.**
+   A file that imports from ten unrelated modules is probably doing too much, or the modules are poorly factored.
+4. **Match the patterns next door.**
+   New code that looks like a stranger in its own folder forces every reader to context-switch.
+5. **Prefer types that make illegal states unrepresentable** over runtime checks that detect them.
+   The earliest place a bug can be caught is the cheapest place to fix it.
+6. **Co-locate the "what" with the "how".**
+   The type definition, its metadata, and its operations belong in one module — not scattered across `types/`, `constants/`, and `utils/`.
+
+## What Maintainability Is Not
+
+- **Maintainability is not maximum DRY.**
+  Forced abstractions that only one or two callers use are anti-maintainability — they couple unrelated code together and grow flag parameters over time.
+- **Maintainability is not "design for every future need".**
+  Future-proofing for needs that never arrive is the opposite of maintainable: dead options become traps for the next reader.
+- **Maintainability is not endless refactoring.**
+  Stop when the change footprint is small and the next variant is obviously a one-file edit.
+  Perfect is a moving target; "easy to change tomorrow" is the goal.

--- a/skills/code-quality/rules/maintainability.md
+++ b/skills/code-quality/rules/maintainability.md
@@ -136,6 +136,20 @@ Accessors stay trivial: `ORDER_STATUS[status].label`.
 
 If two maps happen to share a key set but model different concepts (e.g., `USER_PERMISSIONS` and `USER_AVATAR_URLS` both keyed by user id), keep them separate — they are different domains that just happen to share an index.
 
+### Schemas as the source of truth for boundary shapes
+
+The same single-source-of-truth principle applies to validated input/output shapes.
+Define one schema (Zod, Pydantic, valibot, ArkType, etc.), then **infer the static type from the schema** rather than declaring both separately.
+A separate `type User` and `userSchema` will drift; one declaration cannot.
+
+```typescript
+export const UserSchema = z.object({ id: z.string().uuid(), email: z.string().email() });
+export type User = z.infer<typeof UserSchema>;
+```
+
+Compose nested schemas (`AddressSchema`, then `UserSchema` referencing it) **only when the sub-shape is genuinely reused or has its own boundary** — otherwise leave the schema flat.
+The full pattern, including when to split sub-schemas and when to keep them inline, lives in `error-handling.md` under "Schema-First Validation".
+
 ### Functions over records
 
 If the value depends on runtime data, replace `STATUS_X` lookup with a function that takes the structured record:

--- a/skills/code-quality/rules/refactor-recipes.md
+++ b/skills/code-quality/rules/refactor-recipes.md
@@ -1,0 +1,221 @@
+---
+title: 'Refactor Recipes — Named, Citeable Refactors'
+impact: MEDIUM
+tags:
+  - refactor
+  - recipes
+  - review
+---
+
+# Refactor Recipes
+
+Named refactors so reviews can cite a recipe by ID instead of describing it from scratch.
+"Apply R1 (Consolidate Parallel Maps)" is faster, more actionable, and less ambiguous than free-form prose.
+
+## How to use this catalog
+
+In review output:
+
+```
+- src/orders/status.ts:12 — parallel maps over OrderStatus → apply R1
+- src/billing/charge.ts:84 — function calls Date.now() directly → apply R9
+- src/api/parse-user.ts:5 — hand-written type next to schema → apply R6
+```
+
+In authoring mode, recipes are reminders during the REFACTOR phase of TDD.
+
+---
+
+## R1: Consolidate Parallel Maps
+
+**Trigger:** 2+ maps keyed by the same union (`STATUS_LABEL`, `STATUS_COLOR`, `STATUS_ICON`).
+**Replace with:** one `Record<Union, { ...metadata }>`.
+**Why:** Adding a variant becomes one edit, not N. The type system enforces completeness.
+**See:** `maintainability.md` §2.
+
+---
+
+## R2: Hoist Shared Constant
+
+**Trigger:** Same magic value (`MAX_RETRIES = 3`, `'2024-01-01'`, an env-var key) duplicated across files.
+**Replace with:** One named constant in the module owning the concept.
+**Why:** One concept, one home. Drift becomes impossible.
+**See:** `maintainability.md` §3.
+
+---
+
+## R3: Replace Conditional with Lookup
+
+**Trigger:** `if/else if` chain dispatching on a value rather than a condition.
+**Replace with:** Lookup table or strategy map.
+**Why:** Data structure beats control flow; extension is one line.
+**See:** `control-flow.md`.
+
+---
+
+## R4: Extract Guarded Function
+
+**Trigger:** Long function with multiple early-exit conditions buried in nesting.
+**Replace with:** Guard clauses at the top, happy path unindented below.
+**Why:** Linear flow beats branching.
+**See:** `control-flow.md`.
+
+---
+
+## R5: Co-locate Type with Operations
+
+**Trigger:** Type, its metadata, and its operations scattered across `types/`, `constants/`, `utils/`.
+**Replace with:** One module owning the union, its metadata, and its operations.
+**Why:** A reader who lands on the type sees its semantics without grepping.
+**See:** `maintainability.md` §3.
+
+---
+
+## R6: Replace Type Declaration with Inferred Type
+
+**Trigger:** Parallel `type Foo = {...}` and `fooSchema = z.object({...})` for the same shape.
+**Replace with:** One schema; `type Foo = z.infer<typeof FooSchema>`.
+**Why:** Two declarations drift; one cannot.
+**See:** `error-handling.md` Schema-First Validation.
+
+---
+
+## R7: Replace Validation with Schema
+
+**Trigger:** Hand-rolled `if (typeof x === 'string' && x.length > 0)` checks at boundaries.
+**Replace with:** `Schema.parse(x)` once at the boundary.
+**Why:** Schema is a runtime spec and the source of the type. Validation lives in one place.
+**See:** `error-handling.md`.
+
+---
+
+## R8: Push Impurity Outward
+
+**Trigger:** Function that does both computation and I/O.
+**Replace with:** Pure compute function + caller that handles I/O.
+**Why:** Pure code is testable for free; the shell stays thin.
+**See:** `architecture.md` §3.
+
+---
+
+## R9: Inject the Clock / RNG / IDs
+
+**Trigger:** Function calls `Date.now()`, `Math.random()`, or generates IDs internally; tests are flaky or rely on real time.
+**Replace with:** Pass the clock / RNG / ID generator as a parameter or constructor argument.
+**Why:** Determinism. Pure functions are testable; impure functions are flaky.
+**See:** `correctness.md` §7, `testability.md`.
+
+---
+
+## R10: Total-ise the Function
+
+**Trigger:** Function throws for "not found" or returns `-1` / `""` / `0` for "missing".
+**Replace with:** Return `null` for absent-by-design or `Result<T, E>` for expected failures.
+**Why:** Total functions are easier to test exhaustively and call sites become explicit.
+**See:** `api-design.md` §4.
+
+---
+
+## R11: Brand the Primitive
+
+**Trigger:** Raw `string` for `Email`, `UserId`, `Currency`, `OrderId`; the type system cannot catch mix-ups.
+**Replace with:** Branded type via the validating schema (`z.string().uuid().brand<'UserId'>()`).
+**Why:** Mixing IDs becomes a compile error, not a production bug.
+**See:** `abstraction.md` §2, `error-handling.md` Branded Types.
+
+---
+
+## R12: Discriminate the Error Union
+
+**Trigger:** Every error path throws the same `Error` with a different `message`; handlers parse messages to decide what to do.
+**Replace with:** Discriminated `AppError` union with structured fields.
+**Why:** Exhaustive matching at every error site; structured fields beat string parsing.
+**See:** `api-design.md` §5.
+
+---
+
+## R13: Inline the Premature Sub-Schema
+
+**Trigger:** `XxxMetadataSchema` used only inside `XxxSchema`; no second consumer.
+**Replace with:** Inline back into the parent schema.
+**Why:** Sub-schemas split only on real reuse, separate boundary, or independent partial parsing.
+**See:** `error-handling.md` Modular Composition.
+
+---
+
+## R14: Replace Boolean Parameter with Two Functions
+
+**Trigger:** `process(items, true, false)` — boolean flags at the call site are unreadable.
+**Replace with:** Two named functions or an enum variant.
+**Why:** Names tell the reader what `true` and `false` mean; flags do not.
+**See:** `functions.md` Boolean Parameters.
+
+---
+
+## R15: Lift Illegal State Out of the Type
+
+**Trigger:** Optional fields that should never both be missing or both be set; runtime checks enforce the invariant.
+**Replace with:** Discriminated union that makes the illegal combination unrepresentable.
+**Why:** The compiler enforces the invariant; runtime checks become unnecessary.
+**See:** `abstraction.md` §2.
+
+---
+
+## R16: Extract by Abstraction Level
+
+**Trigger:** Function body mixes orchestration sentences with low-level mechanics.
+**Replace with:** Each level becomes its own named helper; the parent reads as orchestration only.
+**Why:** Readers stop at the level they care about.
+**See:** `abstraction.md` §1.
+
+---
+
+## R17: Justify or Remove the `any`
+
+**Trigger:** `any` or unjustified cast (`as Foo`) silencing the type checker.
+**Replace with:** A schema parse, a narrowed `unknown`, or — if the escape is genuinely needed — a `// because:` comment explaining why.
+**Why:** Unjustified `any` is the shape most production type bugs take.
+**See:** `abstraction.md` §4.
+
+---
+
+## R18: Make the Operation Idempotent
+
+**Trigger:** Operation that may be retried (POST, queue handler) is not safe to invoke twice.
+**Replace with:** Idempotency key + dedupe, or upsert, or the right HTTP method (PUT/DELETE).
+**Why:** Retries are a fact of distributed systems; non-idempotent retryable operations corrupt state.
+**See:** `correctness.md` §1.
+
+---
+
+## R19: Money to Minor Units
+
+**Trigger:** Currency stored as a JavaScript `number`.
+**Replace with:** Integer minor units (cents, satoshis) or a decimal library; currency tagged on the value.
+**Why:** Floating point cannot represent decimal currency exactly; rounding errors compound.
+**See:** `correctness.md` §2.
+
+---
+
+## R20: Factory over Side-Effecting Import
+
+**Trigger:** Importing a module triggers a side effect (DB connection, registry push, singleton creation).
+**Replace with:** Export `createX(...)`; the composition root calls it when ready.
+**Why:** Import order stops being significant; tests are not accidentally integration tests.
+**See:** `architecture.md` §7.
+
+---
+
+## Recipe Index by File
+
+| File | Recipes |
+|---|---|
+| `maintainability.md` | R1, R2, R5 |
+| `error-handling.md` | R6, R7, R11, R12, R13 |
+| `architecture.md` | R8, R20 |
+| `correctness.md` | R9, R18, R19 |
+| `api-design.md` | R10, R12 |
+| `abstraction.md` | R11, R15, R16, R17 |
+| `control-flow.md` | R3, R4 |
+| `functions.md` | R14 |
+| `testability.md` | R9 |

--- a/skills/code-quality/rules/review-checklist.md
+++ b/skills/code-quality/rules/review-checklist.md
@@ -87,7 +87,39 @@ performance concern.
 - [ ] If micro-optimizations exist, are they documented with measurement
       rationale?
 
-## Pass 7: Future-Proofing Smell
+## Pass 7: Maintainability & Reuse
+
+Load `rules/maintainability.md` for the patterns referenced below.
+
+- [ ] **Reuse check.** Did the author write a helper / formatter /
+      validator / constant that already exists in this codebase, the
+      standard library, or an installed dependency? Grep for the domain
+      noun and a synonym before accepting a new helper.
+- [ ] **Single source of truth for union-type data.** If the change adds
+      labels, colours, icons, permissions, or other metadata for a union
+      / enum, is there one record keyed by the union with structured
+      values, or are there parallel maps (`LABELS`, `COLORS`, `ICONS`,
+      `IS_TERMINAL`)? Parallel maps over the same union are a refactor
+      finding regardless of how few values they hold today.
+- [ ] **Change-footprint test.** If the next variant of this concept were
+      added (one more `OrderStatus`, one more role, one more feature
+      flag), how many files would need to change? Anything beyond ~3, or
+      any change the type system cannot enforce, is a maintainability
+      finding.
+- [ ] **Co-location.** Are the type, its metadata, and the operations on
+      it in one module, or scattered across `types/`, `constants/`,
+      `utils/`, and the call sites?
+- [ ] **Shotgun surgery.** Does the same business rule, constant, or
+      schema appear in multiple places that must be kept in sync by
+      hand? Hoist to one shared module or schema.
+- [ ] **Pattern consistency.** Does the new code look like its
+      neighbours? New code that adopts a different style or a parallel
+      utility forces every reader to context-switch.
+- [ ] **Illegal states.** Could the type system make the bug class
+      impossible (discriminated union, branded type, exhaustive `switch`)
+      instead of relying on runtime checks?
+
+## Pass 8: Future-Proofing Smell
 
 - [ ] Any unused parameters / options "for future use"? Delete.
 - [ ] Any abstractions with one concrete implementation? Inline.
@@ -117,6 +149,10 @@ diffs when feasible.
 ### Estimated cognitive complexity scores
 - functionA: ~6 (acceptable)
 - functionB: ~18 (refactor recommended)
+
+### Estimated change footprint
+- Adding a new OrderStatus today: 4 files (parallel maps) — refactor to one record
+- Adding a new role: 1 file (already a single source of truth) — fine
 ```
 
 ## When to Stop

--- a/skills/code-quality/rules/review-checklist.md
+++ b/skills/code-quality/rules/review-checklist.md
@@ -133,7 +133,121 @@ Load `rules/maintainability.md` for the patterns referenced below.
       impossible (discriminated union, branded type, exhaustive `switch`)
       instead of relying on runtime checks?
 
-## Pass 8: Future-Proofing Smell
+## Pass 8: Abstraction & Type-Driven Design
+
+Load `rules/abstraction.md` for the patterns referenced below.
+
+- [ ] **One level of abstraction per function.** Body does not mix
+      orchestration sentences with low-level mechanics. Apply R16 if it
+      does.
+- [ ] **Illegal states unrepresentable.** Optional fields that should
+      never both be missing (or both set) modelled as a discriminated
+      union, not enforced at runtime. Apply R15.
+- [ ] **Branded primitives at boundaries.** `Email`, `UserId`, `OrderId`
+      are branded types, not raw `string`. Apply R11.
+- [ ] **Exhaustive matching.** `switch` over a union ends with
+      `assertNever(x)` so adding a variant fails the build.
+- [ ] **Generics earn their keep.** Type parameters introduced only
+      where the same algorithm operates over different concrete types,
+      not for one-caller "flexibility".
+- [ ] **`any` and casts justified.** Every `any` / `as Foo` carries a
+      one-line `// because:` comment. Apply R17.
+
+## Pass 9: Architecture
+
+Load `rules/architecture.md`.
+
+- [ ] **Public surface intentional.** Module exports only what callers
+      need; internals stay internal.
+- [ ] **No barrel files** (or, if present, justified — and not creating
+      circular imports).
+- [ ] **Dependency direction.** Domain code imports nothing
+      infrastructure-shaped; circular imports absent.
+- [ ] **Functional core, imperative shell.** Pure decision logic
+      separated from I/O. Apply R8.
+- [ ] **DTO ↔ domain ↔ persistence.** Wire shapes parsed at boundaries;
+      domain types used internally; persistence types do not leak into
+      the UI.
+- [ ] **Immutability defaults.** `const` over `let`; `readonly` on
+      public fields; no shared mutable state without a single owner.
+- [ ] **No side-effecting imports.** Importing a module does not trigger
+      network calls, file writes, or singleton creation. Apply R20.
+
+## Pass 10: API Design
+
+Load `rules/api-design.md`.
+
+- [ ] **Parameter order.** Subject first; required before optional;
+      data before configuration.
+- [ ] **Total functions.** No throws for "expected absence"; no
+      sentinels (`-1`, `""`, `0`). Returns `null` / `Result` instead.
+      Apply R10.
+- [ ] **Error type system.** Discriminated `AppError` union (or
+      equivalent), not `new Error('parse my message')`. Apply R12.
+- [ ] **`Error.cause` preserved** through error transformations.
+- [ ] **Tell, don't ask.** No `a.b.c.d.method()` chains for behaviour
+      (records are exempt — walking pure data is fine).
+- [ ] **File reading order.** Public surface at the top; helpers below
+      in roughly the order they are called.
+
+## Pass 11: Correctness Hotspots
+
+Load `rules/correctness.md`. Apply when the code touches any of these
+domains.
+
+- [ ] **Idempotency.** Retryable operations (POST, queue handlers,
+      external calls) safe to invoke twice. Apply R18.
+- [ ] **Money.** Stored as integer minor units or decimal library;
+      currency tagged. Never `number`. Apply R19.
+- [ ] **Floats.** Equality compared with epsilon; or values converted to
+      integers for exact comparison.
+- [ ] **Dates.** UTC stored, local rendered; `Date` not mutated;
+      durations distinguished from instants.
+- [ ] **Identifiers.** Branded; not used as ordering proxies.
+- [ ] **Encoding.** Escaping at the layer that interprets (HTML at
+      render, SQL via parameters, URL-encoded at URL build).
+- [ ] **Determinism.** No direct `Date.now()` / `Math.random()` /
+      `process.env` reads inside core logic. Apply R9.
+- [ ] **Async / concurrency.** Serial vs. parallel `await` chosen
+      consciously; cancellation observed; no race conditions on shared
+      state.
+- [ ] **Resource management.** Every `open` has a `close` (try/finally
+      or `using`); listeners and timers torn down.
+- [ ] **Assertions.** Invariants encoded with `assert` / `assertNever`
+      where the type system cannot enforce them.
+
+## Pass 12: Testability
+
+Load `rules/testability.md`.
+
+- [ ] **Cheap to test.** A test for the public behaviour fits in <10
+      lines for a function under 30 lines.
+- [ ] **No hidden non-determinism.** Clock, RNG, IDs injected. Apply R9.
+- [ ] **Pure core surfaced.** Decision logic separable from I/O; tests
+      do not require real DB / network.
+- [ ] **Behaviour, not implementation.** Tests bound to the public API;
+      not pinned to internal helpers.
+- [ ] **Exhaustive coverage of total functions** (present + absent
+      branches for `T | null`).
+- [ ] **For new code authored under this review:** was `tdd` invoked
+      before implementation? If not, was the omission justified?
+
+## Pass 13: Collaboration
+
+Load `rules/collaboration.md`.
+
+- [ ] **Symmetry with neighbours.** New code follows the patterns of
+      sibling files (folder layout, error shape, import order, test
+      style).
+- [ ] **PR scope.** One logical change per PR; refactor and feature
+      separated.
+- [ ] **Migration discipline.** Breaking changes ship in two phases
+      (additive, then subtractive); deprecations marked with
+      `@deprecated` and a removal target.
+- [ ] **Diff hygiene.** Format / whitespace changes separated from
+      substantive changes.
+
+## Pass 14: Future-Proofing Smell
 
 - [ ] Any unused parameters / options "for future use"? Delete.
 - [ ] Any abstractions with one concrete implementation? Inline.

--- a/skills/code-quality/rules/review-checklist.md
+++ b/skills/code-quality/rules/review-checklist.md
@@ -75,6 +75,20 @@ For each non-trivial function (rough mental score per `cognitive-complexity.md`)
 - [ ] Error messages include what failed and useful context?
 - [ ] `catch` blocks scoped narrowly, catching specific exception types?
 - [ ] No empty `catch` blocks or "log and continue" patterns?
+- [ ] **Schema-first validation at boundaries.** Untrusted input parsed
+      through a schema (Zod, Pydantic, valibot) at the boundary, not
+      hand-rolled `if (typeof x === 'string')` checks scattered through
+      the code?
+- [ ] **Single source of truth for shape and type.** Where a schema
+      exists, is the type inferred from it (`z.infer<typeof Schema>`),
+      or is there a parallel hand-written `type` declaration that will
+      drift?
+- [ ] **No re-validation deep in the stack.** Once parsed at the
+      boundary, internal code trusts the type — no defensive
+      `Schema.parse(value)` calls inside trusted internals.
+- [ ] **Sub-schemas split only with cause.** Nested schemas extracted
+      only when reused, when they have their own boundary, or when a
+      partial slice must be parsed independently — not "for tidiness".
 
 ## Pass 6: Performance (only if relevant)
 

--- a/skills/code-quality/rules/testability.md
+++ b/skills/code-quality/rules/testability.md
@@ -1,0 +1,147 @@
+---
+title: 'Testability — Hard-to-Test Code Is Badly Factored'
+impact: HIGH
+tags:
+  - testability
+  - tdd
+  - dependency-injection
+  - functional-core
+---
+
+# Testability
+
+Testability is a leading indicator of maintainability.
+If a function is hard to test, the design is wrong.
+This rule covers the design levers that make tests cheap, and the integration with the `tdd` skill for authoring new code.
+
+## Compose with the `tdd` Skill When Authoring
+
+When the user is **creating new code** — a new function, a new module, a new behaviour — invoke the [`tdd` skill](../../tdd/SKILL.md) to drive the implementation through a strict RED → GREEN → REFACTOR cycle.
+The two skills compose:
+
+- `tdd` decides what to build next and writes the failing test first.
+- `code-quality` ensures the GREEN and REFACTOR passes meet the readability and maintainability bar in this skill.
+
+### When to invoke `tdd`
+
+| Situation | Action |
+|---|---|
+| User asks to implement a new function or feature from scratch | Invoke `tdd` first; apply `code-quality` rules in GREEN and REFACTOR |
+| User asks to add a new behaviour to an existing module | Invoke `tdd` for the new behaviour; modifications to surrounding code follow `code-quality` directly |
+| User asks to refactor / clean up existing code | Stay in `code-quality`; ensure existing tests still pass |
+| User asks for a one-line tweak / typo / config change | Stay in `code-quality`; tests not always required for trivial edits |
+| User explicitly opts out ("no tests", "just write the code") | Honour the request; note that this skill normally pairs with `tdd` |
+
+### How the integration works
+
+```
+User: "add a function that calculates next billing date"
+  │
+  ▼
+code-quality skill detects: new function authoring
+  │
+  ▼
+Skill('tdd')   ◄── invokes the tdd skill
+  │
+  ▼ tdd runs RED → write a failing test
+  ▼ tdd runs GREEN → minimal implementation (code-quality rules apply silently)
+  ▼ tdd runs REFACTOR → improve until clean (code-quality rules apply explicitly)
+  │
+  ▼
+Both skills complete; result is tested, clean code
+```
+
+The composition is silent: the agent does not narrate the handoff; the user sees a clean diff with the test and the implementation.
+
+## Testability as a Quality Signal
+
+A function that is hard to test is signalling a design problem.
+Common shapes and their fixes:
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| Test needs >5 mocks | Too many collaborators / wrong abstraction level | Extract pure core; mock only the shell |
+| Test reads `Date.now()` / `Math.random()` indirectly | Hidden non-determinism | Inject the clock / RNG (see `correctness.md` §7) |
+| Test depends on a real DB / network | I/O tangled with logic | Push impurity outward (see `architecture.md` §3) |
+| Test is >50 lines for a 30-line function | Function under test does too much | Split by responsibility |
+| Test must run in a specific order | Shared mutable state | Give each test fresh state (see `architecture.md` §6) |
+| Test changes whenever an internal helper changes | Tests coupled to implementation | Test the public behaviour, not the internals |
+
+If a test is hard to write, fix the *design* before writing a more elaborate test.
+
+## Design Levers for Cheap Tests
+
+### 1. Inject I/O dependencies
+
+Pass the clock, RNG, fetcher, logger, and ID generator as parameters or constructor arguments.
+The composition root resolves the real implementations; tests pass fakes.
+
+```typescript
+type Clock = { now(): Date };
+
+class TrialService {
+  constructor(private readonly clock: Clock) {}
+
+  expiresAt(ttlMs: number): Date {
+    return new Date(this.clock.now().getTime() + ttlMs);
+  }
+}
+
+// Production wiring
+const service = new TrialService({ now: () => new Date() });
+
+// Test
+const fixed: Clock = { now: () => new Date('2030-01-01') };
+const service = new TrialService(fixed);
+expect(service.expiresAt(86_400_000)).toEqual(new Date('2030-01-02'));
+```
+
+### 2. Pure functions are free to test
+
+A pure function (no I/O, no time, no randomness, no mutation of external state) requires no setup and no mocks.
+The test is `expect(f(input)).toEqual(output)`.
+
+Maximise the surface that is pure (see `architecture.md` §3).
+
+### 3. Test behaviour, not implementation
+
+Tests should bind to the public API, not to internal helpers.
+A test that breaks every time an internal function is renamed is a maintenance tax that punishes refactoring.
+
+### 4. Total functions test exhaustively
+
+A function that returns `User | null` is covered by two tests: present and absent.
+A function that throws for "not found" needs a third test for the throw path — and that path is easy to forget.
+
+See `api-design.md` §4 — total functions are also more testable functions.
+
+### 5. Small surface, broad coverage
+
+Test the module's public API.
+Trust the internals through it.
+A unit test per private helper is overhead with low signal — and it pins the implementation, fighting future refactors.
+
+## What Tests Are Not For
+
+- **Documentation that has to read like prose.**
+  Tests document behaviour, not English.
+- **Exercising every internal helper.**
+  See "small surface, broad coverage" above.
+- **Coverage targets as a goal.**
+  100% coverage of trivial code with no assertions is worse than 80% coverage of meaningful behaviour.
+  Coverage is a signal, not a goal.
+- **Replacing types.**
+  A test cannot prove "this is always a `User`"; the type system can.
+  Use both.
+
+## Working with `tdd`'s RED-GREEN-REFACTOR
+
+When invoked under `tdd`, this skill applies in two phases:
+
+- **GREEN**: write the simplest implementation that passes.
+  Apply *all* critical rules (no defensive code, no premature abstraction, no parallel maps), but do not yet polish.
+- **REFACTOR**: tighten naming, extract where the rule of three has fired, consolidate parallel maps, push impurity outward.
+  The tests are the safety net for the cleanup.
+
+Do not skip REFACTOR.
+GREEN code that ships without REFACTOR accumulates the debt this skill exists to prevent.

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -3,13 +3,16 @@ name: tdd
 description: >
   Test-Driven Development skill enforcing strict RED-GREEN-REFACTOR cycles.
   Writes one failing test at a time, implements minimal code to pass, then
-  refactors. Uses subagent isolation to prevent tests-by-construction.
+  refactors. Uses subagent isolation to prevent tests-by-construction. Pairs
+  with the `code-quality` skill: invokes `Skill('code-quality')` during the
+  REFACTOR phase to apply the full code-quality rule set against the GREEN
+  output, and cites refactor recipes (R1–R20) by ID when reporting changes.
   Triggers on: "tdd", "write tests", "test this", "add test coverage",
   "test driven", "red green refactor", "/tdd".
 license: MIT
 metadata:
   author: mthines
-  version: '1.0.0'
+  version: '1.1.0'
   workflow_type: test-driven-development
   modes:
     - tdd-full
@@ -72,14 +75,14 @@ See `rules/green.md`
 
 Write the MINIMUM code to make the failing test pass. No more. Run the test. Confirm it passes. Run the full relevant test suite to check for regressions.
 
-**Even in this phase, apply the basic readability primitives** from the `code-quality` skill while you write: meaningful names, guard clauses for the cases the test forces, no nesting beyond 2 levels. These cost almost nothing during authoring but are expensive to bolt on later. Don't optimize, abstract, or add unrequested features — REFACTOR will handle deeper improvements.
+**Even in this phase, apply the basic readability primitives** while you write: meaningful names, guard clauses for the cases the test forces, no nesting beyond 2 levels. These cost almost nothing during authoring but are expensive to bolt on later. Don't optimize, abstract, or add unrequested features — REFACTOR will handle deeper improvements via `Skill('code-quality')`.
 
 ### REFACTOR Phase
 See `rules/refactor.md`
 
 Evaluate whether refactoring is needed. If yes, refactor while keeping all tests green. If no, move to the next cycle.
 
-**Apply code-quality principles during this phase.** The `code-quality` skill defines what "clean" means in concrete terms — guard clauses, low cognitive complexity, single-responsibility functions, intent-revealing names. Load `code-quality/rules/cognitive-complexity.md`, `code-quality/rules/control-flow.md`, and `code-quality/rules/review-checklist.md` to score each function you wrote and target the highest-load ones for refactoring. The GREEN phase delivers working code; the REFACTOR phase makes it readable.
+**Invoke `Skill('code-quality')` for this phase.** The `code-quality` skill is the source of truth for what "clean" means — guard clauses, low cognitive complexity, single-responsibility functions, intent-revealing names, single source of truth for union-type metadata, schema-first validation with type inference, total functions, type-driven design, functional core / imperative shell, and the named refactor recipes catalog (R1–R20). Routing through the skill — rather than reading individual rule files — picks up its Review Mode procedure, the structured output contract, and any rules added since this skill was written. Cite recipes by ID in commit messages and PR descriptions (e.g., "R1 Consolidate Parallel Maps", "R10 Total-ise the Function") so reviews are reproducible.
 
 ---
 
@@ -126,15 +129,17 @@ Follow the project's existing convention. If none exists, use:
 - Example: `describe('createOrder')` → `it('should reject order when inventory is zero')`
 
 ### Code Quality (during GREEN and REFACTOR)
-The `code-quality` skill is the source of truth for what "well-written code" means in this workflow. Key principles to apply:
+The `code-quality` skill is the source of truth for what "well-written code" means in this workflow. Apply during GREEN as inline primitives; invoke as a full pass during REFACTOR via `Skill('code-quality')`.
 
-- **Guard clauses + early returns** instead of nested `if`s — flat code is easier to read and easier to test, because each branch has fewer preconditions to set up.
-- **Cognitive complexity ≤ 15** per function (per SonarSource's scoring). If a function you just wrote feels hard to test (lots of mocks, complex setup), that's the metric warning you that the function is doing too much.
+GREEN-phase primitives (apply inline while writing the minimal implementation):
+
+- **Guard clauses + early returns** instead of nested `if`s — flat code is easier to read and easier to test.
+- **Cognitive complexity ≤ 15** per function (SonarSource scoring). If the function feels hard to test (lots of mocks, complex setup), that is the metric warning you the function does too much.
 - **Names that describe intent**, not types or position. `pendingOrders` beats `arr2`.
-- **One responsibility per function**. If you can't name it without "and," split it.
-- **Validate at boundaries, trust internally.** Don't add defensive null checks for impossible states — they hide real bugs.
+- **One responsibility per function** — if you cannot name it without "and", split it.
+- **Validate at boundaries, trust internally.** No defensive null checks for impossible states.
 
-When in doubt during REFACTOR, load `code-quality/rules/review-checklist.md` and walk the function through it.
+For REFACTOR, invoke `Skill('code-quality')` so the skill's Review Mode procedure runs against the GREEN output. The skill returns findings under the High / Medium / Low / Maintainability / Correctness / Testability headings; address each as a separate refactoring move (one change at a time per the "Procedure" below). Cite recipe IDs (R1–R20) in commit messages.
 
 ### Anti-Patterns to Avoid
 | Anti-Pattern | Why It's Bad | What to Do Instead |

--- a/skills/tdd/rules/refactor.md
+++ b/skills/tdd/rules/refactor.md
@@ -12,12 +12,35 @@ tags:
 Evaluate and improve code quality while keeping all tests green.
 
 This phase delegates the *what counts as quality* question to the
-`code-quality` skill. Read `code-quality/SKILL.md` and the relevant rule
-files (especially `cognitive-complexity.md`, `control-flow.md`,
-`naming.md`, and `review-checklist.md`) to ground your refactoring
-decisions in objective criteria — guard clauses, cognitive complexity
-scoring, single-responsibility functions, intent-revealing names — rather
-than personal taste.
+`code-quality` skill. **Invoke `Skill('code-quality')`** so its Review
+Mode procedure runs against the GREEN output and returns structured
+findings — rather than reading individual rule files yourself, which
+misses the skill's procedure, output contract, and any rules added since
+this file was written.
+
+The skill covers (and routes to the relevant rule file):
+
+- Cognitive complexity, control flow, guard clauses, naming, comments
+- Functions and parameters; single level of abstraction per body
+- Maintainability: reuse, single source of truth for union metadata,
+  change footprint, co-location
+- Schema-first validation with type inference (Zod / Pydantic / valibot)
+- Type-driven design: illegal states unrepresentable, branded
+  primitives, exhaustive matching, generics discipline, `any`/cast
+  justification
+- Architecture: module boundaries, dependency direction, functional
+  core / imperative shell, DTO ↔ domain ↔ persistence, immutability
+  defaults, no side-effecting imports
+- API design: parameter ordering, total functions, error type design,
+  tell-don't-ask, file reading order
+- Correctness hotspots: idempotency, money, floats, dates,
+  identifiers, encoding, determinism, async / concurrency, resources
+- Testability: dependency injection of clock / RNG / IDs
+- Collaboration: PR scope, neighbour-symmetry, migration discipline
+- Refactor recipes catalog (R1–R20) — cite by ID in reports
+
+Ground refactoring decisions in objective criteria from these rules,
+not personal taste.
 
 ---
 
@@ -62,14 +85,34 @@ Each refactoring step should be atomic:
 
 Never batch multiple refactoring steps into one edit. If a test breaks, you need to know exactly which change caused it.
 
-### 3. Refactoring Moves (common patterns)
+### 3. Refactoring Moves (cite recipes by ID)
 
-The `code-quality` skill catalogs these in detail; the highlights below are
-the moves that come up most often in TDD's REFACTOR phase.
+The detailed catalog lives in `code-quality/rules/refactor-recipes.md`.
+Cite recipes by ID in commit messages and progress reports so the move is
+unambiguous and the rationale is one click away.
 
-**Guard clause + early return** — replace nested conditions with a flat
-guarded body. Almost always the highest-value first move because it
-unflattens the function's main intent:
+The recipes that come up most often in TDD's REFACTOR phase:
+
+- **R4 Extract Guarded Function** — replace nested conditions with guard
+  clauses at the top and an unindented happy path. Usually the highest-
+  value first move.
+- **R16 Extract by Abstraction Level** — split when the body mixes
+  orchestration sentences with low-level mechanics.
+- **R3 Replace Conditional with Lookup** — `if/else if` chains
+  dispatching on a value become a record or `Map`.
+- **R1 Consolidate Parallel Maps** — multiple maps keyed by the same
+  union collapse into one `Record<Union, { ...metadata }>`.
+- **R6 Replace Type Declaration with Inferred Type** — drop hand-written
+  `type Foo = {...}` parallel to a Zod schema; use `z.infer<typeof FooSchema>`.
+- **R10 Total-ise the Function** — return `null` / `Result<T, E>` instead
+  of throwing for "not found" or returning sentinel values.
+- **R8 Push Impurity Outward** — extract a pure core; keep I/O at the edges.
+- **R9 Inject the Clock / RNG / IDs** — for any function whose tests
+  proved flaky or required real time / randomness.
+- **Extract test fixture** — when 3+ tests share setup, replace with a
+  factory like `buildUser(overrides)`.
+
+Orientation example (R4 Extract Guarded Function):
 
 ```javascript
 // Before
@@ -92,63 +135,8 @@ function transfer(from, to, amount) {
 }
 ```
 
-
-**Extract function** — when a block of code has a clear single purpose:
-```
-// Before
-function processOrder(order) {
-  if (!order.items.length) throw new Error('Empty order');
-  if (order.total < 0) throw new Error('Invalid total');
-  // ... submit logic
-}
-
-// After
-function validateOrder(order) {
-  if (!order.items.length) throw new Error('Empty order');
-  if (order.total < 0) throw new Error('Invalid total');
-}
-
-function processOrder(order) {
-  validateOrder(order);
-  // ... submit logic
-}
-```
-
-**Extract test fixture** — when 3+ tests share setup:
-```
-// Before: repeated in every test
-const user = { id: '1', name: 'Alice', role: 'admin' };
-
-// After: shared factory
-function buildUser(overrides = {}) {
-  return { id: '1', name: 'Alice', role: 'admin', ...overrides };
-}
-```
-
-**Rename for clarity** — when a name doesn't communicate intent:
-```
-// Before
-const d = calculateDiff(a, b);
-
-// After
-const priceDifference = calculatePriceDifference(originalPrice, discountedPrice);
-```
-
-**Simplify conditionals** — when logic is nested or hard to follow:
-```
-// Before
-if (user) {
-  if (user.isActive) {
-    if (user.hasPermission('edit')) {
-      return true;
-    }
-  }
-}
-return false;
-
-// After
-return user?.isActive && user?.hasPermission('edit') ?? false;
-```
+For the full catalog and trigger / replacement / rationale of every
+recipe, read `code-quality/rules/refactor-recipes.md`.
 
 ### 4. Run Full Suite
 
@@ -156,14 +144,16 @@ After all refactoring steps, run the complete relevant test suite one final time
 
 ### 5. Report
 
-Output:
+Output, citing the recipe IDs applied:
 ```
-REFACTOR: [brief description of what was improved] — all tests still passing.
+REFACTOR: applied R4 (guard clauses in transfer) + R16 (extracted reserveStock) — all tests still passing.
 ```
 Or:
 ```
 REFACTOR: skipped — code is clean.
 ```
+
+Recipe IDs come from `code-quality/rules/refactor-recipes.md`.
 
 ---
 


### PR DESCRIPTION
Promote maintainability to a first-class concern alongside readability and
performance. Encourage agents to reuse existing utilities before creating new
ones, consolidate parallel maps over the same union into a single source of
truth, and minimise the change footprint for adding the next variant of a
concept.

- New `rules/maintainability.md` with the search-first procedure, the
  single-source-of-truth pattern for union-type metadata (one
  `Record<Union, Meta>` instead of N parallel maps), the change-footprint
  test, co-location guidance, and a decision tree for reuse vs. duplication.
- `SKILL.md`: tightened description and quality axes, expanded Quick
  Reference table with maintainability rows, added "reuse before creating"
  and single-source-of-truth steps to authoring mode, added change-footprint
  and reuse checks to review mode, added critical rules 8–10, sharpened the
  DRY-vs-clarity conflict resolution, added a required Maintainability
  findings section to the review output contract.
- `rules/review-checklist.md`: new Pass 7 (Maintainability & Reuse) covering
  reuse, parallel maps, change-footprint test, co-location, shotgun surgery,
  pattern consistency, and illegal states.