### PR TITLE
Add MIT LICENSE at repo root

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mads Thines <madsthines@gmail.com> (https://github.com/mthines)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- Adds a single MIT `LICENSE` at the repo root covering all skills, agents, and plugins.
- Permits free reuse, modification, and redistribution subject to attribution (name, email, GitHub handle included in the copyright line).
- One root file rather than per-skill duplicates — standard tooling (GitHub, npx skills, marketplace) only looks at the root.

## Test plan
- [x] `LICENSE` resolves at repo root
- [x] Copyright line includes full name, email, and GitHub URL
- [ ] GitHub recognises the license in the repo sidebar after merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01Er1XQ4FzAb4HkwwZ7poswK)_