### PR TITLE
feat(code-quality): simplify mode — review-then-apply for end-of-feature cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Type markers: `auto` = model-invokable via `Skill()`; `/` = slash command only; 
 ### `quality/` — code, tests, plans, AI apps
 
 - `ai-engineering` (`/`) — LLM/AI app review across 13 concerns (prompts, caching, RAG, agents, evals, safety, observability)
-- `code-quality` (`auto`) — readability, complexity, maintainability
+- `code-quality` (`auto`) — readability, complexity, maintainability. Four modes: `plan` (validate a plan), authoring (default), `review` (findings only), `simplify` (review-then-apply for end-of-feature cleanup — auto-applies Class M refactor recipes behind `confidence(code) ≥ 90 %` + scoped fast-check, with revert-on-failure). Class M/J taxonomy lives in [`refactor-recipes.md`](./skills/quality/code-quality/rules/refactor-recipes.md#recipe-class--mechanical-vs-judgment) and is guarded by L1 G7
 - `confidence` (`auto`) — multi-signal confidence gate for `plan` / `code` / `analysis`; deterministic rule caps LLM score at 89%
 - `critical` (`auto`) — adversarial pre-mortem with mandatory steelman alternative. Never iterates
 - `dx` (`/`) — CLI / shell-script DX review

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Decide whether something is good before you commit to it.
 
 | Skill | What it does | Type |
 |-------|--------------|------|
-| **[code-quality](./skills/quality/code-quality/SKILL.md)** | Authors and reviews code for low cognitive complexity, guard clauses, early returns, single-responsibility. | `auto` |
+| **[code-quality](./skills/quality/code-quality/SKILL.md)** | Authors and reviews code for low cognitive complexity, guard clauses, early returns, single-responsibility. Four modes: `plan`, authoring (default), `review` (proposes), `simplify` (review-then-apply mechanical refactors behind `confidence(code) ≥ 90 %`). | `auto` |
 | **[confidence](./skills/quality/confidence/SKILL.md)** | Rates confidence that work fully solves the requirement. Modes: `plan`, `code`, `analysis`. Multi-signal gate; deterministic rule checks cap LLM score. | `auto` |
 | **[critical](./skills/quality/critical/SKILL.md)** | Adversarial pre-mortem: hostile-persona walk through failure modes, blast radius, rollback, hidden coupling, and a mandatory steelman alternative. Never iterates. | `auto` |
 | **[tdd](./skills/quality/tdd/SKILL.md)** | Strict RED-GREEN-REFACTOR cycles. Writes one failing test, implements minimal code, refactors. | `auto` |

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -41,8 +41,12 @@ Zero dependencies, no network. Exits non-zero on failure (CI gate). Checks:
   sentence shared verbatim by persistent-memory and the autonomous-workflow
   loop, the fast-lane plan ⊇ Core-8 sections, implement-suggestion keyed on
   `/critical`'s real Must-fix bucket, the per-comment gate consuming
-  `confidence(code)`'s real output, and a forbidden-phrase list for audited
-  contradictions and phantom references.
+  `confidence(code)`'s real output, a forbidden-phrase list for audited
+  contradictions and phantom references, and the
+  `code-quality` Recipe Class table being exhaustive over every R-recipe in
+  the Contents list (G7 — `simplify` mode keys auto-apply on this
+  classification, so an unclassified or doubly-classified recipe is a hard
+  failure).
 
 Add a check: append a `s.check(label, condition, detail)` in `l1.mjs`.
 

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -207,6 +207,31 @@ function acceptanceCriteriaCount(plan) {
     rcmd.includes("Cross-rubric agreement"));
   s.check("G6 rubric-composition 80 → 70 promotion language present",
     rcmd.includes("80") && rcmd.includes("70") && /agreement.promoted/i.test(rcmd));
+
+  // G7: every refactor recipe (R\d+) in refactor-recipes.md's Contents list appears
+  // in exactly one of the M or J rows of the Recipe Class table. The "simplify" mode
+  // auto-applies Class M recipes; an unclassified recipe silently defaults to J, but
+  // the contract is that the table is exhaustive — drift here erodes the classification
+  // as a correctness boundary.
+  const recipes = read("skills/quality/code-quality/rules/refactor-recipes.md");
+  const contentsBlock = recipes.match(/## Contents\n([\s\S]+?)\n## /);
+  const contentsIds = contentsBlock
+    ? [...contentsBlock[1].matchAll(/^- (R\d+):/gm)].map((m) => m[1])
+    : [];
+  const classTable = recipes.match(/\| \*\*M \(Mechanical\)\*\* \| ([^|]+) \|[\s\S]+?\| \*\*J \(Judgment\)\*\* \| ([^|]+) \|/);
+  const mIds = classTable ? [...classTable[1].matchAll(/R\d+/g)].map((m) => m[0]) : [];
+  const jIds = classTable ? [...classTable[2].matchAll(/R\d+/g)].map((m) => m[0]) : [];
+  const classified = new Set([...mIds, ...jIds]);
+  const unclassified = contentsIds.filter((id) => !classified.has(id));
+  s.check("G7 every recipe in Contents has a class (M or J)",
+    contentsIds.length > 0 && unclassified.length === 0,
+    unclassified.length ? `unclassified: ${unclassified.join(", ")}` : `${contentsIds.length} recipes classified`);
+  const dupInM = mIds.filter((id, i) => mIds.indexOf(id) !== i);
+  const dupInJ = jIds.filter((id, i) => jIds.indexOf(id) !== i);
+  const inBoth = mIds.filter((id) => jIds.includes(id) && !/R17/.test(id));
+  s.check("G7 no recipe appears in both M and J (R17 split is the only exception)",
+    inBoth.length === 0 && dupInM.length === 0 && dupInJ.length === 0,
+    [inBoth.length && `both: ${inBoth.join(", ")}`, dupInM.length && `dup M: ${dupInM.join(", ")}`, dupInJ.length && `dup J: ${dupInJ.join(", ")}`].filter(Boolean).join("; "));
 }
 
 process.exit(s.report() ? 0 : 1);

--- a/skills/quality/code-quality/SKILL.md
+++ b/skills/quality/code-quality/SKILL.md
@@ -48,13 +48,14 @@ The three quality axes this skill targets, in priority order:
 3. **Pragmatic performance** — algorithmic wins by default, micro-optimizations
    only when a profiler points at them.
 
-This skill applies in three modes:
+This skill applies in four modes:
 
 1. **Plan mode** — invoked with `Skill("code-quality", "plan")`, before any code is written. Reads a `plan.md` (or proposed approach) and the existing codebase, and verifies the plan's structure follows the existing patterns and avoids predictable design-time risks (premature parallel maps, missing branded primitives, untyped error paths, parameter creep, neighbour mismatch). Returns findings only — no code edits. Used by `autonomous-workflow` Phase 1. See [`rules/plan-mode.md`](./rules/plan-mode.md).
 2. **Authoring mode** — when writing new code (e.g., GREEN phase of TDD, new features). Apply principles inline so the first version already meets the bar. Default mode when no argument is passed.
-3. **Review mode** — invoked with `Skill("code-quality", "code")` or `Skill("code-quality", "review")`, after code is written. When refactoring, reviewing PRs, or being asked to "clean this up". Diagnose against the rules and propose targeted changes.
+3. **Review mode** — invoked with `Skill("code-quality", "code")` or `Skill("code-quality", "review")`, after code is written. When refactoring, reviewing PRs, or being asked to "clean this up". Diagnose against the rules and propose targeted changes. Returns findings only — no code edits.
+4. **Simplify mode** — invoked with `Skill("code-quality", "simplify")`, after a feature is implemented and tests are green. Runs the review pass, then **applies** mechanical refactors (Class M recipes from [`rules/refactor-recipes.md`](./rules/refactor-recipes.md#recipe-class--mechanical-vs-judgment)) one at a time behind `Skill("confidence", "code") ≥ 90 %` and a scoped fast-check, reverting on failure. Judgment-class recipes (Class J) stay as proposals. See [`rules/simplify-mode.md`](./rules/simplify-mode.md). Variants: `simplify aggressive` also auto-applies Medium-impact mechanical recipes; `simplify dry-run` reports without writing; `simplify <path>` scopes to a path instead of the diff.
 
-Detect the mode from the `$ARGUMENTS` first token: `plan` → plan mode; `code` or `review` → review mode; anything else (including no argument) → authoring mode. The legacy convention "user said review or audit" still routes to review mode for ad-hoc invocations.
+Detect the mode from the `$ARGUMENTS` first token: `plan` → plan mode; `code` or `review` → review mode; `simplify` → simplify mode; anything else (including no argument) → authoring mode. The legacy convention "user said review or audit" still routes to review mode for ad-hoc invocations.
 
 ---
 
@@ -141,9 +142,9 @@ when working in that stack.
 
 ## Procedure
 
-The skill operates in two modes — authoring (writing new code) and review (refactoring or auditing existing code). Detect the mode from context: if the user says "review" or "audit" or references existing code, use review mode. Otherwise default to authoring and apply principles silently while you write.
+The skill operates in four modes — plan (validate a plan), authoring (writing new code), review (refactor / audit, findings only), and simplify (review then auto-apply mechanical recipes). Detect the mode from `$ARGUMENTS` per the table above; default is authoring.
 
-Load [`rules/procedure.md`](./rules/procedure.md) for the full mode procedures: the 13-step authoring checklist (compose with `tdd` and `ux`, naming-first, design-the-type-before-body, guard clauses, push impurity outward) and the 8-step review pass (cognitive-load scoring, change-footprint scoring, recipe citations).
+Load [`rules/procedure.md`](./rules/procedure.md) for authoring (13-step checklist) and review (8-step pass). Load [`rules/simplify-mode.md`](./rules/simplify-mode.md) for the simplify procedure (partition → confidence-gate → apply one recipe at a time → scoped fast-check → revert on failure → whole-suite verify at end).
 
 ---
 
@@ -175,6 +176,7 @@ that stack.
 | Hard-to-test code, dependency injection of clock / RNG / IDs, when to invoke the `tdd` skill, UI components locatable by role / label without `data-testid` | `rules/testability.md` |
 | PR scope, neighbour-pattern symmetry, migration & evolution, working with legacy code, diff hygiene | `rules/collaboration.md` |
 | Naming a refactor in review output (R1 Consolidate Parallel Maps, R6 Replace Type Declaration with Inferred Type, etc.) | `rules/refactor-recipes.md` |
+| Auto-applying mechanical refactors at end of feature (review-then-apply, confidence-gated, revert-on-failure) | `rules/simplify-mode.md` |
 
 ### Stack-specific rules
 

--- a/skills/quality/code-quality/rules/procedure.md
+++ b/skills/quality/code-quality/rules/procedure.md
@@ -9,7 +9,7 @@ tags:
 
 # Procedure
 
-The skill operates in two modes — authoring (writing new code) and review (refactoring or auditing existing code). Detect the mode from context: if the user says "review" or "audit" or references existing code, use review mode. Otherwise default to authoring and apply principles silently while you write.
+This file covers the two foundational modes — authoring (writing new code) and review (refactoring or auditing existing code, findings only). The skill also has **plan mode** ([`plan-mode.md`](./plan-mode.md)) and **simplify mode** ([`simplify-mode.md`](./simplify-mode.md), which runs the review pass below and then auto-applies the mechanical findings behind a confidence gate). Detect the mode from `$ARGUMENTS`: `plan` → plan-mode.md, `code`/`review` → use this file's *Review Mode* section, `simplify` → simplify-mode.md, anything else → use this file's *Authoring Mode* section.
 
 ## Authoring Mode
 

--- a/skills/quality/code-quality/rules/refactor-recipes.md
+++ b/skills/quality/code-quality/rules/refactor-recipes.md
@@ -50,6 +50,7 @@ Named refactors so reviews can cite a recipe by ID instead of describing it from
 - R33: Wire TanStack Query Offline Persistence
 - R34: Replace Prop-Soup Component with Deep-Namespace Compound
 - R35: Trim Verbose Comment
+- Recipe Class — Mechanical vs Judgment
 - Recipe Index by File
 
 ## How to use this catalog
@@ -386,6 +387,35 @@ In authoring mode, recipes are reminders during the REFACTOR phase of TDD.
 No hard length cap — a rare comment legitimately needs a paragraph (subtle invariant, hard-won workaround). Keep those; rewrite everything else to one line.
 **Why:** Verbose comments accrete faster than they decay. They restate code, drift from it, lull readers into trusting stale narration, and crowd the diff on every unrelated change. The reader can read the code — comments must add what code can't: the WHY, the constraint, the surprise. Brevity preserves the signal that *this comment is worth reading*.
 **See:** [`comments.md` § Brevity — Trim to the WHY](./comments.md#brevity--trim-to-the-why).
+
+---
+
+## Recipe Class — Mechanical vs Judgment
+
+`simplify` mode auto-applies **Class M (Mechanical)** recipes behind a `confidence(code) ≥ 90 %` gate; **Class J (Judgment)** recipes are proposed but never auto-written.
+See [`simplify-mode.md`](./simplify-mode.md) for the gate, ordering, and revert contract.
+
+| Class | Recipes | Why this class |
+|---|---|---|
+| **M (Mechanical)** | R1, R2, R6, R7, R13, R17 (remove branch only), R35 | Structural transformation. Trigger is unambiguous from the source. No naming, architectural, or cross-module judgment required. Confidence on the diff is a sufficient correctness proxy. |
+| **J (Judgment)** | R3, R4, R5, R8, R9, R10, R11, R12, R14, R15, R16, R17 (justify branch), R18, R19, R20, R21, R22, R23, R24, R25, R26, R27, R28, R29, R30, R31, R32, R33, R34 | Requires naming, architectural taste, cross-module impact analysis, framework / runtime knowledge, semantic decision, or a domain decision. Confidence on the diff alone cannot validate correctness — propose to the human. |
+
+Three recipes that look structural but carry semantic side-effects sit in **J** for documented reasons (the adversarial review that produced this classification flagged each as a confident-but-wrong auto-apply trap):
+
+- **R3 Replace Conditional with Lookup** — moves from lazy branch evaluation (`if (a) return f(); if (b) return g();`) to eager record-value evaluation (`{ a: f(), b: g() }[key]`). If any branch has side effects or throws, the transformation silently changes runtime behaviour. `tsc --noEmit` does not catch this. To make a future variant Class M, narrow the Trigger to "every branch value is a literal or already-bound function reference (no calls in the lookup values)".
+- **R4 Extract Guarded Function** — "long function" is a semantic judgment (fails Class M test 1). Extraction also changes the call-stack visible to debuggers and any instrumentation wrapping the function (OTel spans, Proxy intercepts).
+- **R14 Replace Boolean Parameter with Two Functions** — deletes a function signature. External callers not in the scoped files break. `simplify`'s scoped fast-check cannot prove no caller is dynamic or in another compilation unit. To make a future variant Class M, gate on "all call sites are inside the scoped files" via static caller-graph analysis.
+
+**Rule for new recipes:** when adding a recipe, append it to the table above with an explicit class.
+Default for an un-classified recipe is **J** — `simplify` mode never auto-applies an un-classified recipe.
+
+Class-defining tests for **M**:
+
+1. The recipe's *Trigger* is a syntactic / structural pattern, not a semantic decision (e.g., "two maps keyed by the same union" is structural; "this function does too much" is semantic).
+2. The recipe's *Replace with* preserves observable behaviour (no API contract change, no error-shape change, no timing change).
+3. The recipe's change footprint is bounded by the recipe text itself (no "...and update every caller in the codebase" without an explicit, mechanical rewrite path).
+
+If any of those three fail, the recipe is **J**.
 
 ---
 

--- a/skills/quality/code-quality/rules/simplify-mode.md
+++ b/skills/quality/code-quality/rules/simplify-mode.md
@@ -1,0 +1,240 @@
+---
+title: Simplify Mode — Review-Then-Apply for End-of-Feature Cleanup
+impact: HIGH
+tags:
+  - simplify
+  - refactor
+  - auto-apply
+  - end-of-feature
+  - confidence-gated
+---
+
+# Simplify Mode
+
+A fourth mode of `code-quality` that **applies** mechanical refactors after a feature is delivered, instead of only reporting them like `review` mode does.
+Invoked with `Skill("code-quality", "simplify")` (default safe partition) or `Skill("code-quality", "simplify aggressive")` (also auto-applies Medium-impact mechanical recipes).
+
+This mode is designed to run **once at the end of a feature** — after the implementation is correct, tests are green, and the diff is roughly the shape it will ship in.
+Use it as the final pass before opening a PR.
+
+The contract: every write is gated by `Skill("confidence", "code") ≥ 90 %` and a scoped fast-check (TS / lint on touched files), one recipe at a time, with automatic revert on failure.
+This is the same gate `test-provenance-guard --fix` uses for autonomous mutation; see `autonomous-workflow/CLAUDE.md` § *Confidence-gated autonomous action — design intent*.
+
+---
+
+## When to use
+
+| Situation | Mode |
+|---|---|
+| After a feature is implemented and tests are green, before opening the PR | `simplify` |
+| During interactive review, want a list of findings to discuss | `code` / `review` |
+| Before any code is written | `plan` |
+| While writing new code | authoring (no argument) |
+
+Invocation:
+
+```
+Skill("code-quality", "simplify")              # safe partition (default): only mechanical recipes
+Skill("code-quality", "simplify aggressive")   # also auto-applies medium-impact mechanical recipes
+Skill("code-quality", "simplify dry-run")      # runs the partition, reports, but never writes
+Skill("code-quality", "simplify <path>")       # scope to a specific path instead of the diff
+```
+
+Default scope: files in `git diff --name-only main...HEAD` (or `git diff --name-only HEAD~1..HEAD` if not on a feature branch).
+Path scope is whatever the user passes.
+
+---
+
+## Procedure
+
+### Step 1 — Run the review pass
+
+Run the standard `review` procedure from [`procedure.md`](./procedure.md) § *Review Mode* against the scoped files.
+Produce the full Output Contract structure: High / Medium / Low / Maintainability / Correctness / Testability sections.
+**Do not write anything yet.** This step exists so the partition in Step 2 has named findings to work from.
+
+### Step 2 — Partition findings by recipe class
+
+Walk every finding produced in Step 1 and tag it `mechanical` or `judgment` using the table in [`refactor-recipes.md`](./refactor-recipes.md) § *Recipe Class — Mechanical vs Judgment*.
+
+A finding is `mechanical` only if **all four** hold:
+
+1. It cites a recipe ID classified as Mechanical (Class M).
+2. The transformation is **structural** — no naming change, no architectural move, no API redesign across modules.
+3. The change footprint is **inside the scoped files** (no cascading edits to callers in other files), unless the recipe explicitly covers cross-file replacement (R2 Hoist Shared Constant, where the move is into a single new home and call sites swap import).
+4. The recipe's *Trigger* is unambiguously present (e.g., R6 requires both a `type Foo = ...` and a `fooSchema = ...` for the same shape — partial matches do not qualify).
+
+Anything that doesn't satisfy all four is `judgment`, regardless of recipe ID.
+
+"Impact" here refers to the **finding-impact** bucket from Step 1's review pass (`### High Impact` / `### Medium Impact` / `### Low Impact` in the Output Contract — the impact of a *finding*, not the recipe). The same recipe (say R1 Consolidate Parallel Maps) can surface as High in one file and Low in another depending on visibility and blast radius.
+
+- **Default mode** applies only `mechanical` findings in the **High** Impact bucket.
+- **`aggressive`** also applies `mechanical` findings in the **Medium** Impact bucket.
+- `mechanical` findings in the **Low** Impact bucket are never auto-applied; they stay as proposals (Low impact + auto-apply is a poor tradeoff — small wins, real risk of churn).
+
+### Step 3 — Order recipes for safe application
+
+Apply in this order, then by file path. Earlier recipes shrink later recipes' surface area; later recipes risk re-introducing patterns earlier ones removed.
+
+1. **R35** Trim Verbose Comment — independent of any code change; reduces noise before everything else.
+2. **R13** Inline the Premature Sub-Schema — collapses single-use sub-schemas first so the parent schema is fully expanded before R6 takes its inferred type. Running R6 first would freeze the sub-schema as a referenced identifier in the inferred type and leave a half-migrated shape.
+3. **R6** Replace Type Declaration with Inferred Type — now safe to run because R13 has consolidated the schema shape.
+4. **R7** Replace Validation with Schema — replaces hand-rolled checks with the now-canonical schema.
+5. **R17** Justify or Remove the `any` — only the **remove** branch is mechanical (deletes the `as Foo` / `any` cast once a schema parse exists at the boundary). The **justify** branch (writing a `// because:` comment) is Class J and stays as a proposal.
+6. **R2** Hoist Shared Constant — single-source-of-truth move, late so it picks up constants introduced by earlier recipes.
+7. **R1** Consolidate Parallel Maps — structural merge of N maps into one record.
+
+R3, R4, and R14 are intentionally absent — they are Class J (see [`refactor-recipes.md`](./refactor-recipes.md#recipe-class--mechanical-vs-judgment)) and are proposed but never auto-applied.
+
+If a recipe's Trigger is no longer satisfied after an earlier recipe ran (e.g., R6 already collapsed the type declaration so R7 has nothing to do), skip it silently and continue.
+
+### Step 4 — Apply one recipe at a time, behind the gate
+
+For each `mechanical` finding in order:
+
+1. **Construct the diff** — produce the unified diff for this single finding. Do not batch findings into one diff; one recipe = one commit-able unit.
+2. **Run `confidence(code)`** against the diff with the question *"Does this diff correctly apply ${R-ID} (${recipe name}) to the cited finding, with no behaviour change and no unintended side effects?"*
+3. **Decision:**
+   - `confidence ≥ 90 %` → apply the diff and proceed.
+   - `confidence < 90 %` → demote the finding to a proposal in the output; do not write; continue to the next finding.
+4. **Fast-check the touched files** — run the project's TS compiler in `--noEmit` mode and the linter, scoped to the touched files only. Whole-project commands are forbidden (Sub-Agent Resource Discipline; see `autonomous-workflow/rules/parallel-coordination.md#sub-agent-resource-discipline`).
+   - Fast-check passes → continue.
+   - Fast-check fails → `git checkout -- <touched-files>` (revert just this recipe's writes), demote the finding to a proposal with a `revert-reason:` note, continue to the next finding.
+5. **Run the scoped test command** if the recipe's Trigger row in `refactor-recipes.md` requires it (default: skip — Step 6 runs the suite once at the end).
+
+### Step 5 — Halt conditions
+
+Stop applying recipes and finalize the report if any of these fire:
+
+- **Five consecutive reverts** (default mode) or **three consecutive reverts** (`aggressive` mode) — the partition is wrong; the remaining diff is risk-only. Demote everything still pending to proposals. The cap is tighter in `aggressive` because the Medium-impact bucket already carries more risk per finding; mirrors the `autonomous-workflow` Lite (3) / Full (5) mode-aware cap.
+- **Confidence gate misses five times in a row** (default) or **three** (`aggressive`) — the diff structure is noisy; the gate's signal is that the rest needs human judgment.
+- **The user invoked with `dry-run`** — never write past Step 4 (`confidence` is still computed so the report has scores).
+- **The fast-check command is unavailable** (no `tsc`, no `lint` script) — `simplify` requires the fast-check to be runnable; without it, switch to dry-run and report.
+
+### Step 6 — Final whole-diff verification
+
+After all `mechanical` findings are processed (applied, demoted, or skipped), run the project's full test command **once** against the cumulative diff (this is the orchestrator-only whole-project boundary explicitly permitted by Sub-Agent Resource Discipline at end-of-phase).
+
+- Tests pass → keep all applied recipes; emit the final report.
+- Tests fail → identify the last applied recipe before the failure, revert it (`git checkout -- <its files>` or `git restore --staged`), re-run; repeat until green or until all applied recipes are reverted. Demote each reverted recipe to a proposal with `revert-reason: post-apply-test-failure`.
+
+### Step 7 — Emit the report
+
+Use the Output Contract in the next section.
+
+---
+
+## Mechanical recipe whitelist
+
+`simplify` only auto-applies recipes flagged **Class M (Mechanical)** in the [Recipe Class table](./refactor-recipes.md#recipe-class--mechanical-vs-judgment) — that table is the single source of truth. Do not duplicate the list here; the L1 eval guards the table against drift (`G7 every recipe in Contents has a class`).
+
+Class J recipes need architectural taste, naming decisions, semantic judgment, or cross-module redesign that confidence scoring on a structural diff cannot validate — propose, never apply.
+
+When a new recipe is added to `refactor-recipes.md`, classify it explicitly in the table. Default for an un-classified recipe is **Judgment** — `simplify` does not auto-apply recipes it has not been told are safe. L1 will flag an un-classified recipe in CI.
+
+---
+
+## Output Contract
+
+```
+## Code Quality Simplify: [target]
+Mode: simplify | simplify aggressive | simplify dry-run
+Scope: <N files in diff main...HEAD>  (or <path>)
+
+### Applied (auto-written, gate-passed)
+- [file:line] R<ID> <recipe-name> — confidence: <score>%
+  - Touched: <files>
+  - Fast-check: pass
+  ```diff
+  <unified diff for this recipe>
+  ```
+
+### Demoted to proposal (gate failed or revert)
+- [file:line] R<ID> <recipe-name> — confidence: <score>%
+  - Reason: <below-threshold | fast-check-failed | post-apply-test-failure>
+  - Proposed diff:
+  ```diff
+  <unified diff>
+  ```
+
+### Judgment proposals (not auto-applyable — needs human decision)
+- [file:line] R<ID> <recipe-name>
+  - <one-line description of the change>
+  - <reason this is Judgment-class: naming, architectural, cross-module, etc.>
+
+### Maintainability findings (proposals)
+- [file:line] [duplicated concept / parallel maps / shotgun-surgery risk] → R<ID>
+- [estimated change footprint for the next obvious variant: N files, type-checked? yes/no]
+
+### Correctness findings (proposals, when relevant)
+- [file:line] [idempotency / money / dates / determinism / async / resources] → R<ID>
+
+### Testability findings (proposals, when relevant)
+- [file:line] [hard-to-test surface, missing injection, coupled to global state] → R<ID>
+
+### Verification
+- Final test run: <pass | fail (N reverts applied)>
+- Final scoped TS / lint: pass
+
+### Summary
+- Applied: <N> recipes across <M> files
+- Demoted: <N> recipes
+- Proposals: <N> judgment-class items for review
+- Halted: <reason if halted before completing the partition>
+```
+
+The `Applied` section is the **only** section where this mode has written to disk.
+Everything else (`Demoted`, `Judgment proposals`, `Maintainability`, `Correctness`, `Testability`) is identical in shape to the `review` mode output — a user can apply them by hand or by re-invoking on a narrower scope after addressing the judgment-class items.
+
+---
+
+## Safety rules (load-bearing — do not relax)
+
+1. **One recipe at a time.** Never bundle two recipes into one diff. Confidence cannot reason about the joint correctness of two independent transformations.
+2. **Scoped fast-check between recipes, full test suite at end.** Whole-project commands inside the loop are forbidden (Sub-Agent Resource Discipline). The single full test run at Step 6 is the only orchestrator-level boundary.
+3. **Revert on any check failure.** A reverted recipe is demoted, never retried with a different prompt. The signal is "this transformation is not as mechanical as the recipe class suggested in this context".
+4. **Never write under `dry-run`.** Confidence scoring still runs so the report carries scores; writes do not.
+5. **Never apply Class J recipes.** Even if confidence is 99 %, judgment recipes stay as proposals. The class is the contract; confidence does not override it.
+6. **Never delete tests.** A test deletion that "fixes" a fast-check failure is a P0 anti-pattern (mirrored from `bug-fix-verifier`'s diff-sanity rule). If a fast-check failure is rooted in a test file, the revert is mandatory.
+7. **Never modify a docstring's contract block.** R35 trims prose; the JSDoc / TSDoc / Python docstring summary line and structured tags (`@param`, `@returns`, etc.) are part of the API surface and must be preserved. See `comments.md` § *Docstrings → Hard rule for auto-fix runs*.
+
+---
+
+## Boundary with the `reviewer` agent Fix Mode
+
+`reviewer`'s **Fix Mode** (own branch, no PR) also auto-applies fixes to owned files — its scope is lint / typo / dead-code class fixes ([`agents/reviewer/rules/auto-fix-policy.md`](../../../../agents/reviewer/rules/auto-fix-policy.md)). Both tools can land on the same lines (R35 ↔ "verbose comment", R17 remove ↔ "dead code", R2 ↔ "duplicated constant").
+
+Sequencing rule when both are invoked on the same diff:
+
+1. **`reviewer` Fix Mode runs first.** Reviewer's auto-fix set is a strict subset of what `simplify` covers, and Reviewer's checks include lint-class fixes that may shift line numbers `simplify` keys on.
+2. **`simplify` runs second.** After Reviewer finishes (or if Reviewer is not invoked at all), `simplify` operates on the post-Reviewer working tree.
+3. **Never invoke them in parallel.** Both write to owned files. There is no shared lock; concurrent writes produce a corrupted working tree.
+
+If a `simplify` finding's file:line was already touched by Reviewer in this session, `simplify` must re-run the review pass (Step 1) on that file before applying — the cached finding may be stale.
+
+---
+
+## Integration with autonomous-workflow
+
+`simplify` is **not** invoked from `autonomous-workflow` Phase 3 by default.
+Phase 3 keeps the existing `Skill("code-quality", "code")` call (audit-only) so the planner / executor cycle does not silently rewrite the diff before the user has seen it.
+
+Two opt-in paths exist:
+
+1. **`plan.md` flag.** A plan that includes `auto_simplify: true` in its frontmatter triggers `Skill("code-quality", "simplify")` at the end of Phase 3, after the existing `code` invocation, before Phase 4 testing. The Phase 4 test pass then validates the post-simplify diff.
+2. **Manual end-of-feature step.** A user calls `Skill("code-quality", "simplify")` themselves after the workflow finishes, before opening the PR.
+
+Both paths produce the same Output Contract; the `plan.md` flag is the way to make `simplify` part of the standard workflow without making it mandatory.
+
+When invoked under `autonomous-workflow`, `simplify` writes its report to `.agent/{branch}/simplify-{ts}.md` in addition to returning it.
+
+---
+
+## Cross-references
+
+- [`refactor-recipes.md`](./refactor-recipes.md) — recipe definitions and the Class table.
+- [`procedure.md`](./procedure.md) § *Review Mode* — the review pass `simplify` runs in Step 1.
+- [`output-contract.md`](./output-contract.md) — the `review` output shape that `simplify`'s proposal sections mirror.
+- `Skill("confidence", "code")` — the gate at Step 4.
+- `autonomous-workflow/rules/parallel-coordination.md#sub-agent-resource-discipline` — why fast-checks are scoped, not whole-project.
+- `autonomous-workflow/CLAUDE.md` § *Confidence-gated autonomous action — design intent* — the broader pattern this mode follows.


### PR DESCRIPTION
## Why

`code-quality`'s `review` mode only proposes refactors — devs still hand-apply mechanical cleanups one by one or skip them. `simplify` runs the review pass and **applies** the safe subset behind a confidence gate, so the end-of-feature tidy stops needing a human in the loop for trivial wins.

## What changed

- New `simplify` mode — review → partition by recipe class → apply one Class M recipe at a time behind `confidence(code) ≥ 90 %` + scoped fast-check → revert on failure → final whole-suite verify
- New *Recipe Class — Mechanical vs Judgment* table in `refactor-recipes.md`; R3 / R4 / R14 explicitly Class J with documented edge cases (eager evaluation, semantic decision, cross-file API surface)
- Opt-in autonomous-workflow integration via `auto_simplify: true` plan.md flag (Phase 3 default stays audit-only); sequencing rule with `reviewer` Fix Mode documented
- L1 G7 guard: every R-recipe in the Contents list has a class (M or J), no duplicates across rows — locks the classification as a correctness contract

## How to verify

- `node scripts/eval/l1.mjs` → 69/69 (+2 from G7)

## Notes for reviewers

The Class M whitelist is intentionally narrow (`R1, R2, R6, R7, R13, R17 remove, R35`) — the adversarial review that produced this PR flagged R3/R4/R14 as confident-but-wrong auto-apply traps. Reasoning lives inline in `refactor-recipes.md`.