### PR TITLE
Limit auto-invokable skills to confidence, holistic-analysis, tdd, ux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Skills live in `skills/` as standard SKILL.md files.
 Agents live in `agents/` since they require their own model and tool configuration.
 
 ### Agent-invokable skills (model can `Skill()`-invoke without a slash command)
+- `autonomous-workflow` — Phase-based orchestrator (0–7) for end-to-end feature development. **Installs two agents** under the `aw-` namespace (`aw-` = "autonomous-workflow"): `aw-planner` for phases 0–2, `aw-executor` for phases 3–7, connected by `plan.md`. See [`skills/autonomous-workflow/CLAUDE.md`](./skills/autonomous-workflow/CLAUDE.md) for design intent before editing
 - `confidence` — Confidence assessment for plans, code, and bug analysis. **Plan mode is multi-signal** (LLM dimensional scoring + deterministic rule checks; a failed rule caps the gate at 89% regardless of LLM score)
 - `holistic-analysis` — Full execution path analysis for stuck bugs/refactors
 - `tdd` — Test-Driven Development with strict RED-GREEN-REFACTOR cycles
@@ -34,7 +35,6 @@ Agents live in `agents/` since they require their own model and tool configurati
 - `aw-review-quality-gate` — Self-check quality gate for review findings before delivery
 
 ### Slash commands (`disable-model-invocation: true`)
-- `autonomous-workflow` — Phase-based orchestrator (0–7) for end-to-end feature development. **Installs two agents** under the `aw-` namespace (`aw-` = "autonomous-workflow"): `aw-planner` for phases 0–2, `aw-executor` for phases 3–7, connected by `plan.md`. See [`skills/autonomous-workflow/CLAUDE.md`](./skills/autonomous-workflow/CLAUDE.md) for design intent before editing
 - `batch-linear-tickets` — Batch orchestrator for Linear tickets. Fans out `linear-ticket-investigator` per ticket, correlates findings, gates user approval, then fans out `aw-planner` + `aw-executor` pairs (autonomous-workflow namespace) in worktrees. Requires Linear MCP
 - `ci-auto-fix` — Diagnose and fix a failed CI check, iteratively pushing fixes until CI is green (currently GitHub Actions via `gh`)
 - `code-quality` — Code-quality review for readability, complexity, and maintainability

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,15 +23,10 @@ Skills live in `skills/` as standard SKILL.md files.
 Agents live in `agents/` since they require their own model and tool configuration.
 
 ### Agent-invokable skills (model can `Skill()`-invoke without a slash command)
-- `autonomous-workflow` — Phase-based orchestrator (0–7) for end-to-end feature development. **Installs two agents** under the `aw-` namespace (`aw-` = "autonomous-workflow"): `aw-planner` for phases 0–2, `aw-executor` for phases 3–7, connected by `plan.md`. See [`skills/autonomous-workflow/CLAUDE.md`](./skills/autonomous-workflow/CLAUDE.md) for design intent before editing
-- `batch-linear-tickets` — Batch orchestrator for Linear tickets. Fans out `linear-ticket-investigator` per ticket, correlates findings, gates user approval, then fans out `aw-planner` + `aw-executor` pairs (autonomous-workflow namespace) in worktrees. Requires Linear MCP
 - `confidence` — Confidence assessment for plans, code, and bug analysis. **Plan mode is multi-signal** (LLM dimensional scoring + deterministic rule checks; a failed rule caps the gate at 89% regardless of LLM score)
-- `dx` — Developer Experience review for CLI tools and shell scripts
 - `holistic-analysis` — Full execution path analysis for stuck bugs/refactors
-- `profile-optimizer` — Analyse React DevTools Profiler exports or Chrome Performance traces; auto-detects the format, extracts hotspots, maps them to source, and emits a ranked optimisation plan. Confidence-gated via `confidence(bug-analysis)` — iterates if root-cause certainty is below 90%
 - `tdd` — Test-Driven Development with strict RED-GREEN-REFACTOR cycles
 - `ux` — UX design review for web and React Native apps
-- `video-analyser` — Analyse a screen recording for bugs: resolves input from a Linear ticket URL, local path, or direct URL; extracts keyframes with ffmpeg; runs optional Tesseract OCR and Whisper transcription; returns structured findings (errors, UI state, repro steps)
 
 ### Workflow companions (`disable-model-invocation: true`, called by orchestrators via `Skill()`)
 - `aw-create-plan` — Generates `.agent/{branch}/plan.md` for autonomous-workflow Full Mode
@@ -39,15 +34,20 @@ Agents live in `agents/` since they require their own model and tool configurati
 - `aw-review-quality-gate` — Self-check quality gate for review findings before delivery
 
 ### Slash commands (`disable-model-invocation: true`)
+- `autonomous-workflow` — Phase-based orchestrator (0–7) for end-to-end feature development. **Installs two agents** under the `aw-` namespace (`aw-` = "autonomous-workflow"): `aw-planner` for phases 0–2, `aw-executor` for phases 3–7, connected by `plan.md`. See [`skills/autonomous-workflow/CLAUDE.md`](./skills/autonomous-workflow/CLAUDE.md) for design intent before editing
+- `batch-linear-tickets` — Batch orchestrator for Linear tickets. Fans out `linear-ticket-investigator` per ticket, correlates findings, gates user approval, then fans out `aw-planner` + `aw-executor` pairs (autonomous-workflow namespace) in worktrees. Requires Linear MCP
 - `ci-auto-fix` — Diagnose and fix a failed CI check, iteratively pushing fixes until CI is green (currently GitHub Actions via `gh`)
 - `code-quality` — Code-quality review for readability, complexity, and maintainability
 - `create-pr` — Generate a narrative PR description, push, then watch CI and auto-fix simple failures (lint, format, lockfiles); escalates judgment-required failures via `/confidence`
 - `create-skill` — Scaffold or review agent skills (SKILL.md + rules/ + references/ + templates/) against best-practice frontmatter, progressive disclosure, token-aware structure, and the agent-skills.git symlink + inventory wiring. Modes: `scaffold` (default), `review`, `upgrade`
+- `dx` — Developer Experience review for CLI tools and shell scripts
 - `implement-suggestion` — Implement fixes from review comments
 - `init-claude` — Initialize Claude Code configuration for a project
+- `profile-optimizer` — Analyse React DevTools Profiler exports or Chrome Performance traces; auto-detects the format, extracts hotspots, maps them to source, and emits a ranked optimisation plan. Confidence-gated via `confidence(bug-analysis)` — iterates if root-cause certainty is below 90%
 - `resolve-conflicts` — Analyze and resolve Git merge/rebase conflicts
 - `review-changes` — Review branch changes or PR (dispatches to reviewer)
 - `update-claude` — Update CLAUDE.md and rules based on code changes
+- `video-analyser` — Analyse a screen recording for bugs: resolves input from a Linear ticket URL, local path, or direct URL; extracts keyframes with ffmpeg; runs optional Tesseract OCR and Whisper transcription; returns structured findings (errors, UI state, repro steps)
 
 ### Agents
 - `reviewer` — Constructive code reviewer with auto-fix, report, and PR comment modes

--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ Most tools auto-discover skills from `~/.agents/skills/`.
 
 ### Orchestrators
 
-Coordinate other skills to execute multi-step workflows. Agent-invokable.
+Coordinate other skills to execute multi-step workflows. Slash-command-only — invoke with `/name`.
 
-| Skill                                                              | What it does                                                                                                                                                                                                                                                                                                                            | Use when...                                                                                      |
-| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| **[autonomous-workflow](./skills/autonomous-workflow/SKILL.md)**   | Phase-based orchestrator (0–7) that handles end-to-end feature development — from validation through tested PR delivery — using isolated Git worktrees. Optionally invokes companions for planning, TDD, UX, code quality, docs, and CI fixing. See [dedicated section](#autonomous-workflow).                                          | "Implement X autonomously", "end-to-end", "in isolation", "in a worktree".                       |
-| **[batch-linear-tickets](./skills/batch-linear-tickets/SKILL.md)** | Batch orchestrator for Linear tickets. Fans out [`linear-ticket-investigator`](#linear-ticket-investigator) per ticket, correlates findings, gates user approval, then fans out `aw-planner` + `aw-executor` pairs (the [`aw-` namespace](#agent-namespace-aw-) from `autonomous-workflow`) in isolated worktrees. Requires Linear MCP. | "Solve these tickets", "batch analyze SUP-123 SUP-456", "analyze tickets in this Linear filter". |
+| Command                                                                | What it does                                                                                                                                                                                                                                                                                                                            | Use when...                                                                                      |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **[/autonomous-workflow](./skills/autonomous-workflow/SKILL.md)**      | Phase-based orchestrator (0–7) that handles end-to-end feature development — from validation through tested PR delivery — using isolated Git worktrees. Optionally invokes companions for planning, TDD, UX, code quality, docs, and CI fixing. See [dedicated section](#autonomous-workflow).                                          | "Implement X autonomously", "end-to-end", "in isolation", "in a worktree".                       |
+| **[/batch-linear-tickets](./skills/batch-linear-tickets/SKILL.md)**    | Batch orchestrator for Linear tickets. Fans out [`linear-ticket-investigator`](#linear-ticket-investigator) per ticket, correlates findings, gates user approval, then fans out `aw-planner` + `aw-executor` pairs (the [`aw-` namespace](#agent-namespace-aw-) from `autonomous-workflow`) in isolated worktrees. Requires Linear MCP. | "Solve these tickets", "batch analyze SUP-123 SUP-456", "analyze tickets in this Linear filter". |
 
 ### Agent-invokable skills
 
@@ -115,12 +115,9 @@ The model can invoke these via `Skill()` when it detects a matching task — no 
 | Skill                                                        | What it does                                                                                                                                                                                                                                                                                                                                | Use when...                                                                                                                                                                                 |
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **[confidence](./skills/confidence/SKILL.md)**               | Rates confidence that work fully solves the stated requirement. Scores across weighted dimensions with auto-fix mode.                                                                                                                                                                                                                       | Validating a plan before execution, checking code before a PR, or assessing a bug analysis.                                                                                                 |
-| **[dx](./skills/dx/SKILL.md)**                               | Reviews CLI tools, shell scripts, and developer tooling against established guidelines ([clig.dev](https://clig.dev), 12 Factor CLI, Heroku CLI Style Guide).                                                                                                                                                                               | Building or reviewing a CLI, shell script, Makefile, or any developer-facing tool.                                                                                                          |
 | **[holistic-analysis](./skills/holistic-analysis/SKILL.md)** | Forces a full execution-path analysis when incremental fixes aren't working. Traces entry-to-exit with structured hypothesis generation.                                                                                                                                                                                                    | A bug fix attempt has failed, you're going in circles, or you need to "step back and think."                                                                                                |
-| **[profile-optimizer](./skills/profile-optimizer/SKILL.md)** | Analyses React DevTools Profiler exports or Chrome DevTools Performance traces. Auto-detects the format, frames the right metric (INP, TBT, LCP, commit duration), extracts ranked hotspots with measured cost, maps each to a file/component, and emits a ranked optimisation plan. Iterates via `confidence(bug-analysis)` — digs deeper if root-cause certainty is below 90%, instead of guessing.                                                                                                                                                          | Handed a `.json` profile, asked "why is this slow?", or asked to optimise a hot path with evidence (not vibes).                                                                            |
 | **[tdd](./skills/tdd/SKILL.md)**                             | Enforces strict RED-GREEN-REFACTOR cycles. Writes one failing test, implements minimal code to pass, then refactors.                                                                                                                                                                                                                        | Adding new features test-first, or retrofitting tests onto existing code.                                                                                                                   |
 | **[ux](./skills/ux/SKILL.md)**                               | Reviews web and React Native UI code for usability, accessibility (WCAG 2.2), and platform compliance (Apple HIG, Material Design 3).                                                                                                                                                                                                       | Building or reviewing UI components, checking accessibility, or improving UX copy.                                                                                                          |
-| **[video-analyser](./skills/video-analyser/SKILL.md)**       | Analyses a screen recording to extract bugs, errors, UI state, and reproduction steps. Resolves input from a Linear ticket URL, local file path, or direct URL. Extracts keyframes with `ffmpeg` (default: 8 frames at 768 px — Pareto-optimal for legibility vs. token cost). Runs optional Tesseract OCR and Whisper audio transcription. | "Analyse this screen recording for bugs", "what does this video show", "investigate this mp4", or whenever a user pastes a `.mp4`/`.mov` path or Linear ticket URL with a video attachment. |
 
 ### Workflow companions
 
@@ -142,11 +139,14 @@ User-invoked only — the model can't auto-trigger these. **Zero baseline contex
 | **[/code-quality](./skills/code-quality/SKILL.md)**                 | Authors and reviews code for low cognitive complexity, readability, and maintainability. Applies guard clauses, early returns, single-responsibility, and pragmatic performance choices grounded in Clean Code, Cognitive Complexity, and Knuth's optimization guidance. |
 | **[/create-pr](./skills/create-pr/SKILL.md)**                       | Generates a narrative PR description, pushes the branch, opens the PR, then watches CI and auto-fixes simple failures (lint, format, lockfiles). Escalates judgment-required failures via `/confidence` rather than guessing.                                            |
 | **[/create-skill](./skills/create-skill/SKILL.md)**                 | Scaffolds new agent skills — or reviews existing ones — against best-practice frontmatter, progressive disclosure, token-aware structure, and this repo's symlink + inventory wiring. Modes: `scaffold` (default), `review`, `upgrade`.                                  |
+| **[/dx](./skills/dx/SKILL.md)**                                     | Reviews CLI tools, shell scripts, and developer tooling against established guidelines ([clig.dev](https://clig.dev), 12 Factor CLI, Heroku CLI Style Guide).                                                                                                            |
 | **[/implement-suggestion](./skills/implement-suggestion/SKILL.md)** | Takes review comments or suggestions and implements the fixes — simple ones directly, complex ones with a plan for approval.                                                                                                                                             |
 | **[/init-claude](./skills/init-claude/SKILL.md)**                   | Analyzes your project and generates a tailored `CLAUDE.md` + `.claude/rules/` setup. Detects tech stack, project size, and conventions automatically.                                                                                                                    |
+| **[/profile-optimizer](./skills/profile-optimizer/SKILL.md)**       | Analyses React DevTools Profiler exports or Chrome DevTools Performance traces. Auto-detects the format, frames the right metric (INP, TBT, LCP, commit duration), extracts ranked hotspots with measured cost, maps each to a file/component, and emits a ranked optimisation plan. Iterates via `confidence(bug-analysis)` — digs deeper if root-cause certainty is below 90%, instead of guessing. |
 | **[/resolve-conflicts](./skills/resolve-conflicts/SKILL.md)**       | Detects merge/rebase conflicts, shows both sides with context, proposes resolution strategies, and asks clarifying questions for ambiguous cases.                                                                                                                        |
 | **[/review-changes](./skills/review-changes/SKILL.md)**             | Reviews branch changes or a PR for quality, correctness, tests, and commit hygiene. Dispatches to the reviewer skill.                                                                                                                                                    |
 | **[/update-claude](./skills/update-claude/SKILL.md)**               | Diffs your branch against main and incrementally updates Claude docs to match code changes. Finds stale references, dead paths, and drift.                                                                                                                               |
+| **[/video-analyser](./skills/video-analyser/SKILL.md)**             | Analyses a screen recording to extract bugs, errors, UI state, and reproduction steps. Resolves input from a Linear ticket URL, local file path, or direct URL. Extracts keyframes with `ffmpeg` (default: 8 frames at 768 px — Pareto-optimal for legibility vs. token cost). Runs optional Tesseract OCR and Whisper audio transcription. |
 
 ### Agents
 
@@ -379,22 +379,10 @@ The orchestrator fans out investigators, gates on user approval, fans out planne
 
 ## Usage Examples
 
-Skills activate automatically. Just describe what you need:
-
-```
-Implement this feature autonomously / end-to-end / in a worktree
-```
-
-```
-Review the DX of my CLI tool
-```
+Agent-invokable skills activate automatically. Just describe what you need:
 
 ```
 Check the accessibility of this component
-```
-
-```
-Refactor this for readability / reduce cognitive complexity
 ```
 
 ```
@@ -409,9 +397,14 @@ Add this feature using TDD
 Rate your confidence in this implementation
 ```
 
-Commands are invoked with a slash:
+Everything else is invoked with a slash:
 
 ```
+/autonomous-workflow implement dark mode toggle end-to-end
+/batch-linear-tickets SUP-123 SUP-456
+/dx review my CLI tool
+/profile-optimizer ./trace.json
+/video-analyser ./bug-recording.mp4
 /init-claude
 /update-claude
 /resolve-conflicts
@@ -459,13 +452,10 @@ packages/
 skills/
   autonomous-workflow/   SKILL.md + README.md + CLAUDE.md +
                          rules/ + templates/ + references/ +
-                         install.sh                          (orchestrator, agent-invokable)
-  batch-linear-tickets/  SKILL.md + rules/                   (orchestrator, agent-invokable)
+                         install.sh                          (orchestrator, slash command)
+  batch-linear-tickets/  SKILL.md + rules/                   (orchestrator, slash command)
   confidence/            SKILL.md                            (agent-invokable)
-  dx/                    SKILL.md + rules/ + templates/      (agent-invokable)
   holistic-analysis/     SKILL.md                            (agent-invokable)
-  profile-optimizer/     SKILL.md + rules/ + references/ +
-                         templates/                          (agent-invokable)
   tdd/                   SKILL.md + rules/                   (agent-invokable)
   ux/                    SKILL.md + rules/ + templates/      (agent-invokable)
   aw-create-plan/        SKILL.md                            (workflow companion, slash-only)
@@ -476,11 +466,15 @@ skills/
   create-pr/             SKILL.md                            (slash command)
   create-skill/          SKILL.md + rules/ + references/ +
                          templates/                          (slash command)
+  dx/                    SKILL.md + rules/ + templates/      (slash command)
   implement-suggestion/  SKILL.md                            (slash command)
   init-claude/           SKILL.md                            (slash command)
+  profile-optimizer/     SKILL.md + rules/ + references/ +
+                         templates/                          (slash command)
   resolve-conflicts/     SKILL.md                            (slash command)
   review-changes/        SKILL.md                            (slash command)
   update-claude/         SKILL.md                            (slash command)
+  video-analyser/        SKILL.md                            (slash command)
 agents/
   reviewer.md                                                (agent)
   linear-ticket-investigator.md                              (agent)

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ Most tools auto-discover skills from `~/.agents/skills/`.
 
 ### Orchestrators
 
-Coordinate other skills to execute multi-step workflows. Slash-command-only — invoke with `/name`.
+Coordinate other skills to execute multi-step workflows. `autonomous-workflow` is agent-invokable; `batch-linear-tickets` is slash-only.
 
-| Command                                                                | What it does                                                                                                                                                                                                                                                                                                                            | Use when...                                                                                      |
+| Skill                                                                  | What it does                                                                                                                                                                                                                                                                                                                            | Use when...                                                                                      |
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| **[/autonomous-workflow](./skills/autonomous-workflow/SKILL.md)**      | Phase-based orchestrator (0–7) that handles end-to-end feature development — from validation through tested PR delivery — using isolated Git worktrees. Optionally invokes companions for planning, TDD, UX, code quality, docs, and CI fixing. See [dedicated section](#autonomous-workflow).                                          | "Implement X autonomously", "end-to-end", "in isolation", "in a worktree".                       |
+| **[autonomous-workflow](./skills/autonomous-workflow/SKILL.md)**       | Phase-based orchestrator (0–7) that handles end-to-end feature development — from validation through tested PR delivery — using isolated Git worktrees. Optionally invokes companions for planning, TDD, UX, code quality, docs, and CI fixing. See [dedicated section](#autonomous-workflow).                                          | "Implement X autonomously", "end-to-end", "in isolation", "in a worktree".                       |
 | **[/batch-linear-tickets](./skills/batch-linear-tickets/SKILL.md)**    | Batch orchestrator for Linear tickets. Fans out [`linear-ticket-investigator`](#linear-ticket-investigator) per ticket, correlates findings, gates user approval, then fans out `aw-planner` + `aw-executor` pairs (the [`aw-` namespace](#agent-namespace-aw-) from `autonomous-workflow`) in isolated worktrees. Requires Linear MCP. | "Solve these tickets", "batch analyze SUP-123 SUP-456", "analyze tickets in this Linear filter". |
 
 ### Agent-invokable skills
@@ -382,6 +382,10 @@ The orchestrator fans out investigators, gates on user approval, fans out planne
 Agent-invokable skills activate automatically. Just describe what you need:
 
 ```
+Implement this feature autonomously / end-to-end / in a worktree
+```
+
+```
 Check the accessibility of this component
 ```
 
@@ -400,7 +404,6 @@ Rate your confidence in this implementation
 Everything else is invoked with a slash:
 
 ```
-/autonomous-workflow implement dark mode toggle end-to-end
 /batch-linear-tickets SUP-123 SUP-456
 /dx review my CLI tool
 /profile-optimizer ./trace.json
@@ -452,7 +455,7 @@ packages/
 skills/
   autonomous-workflow/   SKILL.md + README.md + CLAUDE.md +
                          rules/ + templates/ + references/ +
-                         install.sh                          (orchestrator, slash command)
+                         install.sh                          (orchestrator, agent-invokable)
   batch-linear-tickets/  SKILL.md + rules/                   (orchestrator, slash command)
   confidence/            SKILL.md                            (agent-invokable)
   holistic-analysis/     SKILL.md                            (agent-invokable)

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -9,7 +9,6 @@ description: >
   isolation", "in a worktree", or independent feature work. Invoke with
   /autonomous-workflow.
 license: MIT
-disable-model-invocation: true
 metadata:
   author: mthines
   version: '3.5.0'

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -9,6 +9,7 @@ description: >
   isolation", "in a worktree", or independent feature work. Invoke with
   /autonomous-workflow.
 license: MIT
+disable-model-invocation: true
 metadata:
   author: mthines
   version: '3.5.0'

--- a/skills/batch-linear-tickets/SKILL.md
+++ b/skills/batch-linear-tickets/SKILL.md
@@ -5,6 +5,7 @@ description: >
   cross-ticket correlation, confidence validation, and autonomous execution.
   Triggers on: "batch-linear-tickets", "batch analyze", "solve these tickets", "analyze tickets".
 user-invocable: true
+disable-model-invocation: true
 metadata:
   author: mthines
   version: '1.0.0'

--- a/skills/dx/SKILL.md
+++ b/skills/dx/SKILL.md
@@ -10,6 +10,7 @@ description: >
   "dx feedback", "review the script", "improve usability", "check error handling",
   "review output", "dx writing", "improve help text", "review flags",
   "make this more intuitive", "dx best practices", "/dx".
+disable-model-invocation: true
 metadata:
   author: mthines
   version: "1.0.0"

--- a/skills/profile-optimizer/SKILL.md
+++ b/skills/profile-optimizer/SKILL.md
@@ -13,6 +13,7 @@ description: >
   performance", "optimize from profile", "profile this", "why is this slow",
   "/profile-optimizer".
 license: MIT
+disable-model-invocation: true
 metadata:
   author: mthines
   version: '1.0.0'

--- a/skills/video-analyser/SKILL.md
+++ b/skills/video-analyser/SKILL.md
@@ -11,6 +11,7 @@ description: >
   "look at this screen capture", "what is happening in this video",
   "analyse this screen capture", "video-analyser", "/video-analyser".
 license: MIT
+disable-model-invocation: true
 metadata:
   author: mthines
   version: '1.0.0'


### PR DESCRIPTION
Add disable-model-invocation: true to autonomous-workflow,
batch-linear-tickets, dx, profile-optimizer, and video-analyser.
These remain available as slash commands but no longer auto-trigger
from trigger phrases. Move them to the Slash commands section in
the CLAUDE.md inventory to reflect the new categorization.