### PR TITLE
docs(readme): add TOC and collapse skill descriptions for scannability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,6 @@ Agents live in `agents/` since they require their own model and tool configurati
 - `tdd` — Test-Driven Development with strict RED-GREEN-REFACTOR cycles
 - `test-provenance-guard` — Detects tests that pass by construction (private copy of the SUT instead of an import) via static + mutation checks; self-heals by extracting inline logic, rewiring callers, and rewriting the test. Runs autonomously inside `autonomous-workflow` Phase 4
 - `ux` — UX, accessibility, microcopy, and dark-pattern review for web and React Native apps (WCAG 2.2, Apple HIG, Material Design 3). Never recommends a dark pattern. See [`skills/ux/SKILL.md`](./skills/ux/SKILL.md).
-- `screen-recorder` — Records short cropped videos of UI sections via Playwright + ffmpeg to validate multi-frame interactions. Called by `animations`, `ux`, `reviewer`. See [`skills/screen-recorder/SKILL.md`](./skills/screen-recorder/SKILL.md).
 
 ### Workflow companions (`disable-model-invocation: true`, called by orchestrators via `Skill()`)
 
@@ -65,6 +64,7 @@ Agents live in `agents/` since they require their own model and tool configurati
 - `playwright-trace-analyzer` — Analyse Playwright `trace.zip` files; accepts a GitHub Actions run URL and uses `gh run download` to fetch artifacts, then extracts the action timeline, network waterfall, and console errors. Names the race behind a flake and emits a ranked fix plan. Confidence-gated via `confidence(analysis)`
 - `resolve-conflicts` — Analyze and resolve Git merge/rebase conflicts
 - `review-changes` — Review branch changes or PR (dispatches to reviewer)
+- `screen-recorder` — Records short cropped videos of UI sections via Playwright + ffmpeg to validate multi-frame interactions. Called by `animations`, `ux`, `reviewer`. See [`skills/screen-recorder/SKILL.md`](./skills/screen-recorder/SKILL.md).
 - `storybook` — Scaffolds and tests Storybook stories for React (web) and React Native / Expo. Emits visual regression + Playground + interaction-test artefacts. Opt-in OS-keychain auth profiles. See [`skills/storybook/SKILL.md`](./skills/storybook/SKILL.md).
 - `video-analyser` — Analyse a screen recording for bugs: resolves input from a Linear ticket URL, local path, or direct URL; extracts keyframes with ffmpeg; runs optional Tesseract OCR and Whisper transcription; returns structured findings (errors, UI state, repro steps)
 - `visual-design` — Guides and reviews the visual design and brand identity of UI components for web and React Native — named style directions (minimal, swiss, editorial, brutalist, neo-brutalist, glass, soft-UI, terminal, playful, retro), color systems, typography pairing, visual hierarchy, signature details. Owns the generative, brand-aware side; defers WCAG contrast math, size minimums, and dark-mode mechanics back to `/ux`. Modes: `guide` (default), `review`, `direction`. See [`skills/visual-design/SKILL.md`](./skills/visual-design/SKILL.md).

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Decide whether a plan, fix, or analysis is sound before you commit to it.
 | Skill | What it does | Type |
 |-------|--------------|------|
 | **[ux](./skills/ux/SKILL.md)** | Reviews UI for usability, WCAG 2.2 accessibility, platform compliance (Apple HIG, Material Design 3), and **dark-pattern detection**. Hard rule: never recommends a dark pattern. | `auto` |
-| **[screen-recorder](./skills/screen-recorder/SKILL.md)** | Records short cropped videos of UI sections via Playwright + ffmpeg. Validates multi-frame interactions a screenshot can't prove. | `auto` |
 | **[/animations](./skills/animations/SKILL.md)** | CSS-first web animation. Three modes: Brainstorm, Perceived-Performance, technical workflow (CSS → WAAPI → Motion → R3F). | `/` |
+| **[/screen-recorder](./skills/screen-recorder/SKILL.md)** | Records short cropped videos of UI sections via Playwright + ffmpeg. Validates multi-frame interactions a screenshot can't prove. | `/` |
 | **[/visual-design](./skills/visual-design/SKILL.md)** | Generative, brand-aware visual design. Style-direction taxonomy (minimal, swiss, brutalist, glass, …), color systems, typography, signature details. Defers WCAG math to `/ux`. | `/` |
 | **[/charting](./skills/charting/SKILL.md)** | Selects chart type + visualization library for web (React/Next.js) and mobile (Expo/RN). Maps intent → chart → library based on platform and dataset size. | `/` |
 | **[/storybook](./skills/storybook/SKILL.md)** | Scaffolds three artefacts per component: visual regression story, Playground, interaction test. Opt-in OS-keychain auth profiles. | `/` |
@@ -236,15 +236,11 @@ The mode-aware stuck-loop cap at Phase 4 (3 Lite / 5 Full) is the biggest cost-s
 ### Install
 
 ```bash
-npx skills add https://github.com/mthines/agent-skills \
-  --skill autonomous-workflow aw-create-plan aw-create-walkthrough confidence \
-          code-quality holistic-analysis tdd ux documentation \
-          review-changes create-pr ci-auto-fix \
-  --agent claude-code --yes
+npx skills add https://github.com/mthines/agent-skills --all --agent claude-code --yes
 bash ~/.claude/skills/autonomous-workflow/install.sh --global
 ```
 
-For per-project install, drop `--global` from both lines.
+This installs every skill in the repo, which is the shorter command. The companion skills (`tdd`, `ux`, `code-quality`, `documentation`, `ci-auto-fix`, etc.) skip silently if you don't want them — see [Customizing](./skills/autonomous-workflow/README.md) to opt out individually. For a per-project install, drop `--global` from both lines.
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -1,86 +1,85 @@
 # Agent Skills
 
-A personal collection of skills for AI coding assistants — covering autonomous feature development, code review, DX/UX analysis, TDD, holistic debugging, and developer productivity.
+> Skills and agents for AI coding assistants — autonomous workflows, code review, TDD, UX, DX, debugging, and more.
 
-Skills and agents follow the open [Agent Skills](https://agentskills.io/) format and work with Claude Code, Cursor, Codex, Gemini CLI, Copilot, Windsurf, OpenCode, and more.
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Agent Skills spec](https://img.shields.io/badge/spec-Agent%20Skills-7c3aed)](https://agentskills.io/)
+[![Skills](https://img.shields.io/badge/skills-37-0a7)](#skills-at-a-glance)
+[![Agents](https://img.shields.io/badge/agents-4-0a7)](#agents-at-a-glance)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-supported-d97706)](https://claude.com/claude-code)
 
-> **New:** The [`autonomous-workflow`](#autonomous-workflow) skill orchestrates end-to-end feature development through a phase-based pipeline with optional companion skills. See its [dedicated section](#autonomous-workflow) below.
-
-## Install
-
-> **Tip — keep it tidy.** Always pass `--agent <your-tool>` (e.g. `--agent claude-code`). Without it, `npx skills` symlinks every skill into ~24 different AI-tool directories at once (`.codebuddy/`, `.continue/`, `.crush/`, …). Scoping the install to the tool you actually use keeps your workspace clean and your `git status` short.
-
-**Recommended — Claude Code only:**
-
-```bash
-npx skills add https://github.com/mthines/agent-skills \
-  --skill confidence \
-  --agent claude-code \
-  --yes
-```
-
-To install all skills:
+Works with Claude Code, Cursor, Codex, Gemini CLI, Copilot, Windsurf, OpenCode, and any other [Agent Skills](https://agentskills.io)-compatible tool.
 
 ```bash
 npx skills add https://github.com/mthines/agent-skills --all --agent claude-code
 ```
 
-**Universal** (works with any [Agent Skills](https://agentskills.io)-compatible tool — only use this if you switch between many tools):
+---
+
+## Table of contents
+
+- [Install](#install)
+- [Skills at a glance](#skills-at-a-glance)
+  - [Autonomous workflows](#autonomous-workflows)
+  - [Analysis & validation](#analysis--validation)
+  - [Testing](#testing)
+  - [UI, UX & visual design](#ui-ux--visual-design)
+  - [Code review & PRs](#code-review--prs)
+  - [Performance & debugging](#performance--debugging)
+  - [Docs, meta-skills & memory](#docs-meta-skills--memory)
+  - [AI engineering & DX](#ai-engineering--dx)
+  - [Workflow companions](#workflow-companions)
+- [Agents at a glance](#agents-at-a-glance)
+- [Claude Code plugins](#claude-code-plugins)
+- [Featured: autonomous workflow](#featured-autonomous-workflow)
+- [Linear ticket investigator (per-project plug-in)](#linear-ticket-investigator-per-project-plug-in)
+- [Usage examples](#usage-examples)
+- [VS Code extension](#vs-code-extension)
+- [Repository structure](#repository-structure)
+- [Local development](#local-development)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Install
+
+> **Tip — keep it tidy.** Always pass `--agent <your-tool>` (e.g. `--agent claude-code`). Without it, `npx skills` symlinks every skill into ~24 different AI-tool directories at once.
+
+**Recommended — Claude Code, single skill:**
+
+```bash
+npx skills add https://github.com/mthines/agent-skills \
+  --skill confidence --agent claude-code --yes
+```
+
+**All skills, Claude Code:**
+
+```bash
+npx skills add https://github.com/mthines/agent-skills --all --agent claude-code
+```
+
+**Universal — any Agent Skills tool:**
 
 ```bash
 npx skills add https://github.com/mthines/agent-skills --all
 ```
 
 <details>
-<summary>Claude Code (plugin marketplace)</summary>
+<summary>Other tools (Claude Code marketplace, Gemini, Cursor, Copilot, Codex, manual)</summary>
+
+**Claude Code plugin marketplace:**
 
 ```bash
 /plugin marketplace add mthines/agent-skills
 /plugin install mthines-agent-skills@mthines
 ```
 
-</details>
-
-<details>
-<summary>Gemini CLI</summary>
+**Gemini CLI:**
 
 ```bash
 gemini extensions install https://github.com/mthines/agent-skills
 ```
 
-</details>
-
-<details>
-<summary>Cursor</summary>
-
-```bash
-git clone https://github.com/mthines/agent-skills.git ~/.cursor/skills/mthines-agent-skills
-```
-
-</details>
-
-<details>
-<summary>GitHub Copilot</summary>
-
-```bash
-git clone https://github.com/mthines/agent-skills.git ~/.copilot/skills/mthines-agent-skills
-```
-
-</details>
-
-<details>
-<summary>OpenAI Codex</summary>
-
-```bash
-git clone https://github.com/mthines/agent-skills.git ~/.agents/skills/mthines-agent-skills
-```
-
-</details>
-
-<details>
-<summary>Manual (any tool)</summary>
-
-Clone into the cross-client discovery directory:
+**Cursor / Copilot / Codex / manual:**
 
 ```bash
 git clone https://github.com/mthines/agent-skills.git ~/.agents/skills/mthines-agent-skills
@@ -90,177 +89,164 @@ Most tools auto-discover skills from `~/.agents/skills/`.
 
 </details>
 
-## What's Included
+## Skills at a glance
 
-> **About skill loading.** Each skill below is either _agent-invokable_ or _slash-command-only_. The distinction matters for your token budget:
->
-> - **Agent-invokable skills** sit in your model's available-skills list every session — only the short `description` field, not the body. The model can invoke them via `Skill()` when it detects a matching task, without you typing `/name`.
-> - **Slash-command-only skills** (`disable-model-invocation: true` in their frontmatter) are **not in the model's invokable list at all**. They cost nothing in baseline context. They load only when you type `/name` or when another skill calls them via `Skill()` at runtime.
->
-> In all cases, the skill **body** (`SKILL.md` content + `rules/`) is loaded only on invocation, never automatically.
+Two invocation styles:
 
-### Orchestrators
+- **`auto`** — the model invokes the skill when it detects a matching task. Its `description` field sits in your available-skills list every session (~50–150 tokens). The body loads only on invocation.
+- **`/name`** — slash command only. Zero baseline context cost; loads only when you type `/name` or another skill calls it via `Skill()`.
 
-Coordinate other skills to execute multi-step workflows. `autonomous-workflow` is agent-invokable; `batch-linear-tickets` is slash-only.
+### Autonomous workflows
 
-| Skill                                                                  | What it does                                                                                                                                                                                                                                                                                                                            | Use when...                                                                                      |
-| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| **[autonomous-workflow](./skills/autonomous-workflow/SKILL.md)**       | Phase-based orchestrator (0–7) that handles end-to-end feature development — from validation through tested PR delivery — using isolated Git worktrees. Optionally invokes companions for planning, TDD, UX, code quality, docs, and CI fixing. Diagnosable via `/create-skill diagnose autonomous-workflow` — phase model and failure taxonomy declared in [`rules/diagnostic-surface.md`](./skills/autonomous-workflow/rules/diagnostic-surface.md). See [dedicated section](#autonomous-workflow).                                          | "Implement X autonomously", "end-to-end", "in isolation", "in a worktree".                       |
-| **[/batch-linear-tickets](./skills/batch-linear-tickets/SKILL.md)**    | Thin batching wrapper around [`/fix-bug`](#slash-commands). Fans out `/fix-bug --analyse-only` per ticket — each call invokes [`linear-ticket-investigator`](#linear-ticket-investigator) for evidence, [`holistic-analysis`](./skills/holistic-analysis/SKILL.md) for root cause, and [`confidence(analysis)`](./skills/confidence/SKILL.md) for the gate. Correlates findings, gates user approval, then fans out `aw-planner` + `aw-executor` pairs (the [`aw-` namespace](#agent-namespace-aw-)) for approved tickets using the pre-computed analyses (no re-running of `/fix-bug`). Requires Linear MCP. | "Solve these tickets", "batch analyze SUP-123 SUP-456", "analyze tickets in this Linear filter". |
+Coordinate other skills to ship complete changes.
 
-### Agent-invokable skills
+| Skill | What it does | Type |
+|-------|--------------|------|
+| **[autonomous-workflow](./skills/autonomous-workflow/SKILL.md)** | Phase-based orchestrator (0–7): task → plan → worktree → code → test → docs → draft PR → CI gate. See [featured section](#featured-autonomous-workflow). | `auto` |
+| **[fix-bug](./skills/fix-bug/SKILL.md)** | 10-phase bug pipeline: intake → triage → evidence → repro-lock → analyse → gate → handoff → verify → telemetry. Lane-split: fast for simple, standard for complex. | `/` |
+| **[batch-linear-tickets](./skills/batch-linear-tickets/SKILL.md)** | Fan out `/fix-bug --analyse-only` across many Linear tickets, gate user approval, then dispatch planners and executors in parallel. Requires Linear MCP. | `/` |
+| **[implement-suggestion](./skills/implement-suggestion/SKILL.md)** | Apply reviewer suggestions across one or more PRs. Reads humans and AI bots (`claude[bot]`, `coderabbit`, `sourcery`), validates each via `/critical` + `/confidence`, applies in the existing branch. | `/` |
 
-The model can invoke these via `Skill()` when it detects a matching task — no slash command required. Their descriptions are in your context every session (~50–150 tokens each).
+### Analysis & validation
 
-| Skill                                                        | What it does                                                                                                                                                                                                                                                                                                                                | Use when...                                                                                                                                                                                 |
-| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **[confidence](./skills/confidence/SKILL.md)**               | Rates confidence that work fully solves the stated requirement. Scores across weighted dimensions with auto-fix mode. Modes: `plan`, `code`, `analysis` (root-cause, refactor, diagnose); `bug-analysis` accepted as a deprecated alias.                                                                                                       | Validating a plan before execution, checking code before a PR, or assessing an analysis (root-cause, refactor rationale, skill-diagnose proposal).                                          |
-| **[critical](./skills/critical/SKILL.md)**                   | Adversarial pre-mortem reviewer. Hostile-persona walk through a fixed taxonomy (hidden assumptions, top-3 failure modes, blast radius, rollback, hidden coupling, maintainability, scope creep, assertion strength) with mandatory file/line grounding and a mandatory **steelman alternative**. Single-pass; never iterates; never scores (delegates to [`confidence`](./skills/confidence/SKILL.md)); never applies fixes. Three modes: `plan` (default), `code`, `analysis`. Grounded in the literature on self-refine bias amplification (Pride and Prejudice, ACL 2024; SELF-[IN]CORRECT, AAAI) and external-grounding critique (CRITIC). | You're locking a plan before autonomous execution, opening a high-stakes PR (migrations, auth, billing, shared infra), or the proposed root cause / fix "feels off". |
-| **[holistic-analysis](./skills/holistic-analysis/SKILL.md)** | Forces a full execution-path analysis when incremental fixes aren't working. Traces entry-to-exit with structured hypothesis generation.                                                                                                                                                                                                    | A bug fix attempt has failed, you're going in circles, or you need to "step back and think."                                                                                                |
-| **[tdd](./skills/tdd/SKILL.md)**                             | Enforces strict RED-GREEN-REFACTOR cycles. Writes one failing test, implements minimal code to pass, then refactors.                                                                                                                                                                                                                        | Adding new features test-first, or retrofitting tests onto existing code.                                                                                                                   |
-| **[test-provenance-guard](./skills/test-provenance-guard/SKILL.md)** | Detects tests that pass by construction — tests that re-declare the function under test instead of importing it — via a static import/shadow check and a one-shot mutation check, then self-heals by extracting the inline production logic to an exported function and rewriting the test to use it.                                              | A new test passed on first run, you suspect a test re-states production logic locally, or you want a guard inside `autonomous-workflow` Phase 4 to catch tests-by-construction before merge. |
-| **[ux](./skills/ux/SKILL.md)**                               | Reviews web and React Native UI code for usability, accessibility (WCAG 2.2), platform compliance (Apple HIG, Material Design 3), and **dark-pattern / deceptive-design detection** (asymmetric consent UI, roach-motel cancellation, fake urgency/scarcity, drip pricing, confirmshaming, forced continuity, pre-checked opt-ins, manipulative AI). Grounded in Brignull, Gray et al. (2018), FTC 2022 + Click-to-Cancel 2024, EDPB Guidelines 03/2022, EU DSA Art. 25, EU AI Act Art. 5, GDPR Art. 7, California CPRA. Hard rule: never recommends or implements a dark pattern, even when asked.                                                                                                                                                                                       | Building or reviewing UI components, checking accessibility, improving UX copy, or auditing consent / paywall / subscription / sign-up flows for deceptive design.                                                                                                          |
-| **[screen-recorder](./skills/screen-recorder/SKILL.md)**     | Records short videos of specific page sections using Playwright's `recordVideo` API, runs scripted interactions (hover, click, focus, scroll, drag, multi-step), crops the output to the target element with `ffmpeg` (16 px padding), and writes the artifact to `.agent/recordings/`. Optional `.mp4` transcode for GitHub PR previews; `.gif` budget capped at 4 s / 400×400. Headless Chromium only; rejects brittle structural selectors and arbitrary user JS. Hooks into [`animations`](./skills/animations/SKILL.md) (called twice for `prefers-reduced-motion`), [`ux`](./skills/ux/SKILL.md) (Critical/High motion findings), and the [`reviewer`](#agents) agent (PR Mode when the diff matches a motion-relevant regex and the author has not attached a recording). | A still screenshot cannot prove a change — verifying a View Transition, a Motion `layout` morph, a hover stagger, scroll-driven timelines, `@starting-style` entries, or any multi-frame interaction. |
+Decide whether a plan, fix, or analysis is sound before you commit to it.
+
+| Skill | What it does | Type |
+|-------|--------------|------|
+| **[confidence](./skills/confidence/SKILL.md)** | Rates confidence that work fully solves the requirement. Modes: `plan`, `code`, `analysis`. Multi-signal gate; deterministic rule checks cap LLM score. | `auto` |
+| **[critical](./skills/critical/SKILL.md)** | Adversarial pre-mortem: hostile-persona walk through failure modes, blast radius, rollback, hidden coupling, and a mandatory steelman alternative. Never iterates. | `auto` |
+| **[holistic-analysis](./skills/holistic-analysis/SKILL.md)** | Forces a full entry-to-exit execution-path trace when incremental fixes aren't working. | `auto` |
+| **[code-quality](./skills/code-quality/SKILL.md)** | Authors and reviews code for low cognitive complexity, guard clauses, early returns, single-responsibility. | `/` |
+
+### Testing
+
+| Skill | What it does | Type |
+|-------|--------------|------|
+| **[tdd](./skills/tdd/SKILL.md)** | Strict RED-GREEN-REFACTOR cycles. Writes one failing test, implements minimal code, refactors. | `auto` |
+| **[test-provenance-guard](./skills/test-provenance-guard/SKILL.md)** | Detects tests that pass by construction (re-declare the SUT instead of importing it) via static + mutation checks. Self-heals by extracting inline logic and rewriting the test. | `auto` |
+| **[/e2e-testing](./skills/e2e-testing/SKILL.md)** | Spec-first Playwright Test Agents loop (Planner / Generator / Healer, v1.56). Locator ladder, `data-testid` source diffs, 3-attempt heal cap. | `/` |
+| **[/e2e-testing-mobile](./skills/e2e-testing-mobile/SKILL.md)** | Mobile counterpart on Maestro YAML flows for Expo / React Native. `testID`-first locator ladder; runs on Maestro Cloud via EAS Workflow. | `/` |
+
+### UI, UX & visual design
+
+| Skill | What it does | Type |
+|-------|--------------|------|
+| **[ux](./skills/ux/SKILL.md)** | Reviews UI for usability, WCAG 2.2 accessibility, platform compliance (Apple HIG, Material Design 3), and **dark-pattern detection**. Hard rule: never recommends a dark pattern. | `auto` |
+| **[screen-recorder](./skills/screen-recorder/SKILL.md)** | Records short cropped videos of UI sections via Playwright + ffmpeg. Validates multi-frame interactions a screenshot can't prove. | `auto` |
+| **[/animations](./skills/animations/SKILL.md)** | CSS-first web animation. Three modes: Brainstorm, Perceived-Performance, technical workflow (CSS → WAAPI → Motion → R3F). | `/` |
+| **[/visual-design](./skills/visual-design/SKILL.md)** | Generative, brand-aware visual design. Style-direction taxonomy (minimal, swiss, brutalist, glass, …), color systems, typography, signature details. Defers WCAG math to `/ux`. | `/` |
+| **[/charting](./skills/charting/SKILL.md)** | Selects chart type + visualization library for web (React/Next.js) and mobile (Expo/RN). Maps intent → chart → library based on platform and dataset size. | `/` |
+| **[/storybook](./skills/storybook/SKILL.md)** | Scaffolds three artefacts per component: visual regression story, Playground, interaction test. Opt-in OS-keychain auth profiles. | `/` |
+
+### Code review & PRs
+
+| Skill | What it does | Type |
+|-------|--------------|------|
+| **[/create-pr](./skills/create-pr/SKILL.md)** | Narrative PR description, push, open PR, watch CI, auto-fix simple failures. Flags: `--split` (multi-PR breakdown), `--review` (Claude GitHub App + auto-implement loop). | `/` |
+| **[/review-changes](./skills/review-changes/SKILL.md)** | Reviews branch changes or a PR. Dispatches to the [`reviewer`](#agents-at-a-glance) agent. | `/` |
+| **[/ci-auto-fix](./skills/ci-auto-fix/SKILL.md)** | Diagnoses a failed CI check, applies a minimal fix, pushes, iterates until green. Refuses to disable or weaken checks. | `/` |
+| **[/resolve-conflicts](./skills/resolve-conflicts/SKILL.md)** | Detects merge/rebase conflicts, shows both sides with context, proposes resolutions, asks for ambiguous cases. | `/` |
+
+### Performance & debugging
+
+| Skill | What it does | Type |
+|-------|--------------|------|
+| **[/profile-optimizer](./skills/profile-optimizer/SKILL.md)** | Analyses React DevTools Profiler exports or Chrome Performance traces. Maps hotspots to source. Iterates via `confidence(analysis)` until ≥ 90%. | `/` |
+| **[/playwright-trace-analyzer](./skills/playwright-trace-analyzer/SKILL.md)** | Analyses Playwright `trace.zip` (or downloads from a GitHub Actions run URL). Names the race behind a flake, emits a ranked fix plan. | `/` |
+| **[/video-analyser](./skills/video-analyser/SKILL.md)** | Analyses a screen recording for bugs. Resolves input from a Linear ticket URL, local path, or direct URL. Optional Tesseract OCR and Whisper transcription. | `/` |
+
+### Docs, meta-skills & memory
+
+| Skill | What it does | Type |
+|-------|--------------|------|
+| **[/documentation](./skills/documentation/SKILL.md)** | Authors and audits `CLAUDE.md`, `AGENTS.md`, `README.md`, and Diátaxis `docs/` trees. Modes: `init`, `update`, `readme`, `audit`. | `/` |
+| **[/create-skill](./skills/create-skill/SKILL.md)** | Scaffold, review, upgrade, or diagnose agent skills. `diagnose <target>` is the retrospective self-improvement entry point. | `/` |
+| **[/optimize-claude-md](./skills/optimize-claude-md/SKILL.md)** | Audits `CLAUDE.md` for context bloat. Modes: `audit`, `trim`, `extract`. Flags rarely-used agent-invokable skills that should become slash-only. | `/` |
+| **[/optimize-mock-data](./skills/optimize-mock-data/SKILL.md)** | Optimizes JSON/JSONL fixture directories via shared-schema inference, drift detection, safe shrink/normalize. | `/` |
+| **[/changelog](./skills/changelog/SKILL.md)** | Generates a personal markdown changelog of merged PRs and closed Linear tickets over a configurable window (default 7 days). | `/` |
+| **[/persistent-memory](./skills/persistent-memory/SKILL.md)** | Persists context across conversations as plain markdown, scoped per topic. Operations: `write`, `read`, `consolidate`, `forget`. Three storage tiers. | `/` |
+
+### AI engineering & DX
+
+| Skill | What it does | Type |
+|-------|--------------|------|
+| **[/ai-engineering](./skills/ai-engineering/SKILL.md)** | Reviews LLM/AI application engineering across 13 concerns: prompts, caching, RAG, agents, resilience, memory, evals, safety, observability. | `/` |
+| **[/dx](./skills/dx/SKILL.md)** | Reviews CLI tools, shell scripts, developer tooling against clig.dev, 12 Factor CLI, Heroku CLI Style Guide. | `/` |
+| **[/github-actions-author](./skills/github-actions-author/SKILL.md)** | Authors and reviews fast, cheap, maintainable GitHub Actions workflows (2026 best practices). Modes: `scaffold`, `review`. | `/` |
 
 ### Workflow companions
 
-Slash-command-only. Primarily called by `autonomous-workflow` via `Skill()` at runtime. Installable on their own if you want to reuse the artifact-generation logic in your own pipelines, but most users don't invoke them directly.
+Slash-only. Called by `autonomous-workflow` via `Skill()` at runtime. Install on their own to reuse the artifact-generation logic.
 
-| Skill                                                                  | What it does                                                                                                                                            |
-| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **[aw-create-plan](./skills/aw-create-plan/SKILL.md)**                 | Generates `.agent/{branch}/plan.md` — the single source of truth for autonomous execution. A new Claude session can resume from this plan alone.        |
-| **[aw-create-walkthrough](./skills/aw-create-walkthrough/SKILL.md)**   | Generates `.agent/{branch}/walkthrough.md` — the final summary delivered with a PR, summarizing changes, decisions, and how to verify.                  |
-| **[aw-review-quality-gate](./skills/aw-review-quality-gate/SKILL.md)** | Self-check quality gate for review findings before delivery — filters noise, dedupes, ranks severity. Called by the `reviewer` agent and review skills. |
+| Skill | What it does |
+|-------|--------------|
+| **[aw-create-plan](./skills/aw-create-plan/SKILL.md)** | Generates `.agent/{branch}/plan.md` — the source of truth a new session can resume from. |
+| **[aw-create-walkthrough](./skills/aw-create-walkthrough/SKILL.md)** | Generates `.agent/{branch}/walkthrough.md` — the PR-delivery summary. |
+| **[aw-review-quality-gate](./skills/aw-review-quality-gate/SKILL.md)** | Self-check quality gate for review findings: filters noise, dedupes, ranks severity. |
 
-### Slash commands
+## Agents at a glance
 
-User-invoked only — the model can't auto-trigger these. **Zero baseline context cost** (not in the model's available-skills list); they load only when you type `/name` or when another skill calls them via `Skill()` at runtime.
+Agents are specialized sub-processes with their own model and tool configuration. Dispatched by other skills, not invoked directly.
 
-| Command                                                             | What it does                                                                                                                                                                                                                                                             |
-| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **[/ai-engineering](./skills/ai-engineering/SKILL.md)**             | Reviews and guides LLM/AI application engineering across thirteen concerns: prompt writing, system-prompt design, token cost (caching, routing, batching), multimodal (vision/audio/PDFs), RAG, agent loops and tool design, resilience (rate limits, retries, fallbacks, idempotency), memory and long-running state, model migration and version pinning, evals with LLM-as-judge bias mitigations, testing (mocks, VCR, snapshots, CI cost discipline), safety and prompt-injection defence, and observability (delegates OTEL wiring/semconv to the dash0 companion skills). Synthesises 2025–2026 practices from primary provider docs (Anthropic, OpenAI, Google), OWASP LLM Top 10, and practitioners. |
-| **[/animations](./skills/animations/SKILL.md)**                     | CSS-first web-animation slash command with three entry points: **Brainstorm Mode** — given an interaction ("press a button", "close a card", "delete a row", "open a modal"), runs a five-question framework (verb / reversibility / initiator / spatial source / affordance load) and looks up a catalog of ~40 interactions (discrete actions, element lifecycle, status & feedback states, continuous gestures, navigation) to recommend the right feedback shape, duration, easing, property, and intensity rung before any code is written ([`rules/interaction-feedback.md`](./skills/animations/rules/interaction-feedback.md)); **Perceived-Performance Mode** — given an async wait, consults a wait-duration ladder and ships the cheat-the-eye toolkit (skeleton loaders matched to final content shape with `transform`-only shimmer in the 0.6–1.0 opacity band, optimistic UI with mandatory visible rollback, the 200 ms loader floor + sub-200 ms skip to avoid flash-and-glitch, progressive image loading via dominant colour / LQIP / blurhash / `loading="lazy"`, `font-display: swap;` with metrics-matched fallbacks, RSC streamed-content staggered reveals, predictive prefetch on hover / focus / viewport with debounce, stale-while-revalidate with diff-targeted cross-fade) — grounded in Doherty (1982), Nielsen (1993), and RAIL ([`rules/perceived-performance.md`](./skills/animations/rules/perceived-performance.md)); and the **technical workflow** — decision flow CSS → WAAPI → Motion → R3F. Covers GPU-safe properties (`transform`, `opacity`, `filter`), `will-change` discipline, CSS variable / `@property` interactive effects (cursor spotlight, magnetic buttons), modern entry / exit primitives (`@starting-style`, `transition-behavior: allow-discrete`, `interpolate-size`), View Transitions, scroll-driven timelines, state-choreography morphs (list ↔ stacked cards, full ↔ icon-only nav, grid ↔ detail) with a **mandatory pre-code planning checklist** and a dedicated accessibility section, React state patterns for driving them (`useMotionValue`, `AnimatePresence`, Server Components), advanced effects (Apple Liquid Glass, animated glow via pseudo-element + opacity, hover-to-expand, aurora gradient mesh, 3D pointer tilt), external engines (Lottie / dotLottie and Rive — when designer-authored playback or interactive assets beat code), React Three Fiber + Drei for 3D / WebGL scenes, and `prefers-reduced-motion` compliance throughout. Deliberately drops GSAP and `framer-motion` from its decision flow — both superseded by **Motion** ([motion.dev](https://motion.dev), npm `motion`, import path `motion/react`, hybrid WAAPI + JS engine). |
-| **[/charting](./skills/charting/SKILL.md)**                         | Selects the right chart type and visualization library for React/Next.js (web) and Expo/React Native (mobile) tasks. Maps intent (comparison, composition, distribution, relationship, evolution, flow, geographic, hierarchical) → chart → library based on platform, dataset size, and design system. Defers cross-cutting concerns (contrast, touch targets, typography, copy) to the `ux` skill rather than restating them. Links to canonical galleries (data-to-viz, shadcn charts, Tremor, Victory Native XL) instead of duplicating example code. |
-| **[/changelog](./skills/changelog/SKILL.md)**                       | Generates a personal markdown changelog of merged or closed PRs authored by the current user and Linear tickets they closed or worked on, over a configurable window (default 7 days), grouped by feature area (e.g. `Dashboards`, `Agent0`). Sources from `gh search prs --author=@me` (cross-repo) and the Linear MCP, deduplicates PR / ticket pairs, and renders against an editable template at [`skills/changelog/templates/changelog.md`](./skills/changelog/templates/changelog.md). Use for weekly recaps, status updates, performance reviews, or end-of-sprint summaries. |
-| **[/ci-auto-fix](./skills/ci-auto-fix/SKILL.md)**                   | Diagnoses a failed CI check, applies a minimal fix, pushes, and iterates until CI passes. Provider-agnostic in scope; currently implements the GitHub Actions path. Refuses to disable, skip, or weaken checks.                                                          |
-| **[/code-quality](./skills/code-quality/SKILL.md)**                 | Authors and reviews code for low cognitive complexity, readability, and maintainability. Applies guard clauses, early returns, single-responsibility, and pragmatic performance choices grounded in Clean Code, Cognitive Complexity, and Knuth's optimization guidance. |
-| **[/create-pr](./skills/create-pr/SKILL.md)**                       | Generates a narrative PR description, pushes the branch, opens the PR, then watches CI and auto-fixes simple failures (lint, format, lockfiles). Escalates judgment-required failures via `/confidence` rather than guessing. With `--split`, analyses the branch diff and breaks it into 2–4 dependency-ordered draft PRs (hard cap 5) after user approval, so reviewers don't have to digest a sprawling change in one sitting. With `--review` (additive flag, default mode only), posts `@claude review` on the new PR, dispatches a background subagent that polls every 30s for up to 10 minutes for Claude's GitHub App review, then invokes [`/implement-suggestion`](./skills/implement-suggestion/SKILL.md) on the same PR — runs in parallel with the CI watch + auto-fix loop. Refuses `--split --review` at parse time; skips silently if Claude's GitHub App is not installed. |
-| **[/create-skill](./skills/create-skill/SKILL.md)**                 | Scaffolds new agent skills — or reviews, upgrades, or diagnoses existing ones — against best-practice frontmatter, progressive disclosure, token-aware structure, and this repo's symlink + inventory wiring. Modes: `scaffold` (default), `review`, `upgrade`, `diagnose`. **`diagnose <target-skill>`** is the retrospective self-improvement entry point for any diagnosable skill in the repo: classifies a failed run against the target's declared diagnostic surface, walks a phase-attribution matrix, runs `confidence(analysis) ≥ 90 %` as a hard gate, and emits an applyable unified diff against the target skill's source (`--apply` to apply locally, `--pr` to share upstream). Consumers today: `autonomous-workflow` and `fix-bug` — each declares its own `rules/diagnostic-surface.md`. |
-| **[/dx](./skills/dx/SKILL.md)**                                     | Reviews CLI tools, shell scripts, and developer tooling against established guidelines ([clig.dev](https://clig.dev), 12 Factor CLI, Heroku CLI Style Guide).                                                                                                            |
-| **[/e2e-testing](./skills/e2e-testing/SKILL.md)**                   | Drives a spec-first E2E loop on top of Playwright Test Agents (Planner / Generator / Healer, v1.56) and `@playwright/mcp`. Halts Phase 0 to ask before installing Playwright. Enforces the role → label → `data-testid` locator ladder, proposes `data-testid` as a source diff, runs in snapshot mode, and caps the heal loop at 3 attempts. |
-| **[/e2e-testing-mobile](./skills/e2e-testing-mobile/SKILL.md)**     | Mobile counterpart to `/e2e-testing`. Drives a spec-first Maestro YAML-flow loop for Expo / React Native, halts Phase 0 to ask before installing Maestro CLI / EAS or scaffolding `.maestro/`, enforces a `testID`-first locator ladder (with a hard rule that `accessibilityLabel` must NOT double as a test selector), proposes `testID` source diffs via a `setTestId` helper, runs on Maestro Cloud as an EAS Workflow `maestro-cloud` job, and caps the heal loop at 3 attempts. Composes with `/e2e-testing` for hybrid apps (Maestro for native chrome, Playwright for the WebView). |
-| **[/github-actions-author](./skills/github-actions-author/SKILL.md)** | Authors fast, cheap, maintainable GitHub Actions workflows using 2026 best practices for caching (`hashFiles` + `restore-keys`), parallelization (independent jobs, matrix, build-once-fan-out via artifacts), reusability (composite actions for steps, reusable workflows for jobs), security (SHA-pinned third-party actions, `permissions: {}` then per-job grants, OIDC instead of long-lived cloud secrets), scoped triggers + `concurrency` (PR `cancel-in-progress: true`, deploy `false`), and trackable errors (named steps, GitHub-format annotations, `$GITHUB_STEP_SUMMARY`). Two modes: `scaffold` (default) generates the YAML; `review` audits an existing `.github/workflows/*.yml` and returns PASS/WARN/FAIL evidence with a top-3 fixes list. Ships drop-in templates for Node CI, Python CI, reusable workflow (callee + caller), composite action, and OIDC deploy. Complements `/ci-auto-fix` (which fixes failing runs) by authoring sound workflows up front. |
-| **[/fix-bug](./skills/fix-bug/SKILL.md)**                           | v2.1 ships a 10-phase pipeline (intake → **complexity triage** → evidence → preflight → reproduction-lock → analyse → gate → **lane-split handoff** → independent-verify → telemetry-verify) plus a cross-cutting bug-notes ledger that survives compaction. Takes any starting evidence (Dash0 span / log / web event URL with UTC timezone compensation, raw stack trace, error message, code pointer `file:line`, Linear ticket URL via [`linear-ticket-investigator`](#linear-ticket-investigator), screen recording via [`/video-analyser`](./skills/video-analyser/SKILL.md), or free-text symptom). Phase 0 infers a `bugClass`; **Phase 0.5 runs complexity triage on a 14-row signal table** to pick `simple` (lightweight in-skill analysis + fast handoff lane) or `complex` (canonical holistic-analysis + standard lane); conservative default is `complex`. Phase 1.5 runs cheap pre-flight probes which may upgrade triage to `simple`; Phase 2.5 locks a failing reproduction by **delegating to [`/tdd`](./skills/tdd/SKILL.md)**, [`/e2e-testing`](./skills/e2e-testing/SKILL.md), or [`/e2e-testing-mobile`](./skills/e2e-testing-mobile/SKILL.md); Phase 2c runs `git bisect run` for regressions; Phase 3 delegates to [`holistic-analysis`](./skills/holistic-analysis/SKILL.md) on complex bugs or runs a lightweight in-skill analysis on simple ones; Phase 4 gates on `confidence(analysis)`. **At ≥ 92 % Phase 6 dispatches without human confirmation**: fast-lane (simple + non-best-effort repro) routes `/fix-bug` → [`/aw-create-plan`](./skills/aw-create-plan/SKILL.md) → `aw-executor` (no aw-planner); standard-lane routes `aw-planner` → `aw-executor`. Both carry the CEGIS refinement contract (3-round counterexample loop); fast-lane round-3 failure falls back to standard-lane via aw-planner with the captured counterexamples. Phase 7's `bug-fix-verifier` agent grades the PR in fresh context (FAIL_TO_PASS, PASS_TO_PASS, diff sanity, repro integrity), identical for both lanes, and is the only one allowed to undraft. Phase 8 (telemetry inputs only) polls the originating Dash0 query post-deploy. Pass `--analyse-only` to stop at Phase 5 — the read-only primitive `/batch-linear-tickets` calls per ticket; `--force-holistic` skips the fast lane. Diagnosable via `/create-skill diagnose fix-bug` — phase model and hard invariants (only the verifier may undraft; verifier in fresh context; bug-notes ledger append-only; three independent confidence gates **on both lanes**; fast-lane requires ≥ 92 % + non-best-effort repro; fast-lane round-3 fallback is single-shot; CEGIS capped at 3 rounds; telemetry bugs not done until Phase 8) declared in [`rules/diagnostic-surface.md`](./skills/fix-bug/rules/diagnostic-surface.md). Curated [research sources](./skills/fix-bug/references/research-sources.md) (Anthropic, SWE-bench, RepairAgent, CEGIS, bisection, telemetry verification, taxonomies). |
-| **[/implement-suggestion](./skills/implement-suggestion/SKILL.md)** | Implements reviewer suggestions across one or more PRs. Multi-PR mode (default when `$ARGUMENTS` contains PR URLs; empty `$ARGUMENTS` auto-detects the active PR for the current branch via `gh pr view`): per PR, resolves a `gw` worktree, fetches every actionable comment from **both human teammates AND AI code-review bots** (`claude[bot]`, `coderabbitai[bot]`, `sourcery-ai[bot]`, `sweep-ai[bot]` — login allowlist; noise bots like `dependabot` and `github-actions` filtered) via the `gh api` `/pulls/<n>/{reviews,comments}` + `/issues/<n>/comments` endpoints with a GraphQL resolved-thread filter, classifies each as `actionable` / `nit` / `discussion` / `question` / `praise`, and validates each carry-forward comment through [`/critical`](./skills/critical/SKILL.md) (adversarial pre-mortem; severity-tagged findings) then [`/confidence`](./skills/confidence/SKILL.md) (analysis mode; decision matrix `apply` / `surface` / `skip` with `Critical`/`High` `/critical` findings forcing `surface` regardless of score), writing a plan.md-shaped suggestion-pack to `.agent/<branch>/suggestion-pack.md`. Phase 6 lane-split mirrors [`/fix-bug`](./skills/fix-bug/SKILL.md): **fast-lane** (single-file mechanical edits, ≤ 3 files, no `Major` `/critical` findings) dispatches a general-purpose worker subagent directly with the pack; **standard-lane** (cross-file edits, signature changes, `Major` findings, or ≥ 4 files) routes through `aw-planner` first to author `plan.md`, then dispatches the worker. The worker applies edits, runs scoped fast checks, commits one commit per PR, and pushes to the existing branch — **never opens a new PR**, never force-pushes, never skips hooks. Free-text mode (paste a comment or permalink) preserves v1 behaviour: a single validation pass, apply in cwd, no commit. Hard rules: workers have no retry budget; `Critical`/`High` `/critical` findings are non-removable overrides; standard-lane below-gate stops; resolved threads filtered at fetch time. |
-| **[/documentation](./skills/documentation/SKILL.md)**               | Authors, audits, and maintains project documentation across every surface: `CLAUDE.md` / `.claude/rules/` for the agent hot path, `AGENTS.md` for cross-tool agents, `README.md` for humans (standard-readme spec, above-the-fold rule, badge hygiene), and `docs/` trees structured by the Diátaxis framework. Four modes: `init` bootstraps a tiered docs setup from scratch (small / medium / large tiers by complexity); `update` (default when `CLAUDE.md` already exists) detects drift via deterministic checks (dead `@imports`, removed files, renamed scripts, stale narrative, hot-path leakage) and refreshes only what changed via a **Placement Resolver** that pushes rules to the innermost-ancestor destination (subtree rules to `<dir>/CLAUDE.md`, cross-cutting patterns to `.claude/rules/<topic>.md` with `paths:` globs — never root); `readme` writes or audits a README; `audit` produces a read-only doc-health report across every surface. Two targeted update sub-modes: `nested <dir>` for package-level CLAUDE.md and `pattern <glob>` for discovery-driven rules covering files matching a name or directory glob (`**/bindings.ts`, `**/urlState/**`). Replaces the previous separate `init-claude` and `update-claude` skills — same machinery, broader scope, single discovery surface. |
-| **[/optimize-claude-md](./skills/optimize-claude-md/SKILL.md)**     | Audits `CLAUDE.md` files (root, nested package, `.claude/rules/*.md`) for context bloat and emits ranked optimization suggestions across **two levers**: (1) shrink inventory entries via `trim` / `extract`; (2) flag rarely-used **agent-invokable skills that should become slash-only** so their `description` drops from the always-on available-skills list — orthogonal context saving on top of the file-size reduction. Triggers on Claude Code's "Large CLAUDE.md will impact performance" warning (file > 40k chars / ~10k tokens), paragraph-length inventory entries duplicating harness-loaded skill descriptions, or user phrases ("shrink CLAUDE.md", "optimize CLAUDE.md"). Three modes — `audit` (default, read-only ranked report including slash-conversion candidates with per-skill baseline-savings estimates), `trim` (interactive per-offender one-line hook + diff approval), `extract` (moves long sections to linked files preserving content). Distinguishes hot-path content (commands, terse rules, file pointers) from cold-path (verbose descriptions, rationale, paragraph inventory). Composes with `documentation` (Placement Resolver) and `create-skill` (invocation matrix + frontmatter conventions). Hard rules: refuses files < 10k chars; never deletes silently; never edits any skill's canonical `SKILL.md` frontmatter — invocation-flag changes route through `/create-skill review`. |
-| **[/optimize-mock-data](./skills/optimize-mock-data/SKILL.md)**     | Optimizes a directory of structurally-related JSON / JSONL mock fixtures by inferring a shared schema, detecting structural drift between files, normalizing formatting and key order, and optionally shrinking verbose payloads while preserving shape. Three modes — `analyze` (default, read-only report), `normalize` (rewrites files in place with 2-space / LF / trailing-newline canonical form, optionally fills missing keys with `null`), and `shrink` (truncates string fields above a configurable budget with a `…(truncated, was N chars)` marker; refuses to touch `*Id`, `hash`, discriminator tags, or strings that look parseable like URLs / JSON-in-string / base64 / PEM). Ships four stdlib-only Python scripts: [`shape.py`](./skills/optimize-mock-data/scripts/shape.py) (deterministic fingerprint), [`diff-shapes.py`](./skills/optimize-mock-data/scripts/diff-shapes.py) (cluster + drift report with HIGH/MED/LOW severity), [`normalize.py`](./skills/optimize-mock-data/scripts/normalize.py) (canonical formatting with round-trip safety), [`shrink.py`](./skills/optimize-mock-data/scripts/shrink.py) (idempotent truncation). Round-trip safety check on every rewrite — refuses to write if the result doesn't re-parse to the same Python object. Use when fixture files have grown inconsistent (mixed tabs / 2-space, reordered keys, fields in some files but not others, megabyte-sized payloads), when adding a new mock that must match an existing set, or when preparing fixtures for a storage-cost-sensitive context. |
-| **[/persistent-memory](./skills/persistent-memory/SKILL.md)**       | Persists context across conversations as plain markdown so every future session can read prior conversations and enrich a topic-scoped memory (e.g. `parenting`, `relationship-anna`, `work-history`, `project-acme`). Slash-only **by design** — the description does not load into every session; the skill is invoked either explicitly (`/persistent-memory write parenting`) or at runtime via `Skill("persistent-memory", "read <scope>")` from a host skill's pointer block (the canonical integration pattern, documented in [`rules/integration-with-skills.md`](./skills/persistent-memory/rules/integration-with-skills.md)). Four operations: `write` (Mem0-style extract → ADD / UPDATE / DELETE / NOOP), `read` (progressive disclosure from a ≤ 200-line INDEX modeled on Claude Code's `MEMORY.md`), `consolidate` (sleep-style merge + prune), `forget` (delete / archive / redact with audit). Three storage tiers: `home` (`~/.agent-memory/<scope>/`, default), `project-local` (gitignored), `project-shared` (committed). Strict never-store list (passwords, API keys, JWTs, credit cards, SSNs, private keys); PII like names / ages / addresses is allowed but flagged in the consent preview. Documents four scaling tiers — markdown → markdown + SQLite FTS → markdown + local vector DB → managed memory layer (Mem0 / Letta / Zep) — with migration recipes. |
-| **[/profile-optimizer](./skills/profile-optimizer/SKILL.md)**       | Analyses React DevTools Profiler exports or Chrome DevTools Performance traces. Auto-detects the format, frames the right metric (INP, TBT, LCP, commit duration), extracts ranked hotspots with measured cost, maps each to a file/component, and emits a ranked optimisation plan. Iterates via `confidence(analysis)` — digs deeper if root-cause certainty is below 90%, instead of guessing. |
-| **[/playwright-trace-analyzer](./skills/playwright-trace-analyzer/SKILL.md)** | Analyses Playwright `trace.zip` files (or downloads them straight from a GitHub Actions run URL via `gh run download`). Auto-detects the input, extracts the action timeline, network waterfall, and console errors, names the race behind a flake, and emits a ranked fix plan. Confidence-gated via `confidence(analysis)`. |
-| **[/resolve-conflicts](./skills/resolve-conflicts/SKILL.md)**       | Detects merge/rebase conflicts, shows both sides with context, proposes resolution strategies, and asks clarifying questions for ambiguous cases.                                                                                                                        |
-| **[/review-changes](./skills/review-changes/SKILL.md)**             | Reviews branch changes or a PR for quality, correctness, tests, and commit hygiene. Dispatches to the reviewer skill.                                                                                                                                                    |
-| **[/storybook](./skills/storybook/SKILL.md)**                       | Scaffolds and tests Storybook stories for React (web) and React Native / Expo. Generates three artefacts per component: a visual regression `*.stories.tsx` with variants grouped into one snapshot (Chromatic / Loki–optimized), a `Playground` story whose `args` and `argTypes` mirror the component's prop types, and an interaction test `*.test.stories.tsx` under a `/Tests` namespace with awaited `userEvent` / `expect` and the role → label → text → testId locator ladder. Phase 0 preflight detects platform (`@storybook/react-vite`, `@storybook/nextjs(-vite)`, or `@storybook/react-native(-web)`) and halts and asks if Storybook is not installed. Opt-in **multi-profile auth flow** — selectors + account + keychain service live in `.agent/storybook/auth.config.json` (safe to commit), secrets live in the **OS keychain** (macOS `security`, Linux `secret-tool`, Windows Credential Manager), and reusable `storageState.json` is cached under gitignored `.agent/storybook/.auth/`. Sub-commands `auth list / add / remove / test`. Iteration loop runs the Playwright CLI against the live Storybook URL; visual evidence delegates to the [`reviewer`](./agents/reviewer.md) agent (PR Mode screenshots) and the [`screen-recorder`](./skills/screen-recorder/SKILL.md) skill (multi-frame interactions). |
-| **[/video-analyser](./skills/video-analyser/SKILL.md)**             | Analyses a screen recording to extract bugs, errors, UI state, and reproduction steps. Resolves input from a Linear ticket URL, local file path, or direct URL. Extracts keyframes with `ffmpeg` (default: 8 frames at 768 px — Pareto-optimal for legibility vs. token cost). Runs optional Tesseract OCR and Whisper audio transcription. |
-| **[/visual-design](./skills/visual-design/SKILL.md)**               | Guides and reviews the visual design and brand identity of UI components for web and React Native. Owns the **generative, brand-aware** side that complements `/ux`'s **review-against-minimums** mechanics. Modes: `guide` (build a component from scratch with style direction + tokens + signature details + code), `review` (audit existing visuals, produces a `generic-AI-app` score `low | medium | high` and top-3 fixes), `direction` (propose a style direction for a new product or feature, fills the `templates/direction-brief.md` template). Owns the **named style-direction taxonomy** (minimal, swiss, editorial, brutalist, neo-brutalist, glass, soft-UI, terminal, playful, retro), color-system construction (four-layer palette: surface / content / accent / semantic), typography pairing (personality + scale + weight hierarchy), aesthetic hierarchy (focal point + scan path + drama), and signature details (the 10 dimensions where brand lives — radius, shadow, hover, focus ring, selection, dividers, icons, numerics, empty states). **Defers WCAG contrast math, size minimums, dark-mode mechanics, touch targets, microcopy, and dark patterns back to `/ux`.** Cross-composes with `/charting`, `/animations`, `/storybook`. |
+| Agent | What it does |
+|-------|--------------|
+| **[reviewer](./agents/reviewer.md)** | Code reviewer with three modes: `fix` (auto-fix), `report` (findings only), `comments` (PR review comments). Orthogonal `--with <skill>` flag loads up to 3 additional review lenses (`ai-engineering`, `animations`, `charting`, `dx`, `holistic-analysis`, `ux`). |
+| **[linear-ticket-investigator](./agents/linear-ticket-investigator.md)** | Reads a Linear ticket, returns an Evidence Record matching `/fix-bug` Phase 2. Customizable via a per-project [domain navigator](#linear-ticket-investigator-per-project-plug-in). |
+| **[bug-fix-verifier](./agents/bug-fix-verifier.md)** | Independent fresh-context verifier for `/fix-bug` PRs. Runs FAIL_TO_PASS, PASS_TO_PASS, diff sanity, repro integrity. Only agent allowed to undraft. |
+| **[feature-pr-verifier](./agents/feature-pr-verifier.md)** | Feature-PR counterpart to `bug-fix-verifier`. Verifies acceptance criteria, pass-to-pass, walkthrough integrity for `autonomous-workflow` Full Mode. |
 
-### Agents
+## Claude Code plugins
 
-Agents are specialized sub-processes with their own model and tool configuration. They are dispatched by other skills, not invoked directly.
+Plugins live in `plugins/` and ship via [`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json) at the repo root.
 
-| Agent                                                                    | What it does                                                                                                                                                                                                                                                                                                                                                                     |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **[reviewer](./agents/reviewer.md)**                                     | Constructive code reviewer with three modes: **fix** (default — auto-fixes simple issues), **report** (`--report` — findings only), and **comments** (`--comments` — proposes line-level GitHub PR review comments). Orthogonal `--with <skill1>,<skill2>` flag loads up to 3 additional review lenses from `skills/<name>/lens.md` (each ≤ 80 lines / ≤ 600 tokens) and applies them as extra rubric criteria. Contract: [`review-lens-contract.md`](./skills/create-skill/rules/review-lens-contract.md). Available opt-ins: [`ai-engineering`](./skills/ai-engineering/lens.md), [`animations`](./skills/animations/lens.md), [`charting`](./skills/charting/lens.md), [`dx`](./skills/dx/lens.md), [`holistic-analysis`](./skills/holistic-analysis/lens.md), [`ux`](./skills/ux/lens.md) (canonical interface; auto-load already covers UI diffs).                                                                                                                                                             |
-| **[linear-ticket-investigator](./agents/linear-ticket-investigator.md)** | Linear-specific evidence collector. Reads a single ticket via Linear MCP, searches the codebase using domain context + label inference, and returns an Evidence Record matching `/fix-bug`'s Phase 2 schema — no analysis, no fix proposal, no confidence scoring (those live in [`/fix-bug`](./skills/fix-bug/SKILL.md) via [`holistic-analysis`](./skills/holistic-analysis/SKILL.md) and [`confidence`](./skills/confidence/SKILL.md)). Invoked transitively by `/fix-bug`'s Linear input route and by `/batch-linear-tickets`. See [Domain Context](#linear-ticket-investigator) below for plug-in customization. |
-| **[bug-fix-verifier](./agents/bug-fix-verifier.md)**                     | Independent fresh-context verifier for bug-fix PRs produced by [`/fix-bug`](./skills/fix-bug/SKILL.md). Receives only the Evidence Record, the reproduction path/command, the bug-notes ledger (read-only), and the PR diff — explicitly NOT the planner's `plan.md` or the executor's reasoning. Runs four checks: `FAIL_TO_PASS` (repro now passes), `PASS_TO_PASS` (existing tests still pass), diff sanity (no catch-all exception swallows, no debug statements, no test deletions, no `.skip` / `.only`), and repro integrity (the repro itself was not weakened). Returns green / red. The only agent allowed to undraft a `/fix-bug` PR. Used by `/fix-bug` Phase 7. |
-| **[feature-pr-verifier](./agents/feature-pr-verifier.md)**                | Feature-PR counterpart to [`bug-fix-verifier`](./agents/bug-fix-verifier.md). Independent fresh-context verifier for feature PRs produced by [`/autonomous-workflow`](./skills/autonomous-workflow/SKILL.md) Full Mode. Receives only `plan.md` (Acceptance Criteria, Requirements, File Changes), `walkthrough.md`, the PR diff, and the project test command — explicitly NOT the planner's or executor's reasoning. Runs four checks: `ACCEPTANCE_CRITERIA_MATCH` (every criterion is verifiable from the diff or a passing scoped test), `PASS_TO_PASS` (existing tests still pass), diff sanity (same anti-pattern set as `bug-fix-verifier` plus a file-list-mismatch check against `plan.md` `## File Changes`), and walkthrough integrity (the walkthrough describes what the diff actually does — no claims about features absent from the diff, no hunks missing from the walkthrough). Returns green / red as an advisory verdict; the user undrafts the PR. Used by `/autonomous-workflow` Phase 7 Auto Verify (Full Mode only — Lite Mode has no `plan.md` to verify against). |
+| Plugin | What it does |
+|--------|--------------|
+| **[agent-tasks-hooks](./plugins/agent-tasks-hooks/README.md)** | Emits privacy-safe NDJSON lifecycle events (`UserPromptSubmit`, `Stop`, `SessionStart`, `SessionEnd`, `Notification`) for the [Agent Tasks](https://marketplace.visualstudio.com/items?itemName=mthines.agent-tasks) VS Code extension. |
 
-### Claude Code Plugins
+## Featured: autonomous workflow
 
-Claude Code plugins live in `plugins/` and are distributed via the `.claude-plugin/marketplace.json` at the repo root.
+`autonomous-workflow` orchestrates a complete feature cycle — from a one-line task to a tested draft PR — using isolated Git worktrees.
 
-| Plugin                                                         | What it does                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **[agent-tasks-hooks](./plugins/agent-tasks-hooks/README.md)** | Emits privacy-safe NDJSON lifecycle events (`UserPromptSubmit`, `Stop`, `SessionStart`, `SessionEnd`, `Notification`) for the Agent Tasks VS Code extension. Drives sub-second session-state transitions in the Sessions panel. Installed automatically by the extension (with consent) or manually via `claude plugin marketplace add mthines/agent-skills && claude plugin install agent-tasks-hooks@agent-skills-plugins`. |
+### Two agents, one workflow
 
-## Autonomous Workflow
+The skill installs **two agents** that share workflow knowledge, connected by `plan.md`:
 
-`autonomous-workflow` is the largest skill in this repo. It orchestrates a complete feature development cycle — from a one-line task description to a tested, draft pull request — using isolated Git worktrees and optional companion skills for each phase.
+| Agent | Phases | Exit gate |
+|-------|--------|-----------|
+| `aw-planner`  | 0–2 (validate, plan, worktree + `plan.md`) | `confidence(plan) ≥ 90%` |
+| `aw-executor` | 3–7 (implement, test, docs, PR, CI) | CI green, walkthrough delivered |
 
-### Architecture: two agents, one workflow
+Both share the **`aw-`** prefix ("autonomous-workflow"): deliberate namespace so the pair groups together in `~/.claude/agents/` and disambiguates from agents installed by other skills.
 
-The skill installs **two agents** that share the same workflow knowledge, connected by `plan.md`. Both use the [`aw-` namespace prefix](#agent-namespace-aw-):
+### Phases
 
-| Agent         | Phases                                         | Terminal artifact                           | Exit gate                                            |
-| ------------- | ---------------------------------------------- | ------------------------------------------- | ---------------------------------------------------- |
-| `aw-planner`  | 0–2 (validation, planning, worktree + plan.md) | `.agent/{branch}/plan.md`                   | `confidence(plan) ≥ 90%` (or user-approved override) |
-| `aw-executor` | 3–7 (implement, test, docs, PR, CI)            | `.agent/{branch}/walkthrough.md` + draft PR | Walkthrough shown inline, Phase 7 CI gate run        |
+| Phase | Name | Companions (optional unless marked) |
+|-------|------|-------------------------------------|
+| 0 | Validation | — |
+| 1 | Planning | `holistic-analysis`, `code-quality`, **`confidence(plan)` (mandatory)** |
+| 2 | Worktree + plan.md | `aw-create-plan` (Full Mode) |
+| 3 | Implementation | `tdd`, `ux`, `code-quality` |
+| 4 | Testing | `confidence(analysis)`, `holistic-analysis` (auto-replan once at cap) |
+| 5 | Documentation | `documentation update` |
+| 6 | PR creation | `review-changes`, `aw-create-walkthrough`, `create-pr` |
+| 7 | CI gate | `ci-auto-fix` |
 
-The split is along the Phase 2 → Phase 3 context boundary. High-confidence plans flow through automatically; borderline plans pause for user approval. The design rationale (with verbatim Anthropic citations on context-boundary splits, structured handoff artifacts, and pre-implementation contracts) is in [`skills/autonomous-workflow/references/anthropic-architecture-research.md`](./skills/autonomous-workflow/references/anthropic-architecture-research.md).
-
-#### Agent namespace: `aw-`
-
-Both agents share the **`aw-` prefix** — short for "**a**utonomous-**w**orkflow". It's a deliberate namespace, not an abbreviation chosen at random:
-
-- **Grouping** — when you list `~/.claude/agents/`, `aw-planner.md` and `aw-executor.md` sort next to each other, immediately legible as a pair.
-- **Disambiguation** — agents installed by other skills (e.g. `reviewer`, `linear-ticket-investigator`) live in the same directory. The prefix prevents naming collisions and signals at a glance which workflow an agent belongs to.
-- **Predictability** — when this skill grows new agents, expect the same `aw-*` shape (e.g. a hypothetical `aw-rebaser`). If you see `aw-something`, it's part of this skill.
-
-So the first time you encounter `aw-planner` in a routing rule, an agent listing, or an error message, read it as "the autonomous-workflow planner" — not a typo or an unrelated tool.
-
-### What each phase does
-
-| Phase | Name           | What happens                                                                                                                                                                                            | Companion skills (optional unless noted)                                                   |
-| ----- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| 0     | Validation     | Asks clarifying questions; never starts coding without explicit confirmation.                                                                                                                           | —                                                                                          |
-| 1     | Planning       | Analyzes the codebase (parallel `Explore` sub-agents for complex tasks); designs technical approach.                                                                                                    | `holistic-analysis`, `code-quality` (plan), **`confidence` (plan, mandatory gate at 90%)** |
-| 2     | Worktree Setup | Creates an isolated worktree (`gw add` or native `git worktree`), generates `plan.md` artifact in `.agent/{branch}/`.                                                                                   | `aw-create-plan` (Full Mode)                                                               |
-| 3     | Implementation | Codes per the plan, one change at a time, with fast checks after each edit.                                                                                                                             | `tdd` (logic), `ux` (UI), `code-quality` (end-of-phase)                                    |
-| 4     | Testing        | Iterates on failing tests with a mode-aware cap (3 Lite / 5 Full) per area. At the cap, runs `confidence(analysis)` and auto-replans via `holistic-analysis` once before mandatory user escalation. | `confidence` (analysis), `holistic-analysis`                                           |
-| 5     | Documentation  | Updates README, CHANGELOG, and `docs/`; keeps `CLAUDE.md` aligned with code changes.                                                                                                                    | `documentation update` (always)                                                            |
-| 6     | PR Creation    | Reviews changes, generates `walkthrough.md`, opens draft PR with narrative description.                                                                                                                 | `review-changes`, `aw-create-walkthrough` (Full Mode), `create-pr`                         |
-| 7     | CI Gate        | Watches CI; auto-fixes failed checks (parallel sub-agents, cap 2 per PR). Optional post-merge cleanup.                                                                                                  | `ci-auto-fix`                                                                              |
-
-The single biggest cost-saver is the **mode-aware stuck-loop cap** at Phase 4 (3 Lite / 5 Full) — it prevents agents from burning tokens on hallucinated fixes when their root-cause analysis is wrong. At the cap, `confidence(analysis)` runs; if confidence is below 90%, the workflow auto-invokes `holistic-analysis`, regenerates the affected `plan.md` section, and resumes once before escalating to the user.
+The mode-aware stuck-loop cap at Phase 4 (3 Lite / 5 Full) is the biggest cost-saver: it prevents agents burning tokens on hallucinated fixes when their root-cause analysis is wrong.
 
 ### Install
 
-The skill ships with [`install.sh`](./skills/autonomous-workflow/install.sh) which handles agent + routing-rule symlinks for you.
-
-**Global** (personal use, all projects):
-
 ```bash
 npx skills add https://github.com/mthines/agent-skills \
   --skill autonomous-workflow aw-create-plan aw-create-walkthrough confidence \
           code-quality holistic-analysis tdd ux documentation \
           review-changes create-pr ci-auto-fix \
-  --agent claude-code \
-  --global --yes
+  --agent claude-code --yes
 bash ~/.claude/skills/autonomous-workflow/install.sh --global
 ```
 
-**Per-project** (team use, committable):
-
-```bash
-npx skills add https://github.com/mthines/agent-skills \
-  --skill autonomous-workflow aw-create-plan aw-create-walkthrough confidence \
-          code-quality holistic-analysis tdd ux documentation \
-          review-changes create-pr ci-auto-fix \
-  --agent claude-code \
-  --yes
-bash .claude/skills/autonomous-workflow/install.sh
-```
-
-> The `--agent claude-code` flag scopes the install to `.claude/skills/` only.
-> Without it the CLI symlinks the skills into every supported AI-tool's directory
-> (`.codebuddy/`, `.continue/`, `.crush/`, …) — fine if you switch tools, noisy
-> otherwise. Use `--agent '*'` to opt into the universal install explicitly.
-
-Run `bash install.sh --help` for script options.
+For per-project install, drop `--global` from both lines.
 
 ### Usage
-
-After install, just say:
 
 ```
 Implement dark mode toggle independently
@@ -268,71 +254,45 @@ Build the user settings screen end-to-end
 Take care of issue #42 in a worktree
 ```
 
-The agent picks up via the routing rule, runs Phase 0 validation (asks clarifying questions), and proceeds through the phases until it delivers a draft PR with a walkthrough.
-
-### Customizing
-
-Companion skills (`tdd`, `ux`, `code-quality`, `documentation`, `ci-auto-fix`, etc.) **skip silently if not installed**. To run a leaner workflow, omit them from the `--skill` list at install time. The only non-removable companion is `confidence` at Phase 1 — it's the load-bearing safety gate.
-
-For full customization (disabling individual companions, adjusting thresholds, modifying phase rules), see:
-
-- [`skills/autonomous-workflow/README.md`](./skills/autonomous-workflow/README.md) — install / customize / migrate from v2
-- [`skills/autonomous-workflow/CLAUDE.md`](./skills/autonomous-workflow/CLAUDE.md) — design intent and how to work on the skill
-- [`skills/autonomous-workflow/rules/companion-skills.md`](./skills/autonomous-workflow/rules/companion-skills.md) — companion registry with disable links
+Companions skip silently if not installed. The only non-removable companion is `confidence` at Phase 1.
 
 ### Prerequisites
-
-The skill depends on two CLI tools (declared as runtime prerequisites, not bundled):
 
 - [`gw`](https://github.com/mthines/gw-tools) — Git worktree manager (`brew install mthines/gw-tools/gw`)
 - [`gh`](https://cli.github.com) — GitHub CLI
 
-### VS Code Extension (optional)
+### Further reading
 
-Install [**Agent Tasks**](https://marketplace.visualstudio.com/items?itemName=mthines.agent-tasks) from the VS Code Marketplace to visualize `plan.md`, `task.md`, and `walkthrough.md` artifacts in your sidebar — phase progress, decisions, blockers, and completed checkboxes update live as the agent works. Defaults to scanning `.agent/`, with `.gw/` as fallback (configurable via `agentTasks.directories`). Source: [`packages/vscode-agent-tasks/`](./packages/vscode-agent-tasks/).
+- [`skills/autonomous-workflow/README.md`](./skills/autonomous-workflow/README.md) — install, customize, migrate from v2
+- [`skills/autonomous-workflow/CLAUDE.md`](./skills/autonomous-workflow/CLAUDE.md) — design intent
+- [`skills/autonomous-workflow/rules/companion-skills.md`](./skills/autonomous-workflow/rules/companion-skills.md) — companion registry
+- [`skills/autonomous-workflow/references/anthropic-architecture-research.md`](./skills/autonomous-workflow/references/anthropic-architecture-research.md) — rationale for the two-agent split
 
-## linear-ticket-investigator
+## Linear ticket investigator (per-project plug-in)
 
-The [`linear-ticket-investigator`](./agents/linear-ticket-investigator.md) agent reads a single Linear ticket, searches the codebase, and returns an **Evidence Record** matching [`/fix-bug`](./skills/fix-bug/SKILL.md)'s Phase 2 schema — no root-cause analysis, no fix proposal, no confidence scoring (those live in `/fix-bug` via [`holistic-analysis`](./skills/holistic-analysis/SKILL.md) and [`confidence`](./skills/confidence/SKILL.md)).
-It is invoked transitively by `/fix-bug`'s Linear input route, and by [`/batch-linear-tickets`](./skills/batch-linear-tickets/SKILL.md) (which fans out `/fix-bug --analyse-only` per ticket — each call goes through this agent).
+The [`linear-ticket-investigator`](./agents/linear-ticket-investigator.md) agent returns an Evidence Record from a Linear ticket. Investigation accuracy depends on grounding the agent in your project's structure.
 
-### Prerequisites
-
-| Dependency                                                                                                                           | Purpose                                    | Required?                          |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ | ---------------------------------- |
-| Linear MCP (`mcp__claude_ai_Linear__*`)                                                                                              | Read tickets, post PR comments             | **Yes**                            |
-| [`/fix-bug`](./skills/fix-bug/SKILL.md)                                                                                              | Per-ticket analysis + confidence + handoff | **Yes** for `batch-linear-tickets` |
-| `aw-planner` + `aw-executor` (from [`autonomous-workflow`](#autonomous-workflow), under the [`aw-` namespace](#agent-namespace-aw-)) | Planning + execution after approval        | **Yes** for `batch-linear-tickets` |
-| Project domain-navigator skill                                                                                                       | Ground evidence extraction in monorepos    | Optional but recommended           |
-
-### Domain Context (per-project plug-in)
-
-Investigation accuracy depends on grounding the agent in the project's structure.
 The agent looks for context in this order:
 
-1. Top-level `CLAUDE.md` / `AGENTS.md`
-2. Component-specific `CLAUDE.md` / `AGENTS.md` in directories the ticket points at
-3. A project-shipped **domain-navigator skill**, auto-discovered by name and invoked via `Skill()`
-4. Top-level `README.md` (fallback)
+1. Top-level `CLAUDE.md` / `AGENTS.md`.
+2. Component-specific `CLAUDE.md` / `AGENTS.md` in directories the ticket points at.
+3. A **domain-navigator skill**, auto-discovered by name.
+4. Top-level `README.md` (fallback).
 
-Steps 1, 2, and 4 work out of the box.
-Step 3 is the high-leverage customization for monorepos.
+Steps 1, 2, and 4 work out of the box. Step 3 is the high-leverage customization for monorepos.
 
-#### Naming convention (this is the connection)
+### Naming convention
 
-The investigator does **not** know your project's name.
-It discovers domain navigators by scanning its available-skills list at runtime for any skill whose name is:
+The investigator scans its available-skills list at runtime for any skill whose name is:
 
-- **exactly `domain-navigator`** — for projects that only need one, or
-- **ending in `-domain-navigator`** — e.g., `dash0-domain-navigator`, `acme-domain-navigator`, `monorepo-domain-navigator`
+- **exactly `domain-navigator`**, or
+- **ending in `-domain-navigator`** — e.g. `dash0-domain-navigator`, `acme-domain-navigator`.
 
-Any skill matching that pattern is invoked automatically.
-No agent code changes, no registration step.
-If your skill is named anything else (e.g., `domain-context`, `project-map`), the agent will not find it — rename it to match.
+Any match is invoked automatically. No agent code changes, no registration.
 
-#### Starter template
+### Starter template
 
-Create `~/.claude/skills/<project>-domain-navigator/SKILL.md` (for personal use) or commit it under `.claude/skills/<project>-domain-navigator/` in the project (for team use):
+Create `.claude/skills/<project>-domain-navigator/SKILL.md`:
 
 ```markdown
 ---
@@ -351,77 +311,33 @@ user-invocable: true
 | ----- | ------------------------------------- |
 | ui    | components/ui/, packages/web/         |
 | api   | components/api/, packages/server/api/ |
-| ...   | ...                                   |
 
 ## Cross-component dependencies
 
 - `ui` calls `api` via `packages/web/src/client/`
 - `api` reads from `db-migrator` schemas in `packages/db/`
-- ...
 
 ## Where the docs live
 
 - Architecture overview: `docs/architecture.md`
 - API contract: `packages/server/api/openapi.yaml`
-- Runbooks: `docs/runbooks/`
 ```
 
-That's the entire integration.
-The next time `linear-ticket-investigator` runs in a project that has this skill installed, it will see the matching name in its skills list and invoke it during Step 2.
+That is the entire integration.
 
-### Install
+## Usage examples
 
-```bash
-npx skills add https://github.com/mthines/agent-skills \
-  --skill batch-linear-tickets autonomous-workflow aw-create-plan aw-create-walkthrough \
-          confidence code-quality holistic-analysis tdd ux documentation \
-
-          review-changes create-pr ci-auto-fix \
-  --agent claude-code \
-  --yes
-bash ~/.claude/skills/autonomous-workflow/install.sh --global
-```
-
-The agent ships with the skill — no separate install step.
-Symlink it into your agents directory if your tool doesn't auto-discover the `agents/` folder.
-
-### Usage
-
-```
-batch-linear-tickets SUP-123 SUP-456 ENG-789
-```
-
-```
-solve these tickets: SUP-100, SUP-101, SUP-102
-```
-
-The orchestrator fans out investigators, gates on user approval, fans out planners, optionally pauses for plan review, fans out executors, and posts PR links back to each Linear ticket.
-
-## Usage Examples
-
-Agent-invokable skills activate automatically. Just describe what you need:
+Agent-invokable skills activate from natural language — just describe what you need.
 
 ```
 Implement this feature autonomously / end-to-end / in a worktree
-```
-
-```
 Check the accessibility of this component
-```
-
-```
 I've tried fixing this bug three times — step back and analyze holistically
-```
-
-```
 Add this feature using TDD
-```
-
-```
 Rate your confidence in this implementation
 ```
 
-Everything else is invoked with a slash:
+Slash commands are typed explicitly.
 
 ```
 /batch-linear-tickets SUP-123 SUP-456
@@ -435,146 +351,62 @@ Everything else is invoked with a slash:
 /documentation audit
 /resolve-conflicts
 /review-changes --comments 42
-/implement-suggestion <pr-url> [<pr-url> ...]   # multi-PR, validated + auto-applied
-/implement-suggestion <paste review comment>    # free-text, single suggestion
+/implement-suggestion <pr-url> [<pr-url> ...]
 /create-pr
 /ci-auto-fix <run-id|pr-url>
 ```
 
-## VSCode Extension
+## VS Code extension
 
-The [`vscode-agent-tasks`](./packages/vscode-agent-tasks/) package is a standalone VS Code extension that visualizes the artifacts produced by `autonomous-workflow` — `plan.md`, `task.md`, and `walkthrough.md` — directly in the VS Code sidebar.
+The [`vscode-agent-tasks`](./packages/vscode-agent-tasks/) package visualizes `plan.md`, `task.md`, and `walkthrough.md` in the VS Code sidebar — phase progress, decisions, blockers, and completed checkboxes update live as the agent works.
 
-**Install from the Marketplace:**
+Install from the Marketplace by searching for **Agent Tasks** or:
 
 ```
 mthines.agent-tasks
 ```
 
-Or search for **Agent Tasks** in the VS Code Extensions panel.
+Default scan paths are `.agent/` and `.gw/`. Configure via `agentTasks.directories`. See [`packages/vscode-agent-tasks/README.md`](./packages/vscode-agent-tasks/README.md) for full docs.
 
-**What it shows:**
-
-- All in-flight and completed agent tasks, grouped by branch
-- Task progress with phase indicators, in-progress markers, and sub-tasks
-- Plan summaries with files-to-create/modify and complexity estimate
-- Walkthrough auto-open when a `walkthrough.md` is created
-
-**Configurable directories** (default: `.agent/` and `.gw/`):
-
-```jsonc
-// .vscode/settings.json
-{
-  "agentTasks.directories": [".agent", ".gw"],
-}
-```
-
-See [`packages/vscode-agent-tasks/README.md`](./packages/vscode-agent-tasks/README.md) for full documentation and [`packages/vscode-agent-tasks/DEVELOPMENT.md`](./packages/vscode-agent-tasks/DEVELOPMENT.md) for build/release notes.
-
-## Repository Structure
+## Repository structure
 
 ```
-packages/
-  vscode-agent-tasks/    VS Code extension for artifact visualization     (Marketplace: mthines.agent-tasks)
-skills/
-  animations/            SKILL.md + rules/ + references/ +
-                         templates/                          (slash command)
-  autonomous-workflow/   SKILL.md + README.md + CLAUDE.md +
-                         rules/ + templates/ + references/ +
-                         install.sh                          (orchestrator, agent-invokable)
-  batch-linear-tickets/  SKILL.md + rules/                   (orchestrator, slash command)
-  confidence/            SKILL.md                            (agent-invokable)
-  critical/              SKILL.md                            (agent-invokable, advisory)
-  e2e-testing/           SKILL.md + rules/ + references/ +
-                         templates/                          (slash command)
-  e2e-testing-mobile/    SKILL.md + rules/ + references/ +
-                         templates/                          (slash command)
-  fix-bug/               SKILL.md + rules/ + templates/ +
-                         references/                         (slash command)
-  holistic-analysis/     SKILL.md                            (agent-invokable)
-  tdd/                   SKILL.md + rules/                   (agent-invokable)
-  test-provenance-guard/ SKILL.md + rules/ + references/     (agent-invokable, applied)
-  ux/                    SKILL.md + rules/ + templates/      (agent-invokable)
-  aw-create-plan/        SKILL.md                            (workflow companion, slash-only)
-  aw-create-walkthrough/ SKILL.md                            (workflow companion, slash-only)
-  aw-review-quality-gate/ SKILL.md                           (workflow companion, slash-only)
-  ai-engineering/        SKILL.md + rules/ + references/ +
-                         templates/                          (slash command)
-  changelog/             SKILL.md + templates/               (slash command)
-  charting/              SKILL.md + rules/ + references/     (slash command)
-  ci-auto-fix/           SKILL.md                            (slash command)
-  code-quality/          SKILL.md + rules/                   (slash command)
-  create-pr/             SKILL.md                            (slash command)
-  create-skill/          SKILL.md + rules/ + references/ +
-                         templates/                          (slash command)
-  dx/                    SKILL.md + rules/ + templates/      (slash command)
-  github-actions-author/ SKILL.md + rules/ + references/ +
-                         templates/                          (slash command)
-  implement-suggestion/  SKILL.md + rules/ + templates/      (slash command, orchestrator)
-  documentation/         SKILL.md + rules/ + references/ +
-                         templates/                          (slash command)
-  optimize-claude-md/    SKILL.md + rules/ + references/    (slash command)
-  optimize-mock-data/    SKILL.md + rules/ + scripts/ +
-                         references/                         (slash command, applied)
-  profile-optimizer/     SKILL.md + rules/ + references/ +
-                         templates/                          (slash command)
-  playwright-trace-analyzer/ SKILL.md + rules/ + references/ +
-                         scripts/ + templates/               (slash command)
-  resolve-conflicts/     SKILL.md                            (slash command)
-  review-changes/        SKILL.md                            (slash command)
-  persistent-memory/     SKILL.md + rules/ + templates/ +
-                         references/                         (agent-invokable, applied)
-  screen-recorder/       SKILL.md + rules/ + templates/      (agent-invokable, applied)
-  storybook/             SKILL.md + rules/ + references/ +
-                         templates/                          (slash command)
-  video-analyser/        SKILL.md                            (slash command)
-  visual-design/         SKILL.md + rules/ + templates/      (slash command)
-agents/
-  reviewer.md                                                (agent)
-  linear-ticket-investigator.md                              (agent)
-  bug-fix-verifier.md                                        (agent)
-  feature-pr-verifier.md                                     (agent)
+skills/                   37 skills, each with SKILL.md (some with rules/, references/, templates/, scripts/)
+agents/                   4 agents (reviewer, linear-ticket-investigator, bug-fix-verifier, feature-pr-verifier)
+plugins/                  1 Claude Code plugin (agent-tasks-hooks)
+packages/                 VS Code extension (vscode-agent-tasks)
+.claude-plugin/           marketplace.json — plugin distribution manifest
+scripts/                  Local symlink sync (scripts/sync-symlinks.sh)
 ```
 
-Skills live in `skills/` as standard SKILL.md files, making them installable with `npx skills add`. Agents live in `agents/` since they require their own model and tool configuration.
+Skills are installable with `npx skills add`. Agents live in `agents/` because they require their own model and tool configuration.
 
-Each skill has a `SKILL.md` manifest with YAML frontmatter (name, description, metadata) and a Markdown body with instructions. Skills with `rules/` subdirectories contain focused guidance documents that are loaded on demand based on what the code contains. The `autonomous-workflow` skill additionally has `references/` (worked examples), `templates/` (agent + routing-rule definitions), and `install.sh` (one-command setup).
+Each skill has a `SKILL.md` manifest with YAML frontmatter (name, description, metadata) and a Markdown body with instructions. Skills with `rules/` subdirectories contain focused guidance documents that load on demand.
 
-## Local Development
+## Local development
 
-If you're hacking on these skills (rather than just installing them), point your tool's skill directories at this checkout via symlinks. Edits to `skills/<name>/SKILL.md` are then live on the next agent turn — no `npx skills add` reinstall required.
+Hacking on these skills? Wire your tool's skill directory at this checkout via symlinks so edits to `skills/<name>/SKILL.md` are live on the next agent turn — no `npx skills add` reinstall.
 
-The convention used by this repo is a two-tier symlink chain:
+The convention is a two-tier chain:
 
 ```
 ~/.claude/skills/<name>     →  ~/.agents/skills/<name>     →  <this repo>/skills/<name>
 ~/.agents/agents/<name>.md  →  <this repo>/agents/<name>.md
 ```
 
-The middle layer (`~/.agents/skills/`) is the cross-tool discovery directory used by Codex, Cursor, OpenCode, and other Agent Skills–compatible clients, so the same chain serves every tool you use.
+The middle layer (`~/.agents/skills/`) is the cross-tool discovery directory used by Codex, Cursor, OpenCode, and others — one chain serves every tool.
 
 ### Add a new skill
 
-```bash
-SKILL=my-skill
-REPO="$HOME/Workspace/mthines/agent-skills.git/main"   # adjust to your checkout
+1. Create `skills/<name>/SKILL.md` in this repo.
+2. Run `scripts/sync-symlinks.sh` to wire the two-tier chain for every new or missing skill/agent.
+3. Add an entry to the inventory in [`CLAUDE.md`](./CLAUDE.md) and this README.
 
-mkdir -p "$REPO/skills/$SKILL"
-$EDITOR "$REPO/skills/$SKILL/SKILL.md"
-
-ln -s "$REPO/skills/$SKILL" "$HOME/.agents/skills/$SKILL"
-ln -s "$HOME/.agents/skills/$SKILL" "$HOME/.claude/skills/$SKILL"
-```
-
-Agents are simpler — one symlink, no Claude-side mirror:
-
-```bash
-ln -s "$REPO/agents/<name>.md" "$HOME/.agents/agents/<name>.md"
-```
+For agents, write `agents/<name>.md` and rerun the sync script. Use `--dry-run` (or `-n`) to preview without applying changes.
 
 ### Edit an existing skill
 
-Edit `skills/<name>/SKILL.md` directly in this repo. Avoid editing through the symlinked path under `~/.claude/skills/` — writes propagate correctly, but it becomes ambiguous which checkout you touched if you have multiple worktrees.
+Edit `skills/<name>/SKILL.md` directly in this repo. Avoid writing through the symlinked path under `~/.claude/skills/` — writes propagate correctly, but it becomes ambiguous which checkout you touched if multiple worktrees exist.
 
 ### Verify the chain
 
@@ -585,6 +417,10 @@ readlink ~/.agents/skills/<name>      # → <repo>/skills/<name>
 
 Both must resolve. If either is missing, the agent harness won't see the skill.
 
+## Contributing
+
+PRs welcome. Read [`CLAUDE.md`](./CLAUDE.md) for the prose conventions and [`skills/create-skill/SKILL.md`](./skills/create-skill/SKILL.md) for the skill-authoring rubric.
+
 ## License
 
-MIT
+[MIT](./LICENSE)

--- a/skills/screen-recorder/SKILL.md
+++ b/skills/screen-recorder/SKILL.md
@@ -14,7 +14,7 @@ description: >
   evidence to PR comments on motion-heavy diffs. Triggers on "record
   this interaction", "capture this animation", "video of this section",
   "validate the transition visually", "screen recording", "/screen-recorder".
-disable-model-invocation: false
+disable-model-invocation: true
 license: MIT
 metadata:
   author: mthines


### PR DESCRIPTION
## Why

The README had grown to 590 lines with no TOC and 200–400-word descriptions per skill row, so a first-time visitor had to scroll the whole file to figure out what's in the repo.

## What changed

- Add a 25-link table of contents covering every H2 and skill category
- Regroup skills by task (autonomous workflows, analysis, testing, UI/UX, code review, performance, docs, AI/DX, companions) — each row is now one line: name + ≤25-word description + invocation type (`auto` vs `/`)
- Add above-the-fold badges (license, spec, skill/agent counts, Claude Code), tighten the tagline to ≤120 chars, and surface a single install line before the first scroll
- Collapse alternative installers behind one `<details>`; replace the verbose autonomous-workflow and linear-ticket-investigator sections with concise pointers to their canonical docs; trim the repo-structure ASCII tree from 60 lines to 7

## How to verify

- Open README.md on GitHub — first viewport answers what / does it solve my problem / can I trust it; TOC anchors jump to every category