### PR TITLE
feat(autonomous-workflow): one-step --aw install bundle

### DIFF
--- a/scripts/sync-symlinks.sh
+++ b/scripts/sync-symlinks.sh
@@ -15,21 +15,75 @@
 #
 # Usage:
 #   scripts/sync-symlinks.sh            # apply changes (verbose per-action log)
+#   scripts/sync-symlinks.sh --aw       # apply, but only autonomous-workflow + its companions
 #   scripts/sync-symlinks.sh --dry-run  # preview only, table view
 #   scripts/sync-symlinks.sh -n         # short form of --dry-run
+#   scripts/sync-symlinks.sh --aw -n    # flags are combinable
 
 set -euo pipefail
 
 DRY_RUN=0
-if [[ "${1:-}" == "--dry-run" || "${1:-}" == "-n" ]]; then
-  DRY_RUN=1
-fi
+AW_ONLY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run|-n) DRY_RUN=1; shift ;;
+    --aw)         AW_ONLY=1; shift ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      echo "usage: $0 [--aw] [--dry-run|-n]" >&2
+      exit 1
+      ;;
+  esac
+done
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 AGENTS_SKILLS_DIR="$HOME/.agents/skills"
 AGENTS_AGENTS_DIR="$HOME/.agents/agents"
 CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
 CLAUDE_AGENTS_DIR="$HOME/.claude/agents"
+
+# Curated bundle for --aw: the autonomous-workflow skill plus the companion
+# skills documented in skills/workflow/autonomous-workflow/README.md, and the
+# agents the workflow dispatches to (reviewer / pr-reviewer).
+#
+# The aw / aw-planner / aw-executor agent symlinks are created by the
+# autonomous-workflow install.sh, which runs as part of the install.sh
+# discovery pass at the bottom of this script.
+AW_SKILLS=(
+  autonomous-workflow
+  aw-create-plan
+  aw-create-walkthrough
+  confidence
+  code-quality
+  holistic-analysis
+  tdd
+  ux
+  docs
+  review-changes
+  create-pr
+  ci-auto-fix
+  persistent-memory
+)
+AW_AGENTS=(
+  reviewer.md
+  pr-reviewer.md
+)
+
+in_aw_set() {
+  local kind="$1" name="$2"
+  local item
+  if [[ "$kind" == "skill" ]]; then
+    for item in "${AW_SKILLS[@]}"; do
+      [[ "$item" == "$name" ]] && return 0
+    done
+  else
+    for item in "${AW_AGENTS[@]}"; do
+      [[ "$item" == "$name" ]] && return 0
+    done
+  fi
+  return 1
+}
 
 created=0
 repaired=0
@@ -147,6 +201,9 @@ max_name=4   # "NAME"
 while IFS= read -r -d '' skill_md; do
   skill_path="$(dirname "$skill_md")"
   name="$(basename "$skill_path")"
+  if (( AW_ONLY )) && ! in_aw_set skill "$name"; then
+    continue
+  fi
   entries+=("skill	$name	$skill_path")
   (( ${#name} > max_name )) && max_name=${#name}
 done < <(find "$REPO_ROOT/skills" -mindepth 1 -maxdepth 5 -type f -name SKILL.md -print0 2>/dev/null)
@@ -154,9 +211,17 @@ done < <(find "$REPO_ROOT/skills" -mindepth 1 -maxdepth 5 -type f -name SKILL.md
 for agent_path in "$REPO_ROOT"/agents/*.md; do
   [[ -f "$agent_path" ]] || continue
   name="$(basename "$agent_path")"
+  if (( AW_ONLY )) && ! in_aw_set agent "$name"; then
+    continue
+  fi
   entries+=("agent	$name	$agent_path")
   (( ${#name} > max_name )) && max_name=${#name}
 done
+
+if (( AW_ONLY )); then
+  log "mode: --aw (autonomous-workflow bundle: ${#AW_SKILLS[@]} skills + ${#AW_AGENTS[@]} agents)"
+  log ""
+fi
 
 if (( DRY_RUN )); then
   # Header.
@@ -214,7 +279,11 @@ fi
 # failure so the user sees the installer's error directly.
 queued=()
 while IFS= read -r -d '' install_script; do
-  queued+=("$(basename "$(dirname "$install_script")")")
+  skill_name="$(basename "$(dirname "$install_script")")"
+  if (( AW_ONLY )) && ! in_aw_set skill "$skill_name"; then
+    continue
+  fi
+  queued+=("$skill_name")
   (( DRY_RUN )) || bash "$install_script" --development --quiet
 done < <(find "$REPO_ROOT/skills" -mindepth 1 -maxdepth 5 -type f -name install.sh -print0 2>/dev/null)
 

--- a/skills/workflow/autonomous-workflow/README.md
+++ b/skills/workflow/autonomous-workflow/README.md
@@ -1,4 +1,4 @@
-# Autonomous Workflow
+# `@aw` — Autonomous Workflow
 
 > Execute complete feature development cycles autonomously using isolated worktrees, layered companion skills, and a CI gate.
 
@@ -72,51 +72,30 @@ hooks, smart cleanup, shell-integrated `gw cd`), then the workflow continues
 normally. See [`rules/prerequisites.md#fallback-to-native-git-worktree`](./rules/prerequisites.md#fallback-to-native-git-worktree)
 for the full feature comparison.
 
-### Step 2: Install the skill + agents
-
-The skill ships with [`install.sh`](./install.sh) which handles the agent +
-routing-rule symlinks for you. Two steps: download skills, then run install.
-
-> **Pass `--agent claude-code`.** Without it, `npx skills` symlinks every skill
-> into ~24 different AI-tool directories at once (`.codebuddy/`, `.continue/`,
-> `.crush/`, `.factory/`, `.goose/`, `.junie/`, `.kilocode/`, …). Scoping the
-> install to the tool you actually use keeps your workspace tidy and your
-> `git status` short. Drop the flag (or use `--agent '*'`) only if you really
-> want the universal install.
-
-#### Option A: Global (personal use, all projects)
+### Step 2: Clone and install
 
 ```bash
-npx skills add https://github.com/mthines/agent-skills \
-  --skill autonomous-workflow aw-create-plan aw-create-walkthrough confidence \
-          code-quality holistic-analysis tdd ux docs \
-          review-changes create-pr ci-auto-fix persistent-memory \
-  --agent claude-code \
-  --global --yes
-bash ~/.claude/skills/autonomous-workflow/install.sh --global
+git clone https://github.com/mthines/agent-skills.git
+cd agent-skills
+bash scripts/sync-symlinks.sh --aw
 ```
 
-#### Option B: Per-project (team use, committable)
+`--aw` symlinks the autonomous-workflow skill and its 12 companion skills,
+plus the `aw` / `aw-planner` / `aw-executor` agents, into your `~/.claude/`
+directory. Edits to the cloned repo are picked up live on the next agent
+turn — `git pull` is the whole upgrade story.
 
-```bash
-npx skills add https://github.com/mthines/agent-skills \
-  --skill autonomous-workflow aw-create-plan aw-create-walkthrough confidence \
-          code-quality holistic-analysis tdd ux docs \
-          review-changes create-pr ci-auto-fix persistent-memory \
-  --agent claude-code \
-  --yes
-bash .claude/skills/autonomous-workflow/install.sh
-```
+To install **every** skill and agent in this repo (not just the AW bundle),
+drop the `--aw` flag. To preview without applying, add `--dry-run` (or `-n`).
 
-To run with fewer companions, omit them from the `--skill` list. See
-[Disabling Companions](#disabling-companions) below. Run
-`bash install.sh --help` for script options.
+> **Prefer a no-clone install?** `npx skills add` still works — see the root
+> [README](../../../README.md#install) for the npx path and other options.
 
 Then say *"implement X independently"* (or invoke `@aw`) — the routing rule
 dispatches the **`aw` dispatcher**, which detects the tier and routes: Micro/Lite
 run single-pass; Full hands off to the planner→executor split.
 
-#### What `install.sh` sets up
+#### What gets installed
 
 Three agents linked into your `.claude/agents/` directory under the
 **`aw-` namespace** (short for "autonomous-workflow") so they group together
@@ -195,20 +174,21 @@ Best for permanent project-level customization:
    row's "Disable by" link).
 4. Commit. Future runs in this project will skip the companion.
 
-### 2. Skip at install time (omit from `--skill` list)
+### 2. Remove individual symlinks after install
 
-Best for per-machine or one-off customization. When running
-`npx skills add ...`, simply omit the companion from the `--skill` list:
+Best for per-machine or one-off customization. After running
+`bash scripts/sync-symlinks.sh --aw`, delete the symlink for any companion
+you don't want:
 
 ```bash
-# Install everything except `tdd` and `ux`
-npx skills add https://github.com/mthines/agent-skills \
-  --skill autonomous-workflow aw-create-plan aw-create-walkthrough confidence \
-          code-quality holistic-analysis docs \
-          review-changes create-pr ci-auto-fix \
-  --agent claude-code \
-  --yes
+# Drop tdd and ux from this machine's install
+rm ~/.claude/skills/tdd ~/.claude/skills/ux
 ```
+
+Re-running `bash scripts/sync-symlinks.sh --aw` would re-create them, so commit
+to the removal: either don't re-run, or edit the `AW_SKILLS` list in
+[`scripts/sync-symlinks.sh`](../../../scripts/sync-symlinks.sh) to drop them
+permanently.
 
 When the workflow tries to invoke the missing companion, Claude will return an
 error and the workflow will log:

--- a/skills/workflow/autonomous-workflow/SKILL.md
+++ b/skills/workflow/autonomous-workflow/SKILL.md
@@ -308,56 +308,30 @@ the full handoff contract is in
 
 ## Auto-Trigger Setup (Recommended)
 
-Install the skill + companions so Claude auto-triggers on phrases like
-*"implement X independently"*, *"in isolation"*, *"end-to-end"*. Two steps:
-download skills, then run [`install.sh`](./install.sh).
-
-**Global** (personal use, all projects):
+Install the skill, its companions, and the `aw-*` agents in one step:
 
 ```bash
-npx skills add https://github.com/mthines/agent-skills \
-  --skill autonomous-workflow aw-create-plan aw-create-walkthrough confidence \
-          code-quality holistic-analysis tdd ux docs \
-          review-changes create-pr ci-auto-fix persistent-memory \
-  --agent claude-code \
-  --global --yes
-bash ~/.claude/skills/autonomous-workflow/install.sh --global
+git clone https://github.com/mthines/agent-skills.git
+cd agent-skills
+bash scripts/sync-symlinks.sh --aw
 ```
 
-**Per-project** (team use, committable):
+`--aw` symlinks the autonomous-workflow skill and its 12 companion skills
+into `~/.claude/skills/`, plus the `aw` / `aw-planner` / `aw-executor` agents
+into `~/.claude/agents/`. The `reviewer` agent (optional Phase 6/7 review) is
+also linked; remove its symlink and Phase 7 logs `reviewer — not available,
+continuing` and proceeds. Edits to the cloned repo are picked up live on the
+next agent turn.
 
-```bash
-npx skills add https://github.com/mthines/agent-skills \
-  --skill autonomous-workflow aw-create-plan aw-create-walkthrough confidence \
-          code-quality holistic-analysis tdd ux docs \
-          review-changes create-pr ci-auto-fix persistent-memory \
-  --agent claude-code \
-  --yes
-bash .claude/skills/autonomous-workflow/install.sh
-```
+The routing rule dispatches `aw`, which detects the tier and routes —
+Micro/Lite single-pass, or planner→executor for Full. After install, Claude
+auto-triggers on phrases like *"implement X independently"*, *"in isolation"*,
+*"end-to-end"*.
 
-> **Want the optional Phase 7 auto-review?** Install the `reviewer` agent
-> alongside the skill. Today the easiest path is to clone the agent
-> definition into your agents directory (`agents/reviewer.md`); the
-> workflow detects it at `.claude/agents/reviewer.md`,
-> `~/.agents/agents/reviewer.md`, or `~/.claude/agents/reviewer.md` and
-> dispatches it automatically when CI turns green. Skip the install and
-> Phase 7 logs `reviewer — not available, continuing` and proceeds.
-
-> The `--agent claude-code` flag is recommended — it scopes the install to
-> `.claude/skills/` only. Without it the CLI symlinks the skills into every
-> supported AI tool's directory at once (`.codebuddy/`, `.continue/`, `.crush/`,
-> …). Drop it (or use `--agent '*'`) only if you want the universal install.
-
-After the script runs, three agents are linked into your `.claude/agents/`
-directory: `aw.md` (the opt-in dispatcher), `aw-planner.md`, and
-`aw-executor.md` (the `aw-` prefix is the autonomous-workflow namespace). The
-routing rule dispatches `aw`, which detects the tier and routes — Micro/Lite
-single-pass, or planner→executor for Full.
-
-To run with fewer companions, omit them from the `--skill` list. See
-[`rules/companion-skills.md`](./rules/companion-skills.md) for what each does
-and how to disable. Run `bash install.sh --help` for script options.
+To install the full repo (not just the AW bundle) drop the `--aw` flag. For
+the per-project install, the no-clone `npx skills add` alternative, or
+per-companion disabling, see the [README](./README.md#installation) and
+[`rules/companion-skills.md`](./rules/companion-skills.md).
 
 ---
 


### PR DESCRIPTION
## Why

The autonomous-workflow install was two ~12-line `npx skills add` blocks plus a follow-up `install.sh` — intimidating enough that users bounce off. Replacing it with one `bash scripts/sync-symlinks.sh --aw` makes the install a 3-line copy-paste while reusing the existing symlink machinery.

## What changed

- `scripts/sync-symlinks.sh`: add `--aw` flag with a hardcoded `AW_SKILLS` / `AW_AGENTS` allowlist (mirrors the bundle documented in the AW README); proper `while/case` arg parser replaces the prior `$1`-only check and errors cleanly on unknown args.
- `skills/workflow/autonomous-workflow/README.md`: title → `` `@aw` — Autonomous Workflow ``; Step 2 replaced; "Disabling Companions §2" rewritten as "remove individual symlinks after install".
- `skills/workflow/autonomous-workflow/SKILL.md`: same Auto-Trigger Setup swap so the agent-facing index stays in sync.

## How to verify

```bash
HOME=$(mktemp -d) bash scripts/sync-symlinks.sh --aw
# 13 skill symlinks + 5 agent symlinks (incl. aw / aw-planner / aw-executor)
# + routing rule land in $HOME/.claude; all resolve to real targets
```

## Notes for reviewers

If a `--fix-bug` or `--batch` bundle is ever added, the current shape duplicates — flagged but left as YAGNI (Critical Rule 4); refactor cost is low when the second bundle actually arrives.