### PR TITLE
fix(ci-auto-fix): reviewer follow-ups missed by #40 squash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Type markers (by primary entry point — all three are technically model-invocab
 ### `delivery/` — Git, PR, CI
 
 - `changelog` (`/`) — personal PR + Linear ticket digest. Template: [`delivery/changelog/templates/changelog.md`](./skills/delivery/changelog/templates/changelog.md)
-- `ci-auto-fix` (`/`) — diagnose and fix failed GitHub Actions checks until green
+- `ci-auto-fix` (`/`) — verdict-gated, confidence-gated CI diagnosis and fix; `flaky`/`unsure` escalate, `*-bug` verdicts continue to a ≥90/80–89/<80 gate; regressing pushes auto-revert
 - `create-pr` (`/`) — narrative PR description; watch CI. Flags: `--split`, `--review`
 - `github-actions-author` (`/`) — author / review GHA workflows (2026 best practices)
 - `resolve-conflicts` (`/`) — analyze and resolve merge / rebase conflicts

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Plumbing for shipping code.
 | Skill | What it does | Type |
 |-------|--------------|------|
 | **[/create-pr](./skills/delivery/create-pr/SKILL.md)** | Narrative PR description, push, open PR, watch CI, auto-fix simple failures. Flags: `--split` (multi-PR breakdown), `--review` (Claude GitHub App + auto-implement loop). | `/` |
-| **[/ci-auto-fix](./skills/delivery/ci-auto-fix/SKILL.md)** | Diagnoses a failed CI check, applies a minimal fix, pushes, iterates until green. Refuses to disable or weaken checks. | `/` |
+| **[/ci-auto-fix](./skills/delivery/ci-auto-fix/SKILL.md)** | Verdict-gated CI diagnosis and fix (`code-bug\|workflow-bug\|dep-bug\|env-bug\|flaky\|unsure`); confidence gate (≥90 auto, 80–89 ask, <80 escalate); regressing pushes auto-revert. Refuses to disable or weaken checks. | `/` |
 | **[/resolve-conflicts](./skills/delivery/resolve-conflicts/SKILL.md)** | Detects merge/rebase conflicts, shows both sides with context, proposes resolutions, asks for ambiguous cases. | `/` |
 | **[/changelog](./skills/delivery/changelog/SKILL.md)** | Generates a personal markdown changelog of merged PRs and closed Linear tickets over a configurable window (default 7 days). | `/` |
 | **[/github-actions-author](./skills/delivery/github-actions-author/SKILL.md)** | Authors and reviews fast, cheap, maintainable GitHub Actions workflows (2026 best practices). Modes: `scaffold`, `review`. | `/` |

--- a/skills/delivery/ci-auto-fix/rules/confidence-gate.md
+++ b/skills/delivery/ci-auto-fix/rules/confidence-gate.md
@@ -25,7 +25,7 @@ Before editing any file.
 Invoke the `confidence` skill in analysis mode:
 
 ```text
-Skill("confidence", "analyze proposed fix: <one-line summary>; verdict: <code-bug|workflow-bug|dep-bug|env-bug>; surface: ci; risk: <workflow-touch|prod-code-touch|lockfile-touch>")
+Skill("confidence", "analysis proposed fix: <one-line summary>; verdict: <code-bug|workflow-bug|dep-bug|env-bug>; surface: ci; risk: <workflow-touch|prod-code-touch|lockfile-touch>")
 ```
 
 Record the score in the plan artifact under `## Confidence`.
@@ -34,7 +34,7 @@ Record the score in the plan artifact under `## Confidence`.
 
 | Score | Action |
 | --- | --- |
-| ≥ 90 | Auto-apply. Continue to Step 4 in [`../SKILL.md`](../SKILL.md). |
+| ≥ 90 | Auto-apply. Continue to Phase 4 in [`../SKILL.md`](../SKILL.md). |
 | 80–89 | Show the diff, ask the user once, apply on approval. |
 | < 80 | Escalate. Do not write. |
 

--- a/skills/delivery/ci-auto-fix/rules/confidence-gate.md
+++ b/skills/delivery/ci-auto-fix/rules/confidence-gate.md
@@ -56,3 +56,10 @@ The `risk:` tag in the prompt shapes the gate's strictness:
 
 Pick the dominant risk if the fix touches multiple surfaces.
 Do not stack risk tags.
+
+Tiebreaker for mixed surfaces:
+
+1. If any touched surface is `prod-code-touch`, use `prod-code-touch`.
+2. Otherwise, prefer `lockfile-touch` over `workflow-touch`.
+
+Rationale: a wrong production-code change ships incorrect behavior to users (strongest blast radius), a wrong lockfile pin reproduces deterministically in every environment, and a wrong workflow edit only affects future CI runs.

--- a/skills/delivery/ci-auto-fix/rules/regression-detection.md
+++ b/skills/delivery/ci-auto-fix/rules/regression-detection.md
@@ -18,7 +18,7 @@ This rule is non-optional.
 
 ## When to run
 
-In Step 8 of [`../SKILL.md`](../SKILL.md), after the new CI run completes and its failed-job logs have been fetched.
+In Phase 8 of [`../SKILL.md`](../SKILL.md), after the new CI run completes and its failed-job logs have been fetched.
 
 ## Decision table
 
@@ -50,7 +50,7 @@ Other clones, PR review comments, and CI artifacts pinned to the reverted SHA al
 ## Iteration cap
 
 Maximum 4 iterations.
-If still failing after 4 attempts (including any reverts), escalate with the structured exit summary from Step 9.
+If still failing after 4 attempts (including any reverts), escalate with the structured exit summary from Phase 9.
 
 ## Definition of "new failure"
 

--- a/skills/delivery/ci-auto-fix/rules/regression-detection.md
+++ b/skills/delivery/ci-auto-fix/rules/regression-detection.md
@@ -35,9 +35,19 @@ git revert HEAD --no-edit
 git push origin "<branch>"
 ```
 
+Then sync to the authoritative remote state before re-planning — a concurrent worker (`/implement-suggestion`, parallel `ci-auto-fix`) may have pushed between the revert and the next iteration:
+
+```bash
+git pull --rebase origin "<branch>"
+git log -1 --format='Baseline after revert: %H'
+```
+
+Record the printed baseline SHA in the plan artifact's `## Iteration <N> — reverted` section so the user can verify the post-revert HEAD matches the expected pre-fix baseline.
+If the rebase conflicts, stop and report — do not auto-resolve and do not re-plan on an unknown HEAD.
+
 Then:
 
-1. Append a `## Iteration <N> — reverted` section to the plan artifact (see [`../templates/plan-artifact.md`](../templates/plan-artifact.md)).
+1. Append a `## Iteration <N> — reverted` section to the plan artifact (see [`../templates/plan-artifact.md`](../templates/plan-artifact.md)), including the baseline SHA.
 2. Re-classify from the original failure set in [`verdicts.md`](./verdicts.md).
 3. If the second attempt also regresses, escalate — do not try a third.
 

--- a/skills/delivery/ci-auto-fix/rules/verdicts.md
+++ b/skills/delivery/ci-auto-fix/rules/verdicts.md
@@ -33,12 +33,25 @@ Record it in the plan artifact (see [`../templates/plan-artifact.md`](../templat
 
 Read the relevant source files before proposing a fix.
 Never propose a code change from the log alone.
-If the failure is a test, classify whether the test or the production code is wrong (defer to a dedicated test-healing skill, e.g. `/test-healer`, when the local repo has it installed).
+
+Sub-classify the failure shape before fixing:
+
+- Formatter / linter auto-fix available (`pnpm lint --fix`, `ruff --fix`, `gofmt`) → apply and re-run.
+- Trivial type error (missing import, wrong generic argument, obvious null check) → fix in place.
+- Real test failure → classify whether the test or the production code is wrong; defer to a dedicated test-healing skill (e.g. `/test-healer`) when the local repo has it installed.
+
+A failure forwarded from `/create-pr`'s triage as `lint-format` or `trivial-type` is not a test failure and must not be routed to `/test-healer`.
 
 ### `workflow-bug`
 
 Read every workflow file in `.github/workflows/` before editing one.
 Job dependencies (`needs:`), composite actions, and reusable workflows mean a one-file change can break a sibling job — see Phase 2 in [`../SKILL.md`](../SKILL.md).
+
+Common shapes:
+
+- Runner permission / OIDC failures (`Error: Resource not accessible by integration`, `id-token: write` missing) → add or correct the `permissions:` block at the job or workflow level. This is a structural fix, not a logic edit.
+- Wrong action version → bump to a pinned tag (never `@main`) and link the upstream changelog entry justifying the bump.
+- Missing or misnamed secret → surface to the user before editing; secret names are case-sensitive and adding a guess wastes a runner.
 
 ### `dep-bug`
 

--- a/skills/delivery/ci-auto-fix/rules/verdicts.md
+++ b/skills/delivery/ci-auto-fix/rules/verdicts.md
@@ -38,7 +38,7 @@ If the failure is a test, classify whether the test or the production code is wr
 ### `workflow-bug`
 
 Read every workflow file in `.github/workflows/` before editing one.
-Job dependencies (`needs:`), composite actions, and reusable workflows mean a one-file change can break a sibling job — see Step 2 in [`../SKILL.md`](../SKILL.md).
+Job dependencies (`needs:`), composite actions, and reusable workflows mean a one-file change can break a sibling job — see Phase 2 in [`../SKILL.md`](../SKILL.md).
 
 ### `dep-bug`
 

--- a/skills/delivery/ci-auto-fix/templates/plan-artifact.md
+++ b/skills/delivery/ci-auto-fix/templates/plan-artifact.md
@@ -17,6 +17,7 @@
 - Score: <0–100>
 - Risk tag: <workflow-touch | prod-code-touch | lockfile-touch>
 - Action: <auto-apply | ask-once | escalate>
+- Escalation reason: <one sentence — fill in only when Action is `escalate`>
 
 ## Iteration <N> — <result>
 


### PR DESCRIPTION
## Why

PR #40 was squashed early — only the original v3.0 commit landed on `main`. The reviewer auto-fixes and the High/Medium/Low fixes I'd already pushed to the branch never made it across. Without this, the gate's `Skill("confidence", "analyze …")` invocation hits a non-existent mode and the rule files still reference "Step N" against `SKILL.md`'s "Phase N".

## What changed

- `confidence-gate.md` — `"analyze"` → `"analysis"` (broken `confidence` skill mode), `Step 4` → `Phase 4`, plus a tiebreaker for mixed-surface fixes (`prod-code-touch` > `lockfile-touch` > `workflow-touch`)
- `regression-detection.md` — `Step 8/9` → `Phase 8/9`, plus a post-revert `git pull --rebase` + log of the baseline SHA so a concurrent worker push can't land the re-plan on an unknown HEAD
- `verdicts.md` — sub-classify `code-bug` into formatter / trivial-type / real test (stops `/create-pr`-forwarded lint failures mis-routing to `/test-healer`); add OIDC / `permissions:` / missing-secret shapes under `workflow-bug`
- `templates/plan-artifact.md` — escalation-reason field so an escalated artifact records the gate's reason
- `CLAUDE.md` + `README.md` — inventory line updated to reflect the v3 verdict + gate model

## How to verify

- `node scripts/eval/l1.mjs` — 69/69 pass

## Notes for reviewers

Follow-up to #40; ready to merge.