### PR TITLE
feat(testing): add test-autofix global skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ dist
 # Environment
 .env*
 .next
+
+# test-autofix per-project surface files (project-local state, not committed)
+skills/testing/test-autofix/surfaces/*.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Type markers (by primary entry point — all three are technically model-invocab
 - `e2e-testing-mobile` (`/`) — Maestro YAML flows for Expo / React Native; `testID`-first locator ladder; runs on Maestro Cloud via EAS
 - `e2e-pr-stabilizer` (`/`) — local-first stabilizer for Playwright E2E on one PR; Dash0 MCP spans (`git.pull_request_link`) as historical baseline, then iterates locally with `--trace=on` and the same OTel exporter. Validation is empirical, not predictive: every new locator must resolve against source (static grep) or the live app (`locator.count() ≥ 1`) before commit, and the fixed test must pass 3 consecutive local runs before the single push. CI watch ratifies. Refuses `.skip` / `.fixme` / `waitForTimeout`. Two modes: `stabilize` (default) and `optimize` (report-only, ranks slow-action wins by measured ms saved, no commits)
 - `optimize-mock-data` (`/`) — JSON/JSONL fixture analyze / normalize / shrink
+- `test-autofix` (`/`) — stack-agnostic test healer: bootstrap surface on first run, classify test-bug vs prod-bug, confidence-gate every fix, regression-detect after each batch; supports Vitest, Jest, Deno, Playwright, Pytest, Maestro, Storybook
 
 ### `design/` — UI, visual, interaction
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Plumbing for shipping code.
 | **[/e2e-testing-mobile](./skills/testing/e2e-testing-mobile/SKILL.md)** | Mobile counterpart on Maestro YAML flows for Expo / React Native. `testID`-first locator ladder; runs on Maestro Cloud via EAS Workflow. | `/` |
 | **[/e2e-pr-stabilizer](./skills/testing/e2e-pr-stabilizer/SKILL.md)** | Local-first stabilizer for Playwright E2E on one PR. Pulls Dash0 MCP spans (`git.pull_request_link`) as historical baseline, then iterates locally with `--trace=on` and the same OTel exporter. Validation is empirical, not predictive: every new locator must resolve against source (static grep) or the live app (`locator.count() ≥ 1`) before commit, and the fixed test must pass 3 consecutive local runs before the single push. CI watch ratifies. Refuses `.skip` / `.fixme` / `waitForTimeout`. Modes: `stabilize` (default) and `optimize` (report-only, ranks slow-action wins by measured ms saved). | `/` |
 | **[/optimize-mock-data](./skills/testing/optimize-mock-data/SKILL.md)** | Optimizes JSON/JSONL fixture directories via shared-schema inference, drift detection, safe shrink/normalize. | `/` |
+| **[/test-autofix](./skills/testing/test-autofix/SKILL.md)** | Stack-agnostic test healer. Bootstrap auto-detects your stack (Vitest, Jest, Deno, Playwright, Pytest, Maestro, Storybook) and writes a surface file on first run. Classifies each failure as `test-bug`, `prod-bug`, or `unsure`; confidence-gates every fix (≥90 auto, 80–89 ask, <80 escalate); reverts on regression. | `/` |
 
 ### `design/` — UI, visual, interaction
 
@@ -407,7 +408,8 @@ That is the entire integration.
 ## Repository structure
 
 ```
-skills/                   39 skills, each with SKILL.md (some with rules/, references/, templates/, scripts/)
+skills/                   40 skills, each with SKILL.md (some with rules/, references/, templates/, scripts/)
+  testing/test-autofix/    stack-agnostic test healer — bootstrap, classify, confidence-gate, regression-detect
 agents/                   5 agents (reviewer, pr-reviewer, linear-ticket-investigator, bug-fix-verifier, feature-pr-verifier)
 plugins/                  1 Claude Code plugin (agent-tasks-hooks)
 packages/                 VS Code extension (vscode-agent-tasks)

--- a/memory/aw-lessons/AUDIT.log
+++ b/memory/aw-lessons/AUDIT.log
@@ -2,3 +2,4 @@
 # Format: <ISO-8601 timestamp> | <operation> | <count> | <one-line summary>
 2026-06-11T10:00:00Z | write | 1 | ADD: no-chained-reviewer-after-autonomous-pr (Phase 4)
 2026-06-11T10:20:00Z | update | 1 | UPDATE: no-chained-reviewer-after-autonomous-pr (Phase 4 → Phase 7, downgraded to closing-nudge; primary owner moved to reviewer-lessons)
+{"ts":"2026-06-14T12:00:00Z","op":"write","scope":"aw-lessons","added":1,"updated":0,"deleted":0,"actor":"system","auto":true}

--- a/memory/aw-lessons/INDEX.md
+++ b/memory/aw-lessons/INDEX.md
@@ -27,6 +27,8 @@
 
 ### Phase 3 — Implementation
 
+- [2026-06-14-add-contents-to-long-rules-files](entries/2026-06-14-add-contents-to-long-rules-files.md) — When scaffolding a skill, check every rules/*.md line count during authoring and add ## Contents if >100 lines; do not defer to the quality-checklist phase.
+
 ### Phase 4 — Testing
 
 - See Phase 7 entry below — the chained-rounds RAM lesson sits at end-of-run, since `aw`'s own verify is correct and the actionable owner is [`reviewer-lessons`](../reviewer-lessons/INDEX.md).

--- a/memory/aw-lessons/entries/2026-06-14-add-contents-to-long-rules-files.md
+++ b/memory/aw-lessons/entries/2026-06-14-add-contents-to-long-rules-files.md
@@ -1,0 +1,25 @@
+---
+id: 2026-06-14-add-contents-to-long-rules-files
+created: 2026-06-14T12:00:00Z
+updated: 2026-06-14T12:00:00Z
+type: procedural
+scope: aw-lessons
+phase: 3
+trigger-context: skill scaffolding (skills/<category>/<name>/rules/*.md files)
+seen_count: 1
+confidence: high
+status: active
+expires: 2026-09-14T12:00:00Z
+source: system
+redacted: false
+---
+
+# Add ## Contents to rules files exceeding 100 lines before quality-checklist gate
+
+**What failed:** Three rule files (`bootstrap.md`, `project-keying.md`, `surface-validation.md`) were written at 120, 107, and 103 lines respectively without `## Contents` sections. The quality-checklist gate requires every file >100 lines to have one, causing retroactive edits.
+
+**Why:** Files were written to spec and grew past 100 lines organically. The Contents requirement was only caught at the checklist phase rather than during authoring.
+
+**What to do next time:** After writing each `rules/*.md` file, immediately check its line count with `wc -l`. If it exceeds 100 lines, add a `## Contents` section listing all `##` headings before moving to the next file. Do not batch this check to the end of Phase 3.
+
+**Promotion target:** Phase 3 implementation rule for skill scaffolding — could become a per-file gate in `create-skill`'s quality-checklist.md.

--- a/skills/testing/test-autofix/SKILL.md
+++ b/skills/testing/test-autofix/SKILL.md
@@ -46,7 +46,7 @@ Load the matching rule file when you need detail — do not preload them.
 | 4 | Apply + verify single failing test | this file + [`rules/anti-patterns.md`](./rules/anti-patterns.md) |
 | 5 | test-provenance-guard (optional companion) | invoke `Skill("test-provenance-guard")` |
 | 6 | Outer loop: re-run full surface; regression-detect | [`rules/regression-detection.md`](./rules/regression-detection.md) |
-| 9 | Report (structured exit summary) | [`templates/exit-summary.md`](./templates/exit-summary.md) |
+| 7 | Report (structured exit summary) | [`templates/exit-summary.md`](./templates/exit-summary.md) |
 
 Always read [`rules/anti-patterns.md`](./rules/anti-patterns.md) first.
 The hard refusals apply to every phase.
@@ -66,13 +66,29 @@ The argument is: `$ARGUMENTS`.
 
 ## Phase 0 — Resolve the surface
 
-Determine the surface file for the current project.
+Determine the surface file for the current project. Phase 0 is a hard
+two-branch decision; pick exactly one path and follow it through.
+
+### Step 1 — Pick the resolution branch
+
+- **If `--surface <path>` was passed** → branch A.
+- **Otherwise** → branch B.
+
+### Branch A — `--surface <path>` override
+
+Use the file at `<path>` directly as the surface. **Do NOT compute the project
+key, do NOT scan `surfaces/`, do NOT run bootstrap.**
+
+Still validate per [`rules/surface-validation.md`](./rules/surface-validation.md),
+but tolerate the project-key mismatch warning (it's expected when overriding).
+
+When validation passes, jump straight to Phase 1.
+
+### Branch B — Auto-resolve from project key
 
 1. Compute the project key per [`rules/project-keying.md`](./rules/project-keying.md).
 
-2. If `--surface <path>` was passed: use that file directly. Skip steps 3–5.
-
-3. Look for `surfaces/<project-key>.md` next to this skill file.
+2. Look for `surfaces/<project-key>.md` next to this skill file.
    The skill's own directory is resolved by following the symlink chain of
    the loaded `SKILL.md`:
    ```bash
@@ -81,13 +97,15 @@ Determine the surface file for the current project.
    If that fails (model-invocation context), default to
    `~/.agents/skills/test-autofix/surfaces/`.
 
-4. If no surface file is found: run bootstrap per [`rules/bootstrap.md`](./rules/bootstrap.md).
-   Bootstrap detects the stack, proposes a surface diff, waits for user approval,
-   then writes the file. Do NOT proceed to Phase 1 until the surface exists.
+3. **If no surface file is found** → run bootstrap per
+   [`rules/bootstrap.md`](./rules/bootstrap.md). Bootstrap detects the stack,
+   proposes a surface diff, waits for user approval, then writes the file.
+   Do NOT proceed to Phase 1 until the surface exists.
 
-5. If a surface file exists: validate it per [`rules/surface-validation.md`](./rules/surface-validation.md).
-   If validation fails, propose an update diff and ask once.
-   If the user declines the update, escalate — do not run with an invalid surface.
+4. **If a surface file exists** → validate it per
+   [`rules/surface-validation.md`](./rules/surface-validation.md). If validation
+   fails, propose an update diff and ask once. If the user declines the update,
+   escalate — do not run with an invalid surface.
 
 ## Phase 1 — Detect failures and build the plan
 
@@ -205,7 +223,7 @@ After a batch of fixes:
 
 4. On any exit, write a summary section to the plan file.
 
-## Phase 9 — Report
+## Phase 7 — Report
 
 Always end with the structured exit summary from
 [`templates/exit-summary.md`](./templates/exit-summary.md).

--- a/skills/testing/test-autofix/SKILL.md
+++ b/skills/testing/test-autofix/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: test-autofix
+description: >
+  Diagnoses failing tests across any project, classifies each failure as a
+  test-bug, prod-bug, or unsure, confidence-gates the fix (auto-apply at
+  >=90%, 80-89 ask, <80 escalate), applies it, and re-runs until green.
+  Surface-driven: reads per-project configuration from a surface file keyed
+  by normalised git remote URL. Bootstrap auto-detects the stack on first
+  run and proposes a surface diff for user approval. Hard-refuses to delete
+  tests, add .skip/.only, or weaken assertions. Regression-detects after
+  every fix: reverts on new failure instead of stacking. Triggers on "fix
+  my failing tests", "tests are red", "auto-fix tests", "heal the tests",
+  "/test-autofix".
+disable-model-invocation: false
+license: MIT
+metadata:
+  author: mthines
+  version: '1.0.0'
+  workflow_type: applied
+  tags:
+    - tests
+    - auto-fix
+    - confidence-gate
+    - regression-detection
+    - guardrails
+    - stack-agnostic
+    - surface-driven
+    - bootstrap
+---
+
+# test-autofix
+
+Autonomously diagnose and fix failing tests in any project, with hard
+guardrails so the loop never devolves into "make the red go away".
+
+This `SKILL.md` is the **orchestration index**.
+Load the matching rule file when you need detail — do not preload them.
+
+| Phase | Goal | Required rule |
+| ----- | ---- | ------------- |
+| 0 | Resolve the surface (bootstrap or validate) | [`rules/bootstrap.md`](./rules/bootstrap.md) + [`rules/surface-validation.md`](./rules/surface-validation.md) |
+| 1 | Detect which test surface(s) are failing; build fix plan | this file + [`templates/plan-artifact.md`](./templates/plan-artifact.md) |
+| 2 | Per failure: classify as test-bug / prod-bug / unsure | [`rules/verdicts.md`](./rules/verdicts.md) |
+| 3 | Per failure: draft the smallest possible fix | this file |
+| 3.5 | Confidence gate — before any edit | [`rules/confidence-gate.md`](./rules/confidence-gate.md) |
+| 4 | Apply + verify single failing test | this file + [`rules/anti-patterns.md`](./rules/anti-patterns.md) |
+| 5 | test-provenance-guard (optional companion) | invoke `Skill("test-provenance-guard")` |
+| 6 | Outer loop: re-run full surface; regression-detect | [`rules/regression-detection.md`](./rules/regression-detection.md) |
+| 9 | Report (structured exit summary) | [`templates/exit-summary.md`](./templates/exit-summary.md) |
+
+Always read [`rules/anti-patterns.md`](./rules/anti-patterns.md) first.
+The hard refusals apply to every phase.
+
+## Input
+
+The user provides one of:
+
+- Nothing — auto-run every surface defined in the project surface file.
+- A surface name (`vitest`, `unit`, `integration`, etc.) — run only that surface.
+- A file path — narrow detection and re-run to that file.
+- `--surface <path>` — override the surface file lookup entirely.
+- `--plan-only` — diagnose and produce the plan artifact; do not write code.
+- `--max-iterations N` — outer-loop cap (default 5).
+
+The argument is: `$ARGUMENTS`.
+
+## Phase 0 — Resolve the surface
+
+Determine the surface file for the current project.
+
+1. Compute the project key per [`rules/project-keying.md`](./rules/project-keying.md).
+
+2. If `--surface <path>` was passed: use that file directly. Skip steps 3–5.
+
+3. Look for `surfaces/<project-key>.md` next to this skill file.
+   The skill's own directory is resolved by following the symlink chain of
+   the loaded `SKILL.md`:
+   ```bash
+   readlink -f "$(dirname "$0")"
+   ```
+   If that fails (model-invocation context), default to
+   `~/.agents/skills/test-autofix/surfaces/`.
+
+4. If no surface file is found: run bootstrap per [`rules/bootstrap.md`](./rules/bootstrap.md).
+   Bootstrap detects the stack, proposes a surface diff, waits for user approval,
+   then writes the file. Do NOT proceed to Phase 1 until the surface exists.
+
+5. If a surface file exists: validate it per [`rules/surface-validation.md`](./rules/surface-validation.md).
+   If validation fails, propose an update diff and ask once.
+   If the user declines the update, escalate — do not run with an invalid surface.
+
+## Phase 1 — Detect failures and build the plan
+
+1. Run the detect command from the surface file:
+   ```bash
+   <detect-command>
+   ```
+   If `--path <file>` was supplied, append it to narrow the run.
+   If the cache-bust-flag is set in the surface and a prior run was cached-green,
+   append the flag to force a real run.
+
+2. Parse failures using the `failure-parser` regex from the surface file.
+   Group by file, then by failure type.
+
+3. If every surface is green: stop immediately. Tell the user. Do not invent work.
+
+4. Write the fix plan to `.agent/{branch}/test-autofix-plan.md` using
+   [`templates/plan-artifact.md`](./templates/plan-artifact.md).
+   The plan is read-only documentation of intent.
+   Order: high-confidence test-bug fixes first, prod-bug suspects last.
+
+## Phase 2 — Classify each failure (verdict required)
+
+For every failure, apply the rubric in [`rules/verdicts.md`](./rules/verdicts.md).
+
+Getting this wrong means later phases can corrupt production code to satisfy
+a broken test, or "fix" a real regression by patching the test.
+
+Emit exactly one verdict per failure:
+
+- `test-bug` — production code correct; test drifted. Continue to Phase 3.
+- `prod-bug` — production code regressed; test caught it. **Escalate.** Do not touch the test.
+- `unsure` — confidence < 80%. **Escalate.** Surface the evidence and stop.
+
+## Phase 3 — Draft the minimal fix
+
+For each `test-bug` failure, draft the smallest edit that addresses the
+diagnosed root cause.
+
+Hard refusals — full list and detection patterns in [`rules/anti-patterns.md`](./rules/anti-patterns.md):
+
+- Deleting any test, `describe`, `it`, or story export.
+- Adding `.skip`, `.only`, `xit`, `xdescribe`, `fit`, `fdescribe`, `it.todo`, `test.todo`.
+- Replacing strict matchers with loose ones.
+- Deleting `expect(...)` / `assert*()` calls.
+- Mocking the System Under Test (the module being tested) instead of its deps.
+- Wrapping the failing assertion in `try`/`catch` to swallow it.
+
+## Phase 3.5 — Confidence gate (before any edit)
+
+Invoke the `confidence` skill in analysis mode for each proposed fix:
+
+```text
+Skill("confidence", "analysis proposed fix: <one-line summary>; verdict: <test-bug>; surface: <surface-name>; risk: <test-only|prod-touch>")
+```
+
+Record the score in the plan artifact.
+
+Full decision matrix: [`rules/confidence-gate.md`](./rules/confidence-gate.md).
+
+At a glance:
+
+| Score | Action |
+| ----- | ------ |
+| ≥ 90 | Auto-apply. Continue to Phase 4. |
+| 80–89 | Show the diff, ask once, apply on approval. |
+| < 80 | Escalate. Do not write. |
+
+The gate is non-negotiable. Auto mode does not override it.
+
+## Phase 4 — Apply + verify (per fix)
+
+1. Apply the edit with `Edit` — never `Bash sed/awk`.
+
+2. Re-run only the single failing test using the `single-test-command` from
+   the surface file, substituting `{file}` and `{name}`:
+   ```bash
+   <single-test-command>
+   ```
+
+3. If still failing: do not patch over. Revert with:
+   ```bash
+   git restore <file>
+   ```
+   Re-classify at Phase 2.
+
+4. If green, and `test-provenance-guard` is installed: invoke
+   `Skill("test-provenance-guard")` on the file. If it reports
+   tests-by-construction, revert and escalate.
+
+5. Only after both checks pass, mark the failure resolved in the plan.
+
+## Phase 5 — test-provenance-guard (optional)
+
+If `Skill("test-provenance-guard")` is not installed, log:
+`companion: test-provenance-guard — not available, continuing`
+
+## Phase 6 — Outer loop
+
+After a batch of fixes:
+
+1. Re-run the full surface using the detect command:
+   ```bash
+   <detect-command>
+   ```
+   Regressions hide in untouched files — always re-run the full surface.
+
+2. Compare against the previous failure set per
+   [`rules/regression-detection.md`](./rules/regression-detection.md):
+   - Same failures → back to Phase 2 (re-classify; do not repeat same fix).
+   - Strict subset → continue with remaining failures.
+   - New failure → revert last fix, re-plan or escalate.
+
+3. Cap at `--max-iterations` (default 5).
+
+4. On any exit, write a summary section to the plan file.
+
+## Phase 9 — Report
+
+Always end with the structured exit summary from
+[`templates/exit-summary.md`](./templates/exit-summary.md).
+
+```text
+test-autofix run
+  Outcome: <green | escalated | regression-reverted | max-iterations>
+  Resolved: <N> failures
+  Escalated: <N> failures (<verdicts>)
+  Iterations: <N>/<max>
+  Surface: <surface-file-path>
+  Plan: .agent/{branch}/test-autofix-plan.md
+  Escalation reason: <…>           # if not green
+```
+
+## Definition of done
+
+The run is done when ANY of the following is true:
+
+- All surface tests are green AND the structured exit summary has been printed.
+- All remaining failures are `prod-bug` or `unsure` (escalated; user owns next step).
+- The confidence gate scored < 80 and the fix was not written.
+- A regression was detected, reverted, and the user owns the next step.
+- `--max-iterations` (default 5) was reached.

--- a/skills/testing/test-autofix/detectors/deno.md
+++ b/skills/testing/test-autofix/detectors/deno.md
@@ -1,0 +1,73 @@
+---
+title: Deno Test Detector
+stack: deno
+tags:
+  - deno
+  - typescript
+---
+
+# Deno Test Detector
+
+Bootstrap template for projects using Deno's built-in test runner.
+
+## Detection signals
+
+- `deno.json` or `deno.jsonc` in the project root
+- `deno.lock` present
+- Source files use `Deno.test(...)` calls
+
+## Surface starter template
+
+```yaml
+---
+project-key: <normalised-git-remote-key>
+stack: deno
+detect-command: deno test --allow-read --allow-env
+single-test-command: deno test --allow-read --allow-env {file} --filter "{name}"
+failure-parser: '^\./([^ ]+) => (.+?) \.\.\. FAILED'
+# group 1 = file path relative to cwd, group 2 = test name
+cache-bust-flag:
+---
+# Notes
+# Adjust permissions to match your project's requirements:
+#   --allow-net  (for integration tests hitting real endpoints)
+#   --allow-write  (for tests that write temp files)
+#   --env-file=.env.test  (for tests that need env vars from a file)
+# For Nx monorepos: pnpm exec nx run <project>:test
+```
+
+## Failure output format
+
+```
+./tests/unit/parser_test.ts => parseConfig > "handles missing keys" ... FAILED (12ms)
+error: AssertionError: Values are not equal:
+   -   actual: undefined
+   +   expected: "default"
+    at file:///path/to/tests/unit/parser_test.ts:18:5
+```
+
+Parser regex: `^\./([^ ]+) => (.+?) \.\.\. FAILED`
+
+- Group 1: file path relative to the test run directory (e.g., `tests/unit/parser_test.ts`)
+- Group 2: full test name including suite prefix (e.g., `parseConfig > "handles missing keys"`)
+
+## Single-test re-run
+
+```bash
+deno test --allow-read --allow-env tests/unit/parser_test.ts \
+  --filter "handles missing keys"
+```
+
+The `--filter` flag accepts a substring match.
+Wrap the name in quotes to handle spaces.
+
+## Common failure families
+
+- **Assertion drift** — `assertEquals(actual, expected)` fails after a schema change.
+  Check both the returned shape and the expected value in the test.
+- **Permission mismatch** — test needs `--allow-net` but detect-command only has `--allow-read`.
+  Add the missing permission flag to the surface file.
+- **env-file missing** — integration tests read secrets from `.env.test`;
+  confirm the file exists and the flag is included in the command.
+- **Import map drift** — `import_map.json` updated upstream; a module path changed.
+- **Stale lock file** — `deno.lock` out of sync; run `deno cache --reload <entrypoint>`.

--- a/skills/testing/test-autofix/detectors/jest.md
+++ b/skills/testing/test-autofix/detectors/jest.md
@@ -1,0 +1,75 @@
+---
+title: Jest Detector
+stack: jest
+tags:
+  - jest
+  - javascript
+  - typescript
+---
+
+# Jest Detector
+
+Bootstrap template for projects using Jest.
+
+## Detection signals
+
+- `jest.config.ts`, `jest.config.js`, or `jest.config.cjs` in the project root
+- `"jest"` in `package.json` devDependencies
+
+## Surface starter template
+
+```yaml
+---
+project-key: <normalised-git-remote-key>
+stack: jest
+detect-command: pnpm exec jest --verbose
+single-test-command: pnpm exec jest --testPathPattern="{file}" --testNamePattern="{name}"
+failure-parser: '^\s*●\s+(.+?)\s*›\s*(.+?)\s*$'
+# group 1 = describe block, group 2 = test name
+# Note: Jest does not print the file path in the failure line itself.
+# Use the "FAIL src/..." header line to extract the file.
+cache-bust-flag: --no-cache
+---
+# Notes
+# For Nx monorepos: pnpm exec nx run <project>:test
+# Adjust --testPathPattern to match your project structure.
+# If using Jest with Babel/ESM, consider: NODE_OPTIONS='--experimental-vm-modules' pnpm exec jest
+```
+
+## Failure output format
+
+```
+FAIL  src/services/auth.test.ts
+  ● AuthService › login › "returns token on valid credentials"
+
+    expect(received).toEqual(expected)
+
+    Expected: {"token": "abc123"}
+    Received: undefined
+
+      24 |   it("returns token on valid credentials", async () => {
+    > 25 |     expect(await authService.login(creds)).toEqual({ token: "abc123" });
+         |                                            ^
+      26 |   });
+```
+
+The file path is in the `FAIL  src/...` header line.
+The test identity is in the `●  <describe> › <test>` line.
+
+Header parser: `^FAIL\s+(\S+\.(?:test|spec)\.[jt]sx?)`
+Test parser: `^\s+●\s+(.+?)\s*$`
+
+## Single-test re-run
+
+```bash
+pnpm exec jest --testPathPattern="src/services/auth.test.ts" \
+  --testNamePattern="returns token on valid credentials"
+```
+
+## Common failure families
+
+- **Snapshot drift** — call `jest --updateSnapshot` after reviewing the diff.
+- **Module mock stale shape** — `jest.mock()` returns outdated API.
+- **Timer mocks** — `jest.useFakeTimers()` not cleared between tests; use `afterEach(() => jest.useRealTimers())`.
+- **DOM cleanup** — components leak DOM state without `@testing-library/jest-dom` `cleanup`.
+- **ESM import** — mixing CJS and ESM; check `transform` config.

--- a/skills/testing/test-autofix/detectors/maestro.md
+++ b/skills/testing/test-autofix/detectors/maestro.md
@@ -1,0 +1,82 @@
+---
+title: Maestro Detector
+stack: maestro
+tags:
+  - maestro
+  - mobile
+  - react-native
+  - expo
+---
+
+# Maestro Detector
+
+Bootstrap template for projects using Maestro for mobile UI flow tests.
+
+## Detection signals
+
+- `.maestro/` directory in the project root
+- `*.yaml` files containing Maestro `appId:` keys
+- `maestro` binary on PATH
+
+## Surface starter template
+
+```yaml
+---
+project-key: <normalised-git-remote-key>
+stack: maestro
+detect-command: maestro test .maestro/
+single-test-command: maestro test "{file}"
+failure-parser: '^\s*(?:✗|FAILED|❌)\s+(.+?)\s*$'
+# group 1 = flow step description or test name
+# Note: Maestro output format varies by version. Adjust regex to match.
+cache-bust-flag:
+---
+# Notes
+# Maestro requires a running simulator/emulator.
+# For iOS: ensure a booted simulator with the app installed.
+# For Android: ensure an emulator with adb connected.
+# For Maestro Cloud: maestro cloud .maestro/ --apiKey=$MAESTRO_CLOUD_API_KEY
+# Adjust detect-command to target a subdirectory if flows are organized by feature.
+```
+
+## Failure output format
+
+```
+✗ Tap on "Sign In" button
+  com.example.app - Unable to find element with id: "sign-in-button"
+  
+✗ Assert text "Welcome" is visible
+  Expected "Welcome" to be visible, but it was not found
+```
+
+Maestro failures are step-level, not test-name-level like unit test runners.
+The failure parser captures the step description.
+
+## Single-test re-run
+
+```bash
+maestro test .maestro/flows/login.yaml
+```
+
+To run a specific flow file with verbose output:
+```bash
+maestro test .maestro/flows/login.yaml --debug-output /tmp/maestro-debug
+```
+
+## Common failure families
+
+- **Element locator drift** — a `testID` or accessibility label was renamed in the app.
+  Check the component's current `testID` value before updating the flow.
+- **App state mismatch** — the flow assumes a logged-out state but the app is logged in.
+  Add a `clearState: true` or logout flow before the test.
+- **Timing** — an animation or network call takes longer than Maestro's default wait.
+  Add `waitForAnimationToEnd` or increase `timeout` on the assertion step.
+- **App version mismatch** — the installed build is outdated; reinstall from the latest build.
+- **Simulator/emulator not ready** — check that the device is booted and the app is installed
+  before running flows.
+
+## Notes on Maestro's output format
+
+Maestro's CLI output format has changed across versions.
+The failure parser regex in the surface file may need adjustment for your installed version.
+Run `maestro --version` and check the output of a failing test to confirm the format.

--- a/skills/testing/test-autofix/detectors/playwright.md
+++ b/skills/testing/test-autofix/detectors/playwright.md
@@ -1,0 +1,82 @@
+---
+title: Playwright Detector
+stack: playwright
+tags:
+  - playwright
+  - e2e
+  - browser
+---
+
+# Playwright Detector
+
+Bootstrap template for projects using Playwright Test (`@playwright/test`).
+
+## Detection signals
+
+- `playwright.config.ts` or `playwright.config.js` in the project root
+- `"@playwright/test"` in `package.json` devDependencies
+
+## Surface starter template
+
+```yaml
+---
+project-key: <normalised-git-remote-key>
+stack: playwright
+detect-command: pnpm exec playwright test
+single-test-command: pnpm exec playwright test "{file}" --grep "{name}"
+failure-parser: '^\s+\d+\)\s+\[.+?\]\s+›\s+(.+?)\s+›\s+(.+?)\s*$'
+# group 1 = describe block / file context, group 2 = test name
+cache-bust-flag:
+---
+# Notes
+# For headed mode during diagnosis: add --headed
+# For a specific browser: add --project=chromium (or firefox, webkit)
+# For Nx monorepos: pnpm exec nx run <project>:e2e
+# Playwright caches nothing by default; cache-bust-flag is not needed.
+```
+
+## Failure output format
+
+```
+  1) [chromium] › auth.spec.ts › Login › "redirects to dashboard after login"
+
+    Error: locator.click: Error: strict mode violation: getByRole('button', { name: 'Sign in' }) resolved to 2 elements
+    ...
+
+  2) [chromium] › auth.spec.ts › Login › "shows error on bad credentials"
+```
+
+Parser captures the file context and test name from the `›`-delimited line.
+
+Full failure header: `\d+\)\s+\[.+?\]\s+›\s+(.+\.spec\.[jt]s)\s+›`
+
+## Single-test re-run
+
+```bash
+pnpm exec playwright test auth.spec.ts --grep "redirects to dashboard after login"
+```
+
+For trace-enabled debugging:
+```bash
+pnpm exec playwright test auth.spec.ts --grep "redirects to dashboard after login" --trace=on
+```
+
+## Common failure families
+
+- **Locator drift** — element selector changed (`getByRole`, `getByText`, `getByLabel`).
+  Check the locator against the current DOM — never derive from a screenshot.
+- **Navigation timing** — page navigation completes after the assertion.
+  Use `await page.waitForURL(...)` or `await expect(page).toHaveURL(...)`.
+- **Parallel test interference** — shared state (DB, auth session) contaminated by a parallel worker.
+  Use isolated test fixtures per worker.
+- **Base URL mismatch** — `baseURL` in the config points at a server that isn't running.
+  Confirm the dev server is started before the test run.
+- **CI environment diff** — a resource (font, image, iframe) loads differently in CI.
+  Use `--update-snapshots` only after reviewing the diff.
+
+## Playwright-specific notes
+
+Playwright E2E tests are inherently integration-heavy.
+Before classifying a failure as `test-bug`, confirm the app is actually running
+and producing the expected DOM structure.
+Use `playwright show-trace trace.zip` to inspect the full interaction timeline.

--- a/skills/testing/test-autofix/detectors/pytest.md
+++ b/skills/testing/test-autofix/detectors/pytest.md
@@ -1,0 +1,69 @@
+---
+title: Pytest Detector
+stack: pytest
+tags:
+  - pytest
+  - python
+---
+
+# Pytest Detector
+
+Bootstrap template for projects using pytest.
+
+## Detection signals
+
+- `pytest.ini` in the project root
+- `[tool.pytest.ini_options]` in `pyproject.toml`
+- `[tool:pytest]` in `setup.cfg`
+- `pytest` in `requirements*.txt` or `pyproject.toml` dependencies
+
+## Surface starter template
+
+```yaml
+---
+project-key: <normalised-git-remote-key>
+stack: pytest
+detect-command: python -m pytest -v
+single-test-command: python -m pytest "{file}::{name}" -v
+failure-parser: '^FAILED\s+(\S+\.py)::(.+?)\s*$'
+# group 1 = file path, group 2 = test node id (e.g., TestClass::test_method or test_function)
+cache-bust-flag: --cache-clear
+---
+# Notes
+# If using a virtual environment: source .venv/bin/activate first, or use
+#   python -m pytest (which uses the active venv's pytest)
+# For pyproject.toml-based projects with uv: uv run pytest
+# For Django: python -m pytest --ds=myapp.settings
+# For async tests: add --asyncio-mode=auto if using pytest-asyncio
+```
+
+## Failure output format
+
+```
+FAILED tests/unit/test_parser.py::TestParser::test_handles_missing_keys - AssertionError: assert result == "default"
+```
+
+Parser regex: `^FAILED\s+(\S+\.py)::(.+?)\s*$`
+
+- Group 1: file path (e.g., `tests/unit/test_parser.py`)
+- Group 2: node ID (e.g., `TestParser::test_handles_missing_keys`)
+
+## Single-test re-run
+
+```bash
+python -m pytest tests/unit/test_parser.py::TestParser::test_handles_missing_keys -v
+```
+
+For parametrized tests, the node ID includes the parameter:
+```bash
+python -m pytest "tests/unit/test_parser.py::test_parse[json-valid]" -v
+```
+
+## Common failure families
+
+- **Fixture drift** — a fixture's return type or shape changed; the test is using the old contract.
+- **Import path moved** — a module was renamed or relocated; the test import is stale.
+- **Environment variable missing** — test reads from `os.environ`; a required var was removed from `.env.test`.
+- **Database state leak** — integration tests share a DB transaction that wasn't rolled back.
+- **Async fixture mismatch** — mixing `asyncio` and `sync` fixtures; check `pytest-asyncio` mode.
+- **Snapshot drift** — `pytest-snapshot` or `syrupy` output changed; review before accepting.

--- a/skills/testing/test-autofix/detectors/storybook.md
+++ b/skills/testing/test-autofix/detectors/storybook.md
@@ -1,0 +1,97 @@
+---
+title: Storybook Interaction Test Detector
+stack: storybook
+tags:
+  - storybook
+  - vitest
+  - playwright
+  - component-testing
+---
+
+# Storybook Interaction Test Detector
+
+Bootstrap template for projects using Storybook interaction tests
+(`@storybook/addon-vitest` + Playwright Chromium, or `@storybook/test-runner`).
+
+## Detection signals
+
+- `.storybook/` directory in the project root
+- `"@storybook/addon-vitest"` or `"@storybook/test-runner"` in `package.json` devDependencies
+- Test files with the suffix `*.test.stories.tsx` or `*.stories.test.ts`
+
+## Surface starter template
+
+### Variant A: @storybook/addon-vitest (Vitest + Playwright Chromium)
+
+```yaml
+---
+project-key: <normalised-git-remote-key>
+stack: storybook
+detect-command: pnpm exec vitest run --config vitest.config.storybook.ts
+single-test-command: pnpm exec vitest run --config vitest.config.storybook.ts "{file}" -t "{name}"
+failure-parser: '^\s*FAIL\s+(\S+\.test\.stories\.tsx?)\s*>\s*(.+?)\s*$'
+# group 1 = file path, group 2 = namespace/story path (e.g., UI/Button/Tests > "renders correctly")
+cache-bust-flag: --no-cache
+---
+# Notes
+# Requires a running Playwright Chromium browser (installed via playwright install chromium).
+# For Nx monorepos: pnpm exec nx run <project>:test-storybook-interaction
+```
+
+### Variant B: @storybook/test-runner
+
+```yaml
+---
+project-key: <normalised-git-remote-key>
+stack: storybook
+detect-command: pnpm exec test-storybook --url http://localhost:6006
+single-test-command: pnpm exec test-storybook --url http://localhost:6006 --testPathPattern="{file}"
+failure-parser: '^\s*FAIL\s+(.+?)\s*>\s*(.+?)\s*$'
+cache-bust-flag:
+---
+# Notes
+# Requires Storybook to be running at --url before tests are invoked.
+# Start Storybook: pnpm exec storybook dev -p 6006
+```
+
+## Failure output format (addon-vitest variant)
+
+```
+ FAIL  src/components/button/button.test.stories.tsx > UI/Button/Tests > "renders primary variant"
+TestingLibraryElementError: Unable to find an element with the role "button" and name "Submit"
+ ❯ play  src/components/button/button.test.stories.tsx:28:12
+```
+
+Parser regex: `^\s*FAIL\s+(\S+\.test\.stories\.tsx?)\s*>\s*(.+?)\s*$`
+
+- Group 1: file path (e.g., `src/components/button/button.test.stories.tsx`)
+- Group 2: full namespace + story name path
+
+## Single-test re-run (addon-vitest)
+
+```bash
+pnpm exec vitest run --config vitest.config.storybook.ts \
+  src/components/button/button.test.stories.tsx \
+  -t "renders primary variant"
+```
+
+## Common failure families
+
+- **Selector drift** — `getByRole`, `getByText`, `getByLabelText`, or `testID` no longer matches
+  because copy, role, or accessibility attribute changed in the component.
+- **`testID` drift** — a `testID` prop was renamed in the production component.
+- **Async mounting** — a `userEvent.click` runs before the component finishes mounting.
+  Use `findBy*` instead of `getBy*` for elements that appear after interaction.
+- **`accessibilityLabel` removed** — React Native components sometimes drop `accessibilityLabel`
+  during refactors; the locator can no longer find the element.
+- **Spy callback expectations** — a `vi.fn()` expectation fails because debouncing or guards
+  changed the number of times the callback is called.
+- **Story args drift** — story `args` reference a prop that was renamed or removed from the component.
+
+## Storybook-specific notes
+
+Interaction tests (`play` functions) are component integration tests — they test the
+component + its interactions, not the full app.
+A failure here is almost always a `test-bug` (component API changed, copy updated,
+accessibility attribute renamed) unless the component has a clear bug that a snapshot
+could not catch.

--- a/skills/testing/test-autofix/detectors/vitest.md
+++ b/skills/testing/test-autofix/detectors/vitest.md
@@ -1,0 +1,78 @@
+---
+title: Vitest Detector
+stack: vitest
+tags:
+  - vitest
+  - javascript
+  - typescript
+---
+
+# Vitest Detector
+
+Bootstrap template for projects using Vitest.
+
+## Detection signals
+
+- `vitest.config.ts` or `vitest.config.js` in the project root
+- `"vitest"` in `package.json` devDependencies
+
+## Surface starter template
+
+Use this as the starting point when writing `surfaces/<project-key>.md`.
+Replace placeholder values with the actual commands from the project.
+
+```yaml
+---
+project-key: <normalised-git-remote-key>
+stack: vitest
+detect-command: pnpm exec vitest run --reporter verbose
+single-test-command: pnpm exec vitest run {file} -t "{name}"
+failure-parser: '^\s*FAIL\s+(\S+\.(?:test|spec)\.[jt]sx?)\s*>\s*(.+?)\s*$'
+# group 1 = file path, group 2 = test name (may include suite prefix)
+cache-bust-flag: --no-cache
+---
+# Notes
+# Adjust detect-command to match your project's npm script (e.g., `npm test` or `yarn test`).
+# For Nx monorepos: pnpm exec nx run <project>:test
+# For Turborepo: pnpm turbo run test
+```
+
+## Failure output format
+
+```
+ FAIL  src/lib/utils/parser.test.ts > parseConfig > "handles missing keys"
+AssertionError: expected { foo: undefined } to deeply equal { foo: 'default' }
+ ❯ src/lib/utils/parser.test.ts:24:5
+```
+
+Parser regex: `^\s*FAIL\s+(\S+\.(?:test|spec)\.[jt]sx?)\s*>\s*(.+?)\s*$`
+
+- Group 1: file path (e.g., `src/lib/utils/parser.test.ts`)
+- Group 2: full nested suite + test name (e.g., `parseConfig > "handles missing keys"`)
+
+## Single-test re-run
+
+```bash
+pnpm exec vitest run src/lib/utils/parser.test.ts -t "handles missing keys"
+```
+
+For React Native / jsdom tests that need an explicit environment:
+
+```bash
+pnpm exec vitest run --environment jsdom src/components/Button.test.tsx -t "renders correctly"
+```
+
+## Cache note
+
+Vitest itself does not cache test results by default.
+If the project uses Nx or Turborepo, the caching layer wraps the runner.
+Set `cache-bust-flag: --skip-nx-cache` (Nx) or `--force` (Turborepo) if you
+observe phantom-green runs.
+
+## Common failure families
+
+- **Snapshot drift** — visual output changed; update snapshot after review.
+- **Module mock mismatch** — `vi.mock()` returns stale shape after refactor.
+- **React / hook timing** — use `findBy*` / `waitFor` instead of `getBy*` for async.
+- **Import alias drift** — path alias (`@/`, `~/`) moved; update the import.
+- **TypeScript strict mode** — null checks or generic constraints tightened upstream.

--- a/skills/testing/test-autofix/rules/anti-patterns.md
+++ b/skills/testing/test-autofix/rules/anti-patterns.md
@@ -1,0 +1,73 @@
+---
+title: Anti-Patterns
+impact: HIGH
+tags:
+  - tests
+  - guardrails
+  - anti-patterns
+---
+
+# Anti-Patterns
+
+The shortcuts this skill exists to prevent.
+Every one of these makes tests green at the cost of correctness.
+They are rejected by contract, not by judgement.
+
+If you find yourself reaching for any of these, the verdict in
+[`verdicts.md`](./verdicts.md) was wrong or the confidence gate in
+[`confidence-gate.md`](./confidence-gate.md) was bypassed.
+Re-classify, do not justify.
+
+## Hard refusals
+
+| Anti-pattern | Why it is rejected |
+| --- | --- |
+| Deleting a `test(...)`, `it(...)`, `describe(...)`, `Deno.test(...)`, or named story export | Test deletion in disguise. Losing the assertion means the regression it guarded against can silently re-enter. |
+| Adding `.skip`, `.only`, `xit`, `xdescribe`, `fit`, `fdescribe` | Same as deletion — hides the failure behind a keyword. A skipped test is a failing test that nobody sees. |
+| Adding `it.todo(...)`, `test.todo(...)`, `Deno.test.ignore(...)` | Marks the test as pending without fixing it. The production code can regress without any signal. |
+| Replacing strict matchers with loose ones (`toBe` → `toBeTruthy`, `toEqual` → `toMatchObject`, removing `expect.objectContaining(...)`) | Weakens the assertion's specificity. Passes with more inputs than the original author intended; hides shape regressions. |
+| Deleting `expect(...)` or `assert*()` calls | Removes the assertion entirely. An empty test body always passes. |
+| Wrapping the failing assertion in `try`/`catch` to swallow it | The test reports green while the assertion silently fails inside the catch. |
+| Mocking the System Under Test (the module being tested) instead of its dependencies | "Test by construction" — the test verifies the mock, not the code. The real module can be completely broken. |
+| Replacing a specific expected value with `expect.anything()`, `any`, or `unknown` | Accepts any value; the assertion no longer validates the contract. |
+| Updating a snapshot without visual review | A snapshot that captures wrong output and is accepted trains future reviewers to trust incorrect renders. |
+| Patching production code to make a `test-bug` pass | Misclassification cover-up. If production code needs to change, re-classify as `prod-bug` and escalate. |
+| Adding `console.error = () => {}` or suppressing error output to hide assertion noise | Masks the signal that indicates what is actually wrong. |
+| Increasing timeouts or adding `sleep(N)` to fix a timing failure | Hides a race condition. Use `waitFor`, `findBy*`, or proper async coordination instead. |
+
+## Detection patterns
+
+Before any `Edit` or `Write` to a test file, scan the proposed new content
+for these patterns and abort if any match:
+
+```
+\.skip\s*[\(\.]
+\.only\s*[\(\.]
+\bxit\s*\(
+\bfit\s*\(
+\bxdescribe\s*\(
+\bfdescribe\s*\(
+\bit\.todo\s*\(
+\btest\.todo\s*\(
+Deno\.test\.ignore\s*\(
+```
+
+Before any `Edit` or `Write` to a test file, compute:
+`(new expect/assert count) - (old expect/assert count)`.
+If negative, abort and re-diagnose.
+
+## Soft refusals (require explicit user approval)
+
+These are not hard-rejected, but cannot be applied silently:
+
+- **Snapshot updates** — show the diff of old vs new snapshot; ask once for confirmation.
+- **Updating a test fixture file** — the fixture's shape may be intentionally strict; surface the change and ask.
+- **Adding a new test dependency** (test utility, mock library) — affects every test in the project; ask once.
+
+## The shape of the trap
+
+Every anti-pattern above shares the same shape:
+*make the red go away without understanding why it was red.*
+
+The verdict + confidence-gate pair exists to make that shape impossible to enter accidentally.
+When the urge to take a shortcut appears, the urge is the signal — re-run [`verdicts.md`](./verdicts.md).

--- a/skills/testing/test-autofix/rules/bootstrap.md
+++ b/skills/testing/test-autofix/rules/bootstrap.md
@@ -47,7 +47,7 @@ Look for these files in the project root (and common subdirectories):
 | **Jest** | `jest.config.ts`, `jest.config.js`, `jest.config.cjs`, or `"jest"` in `package.json` devDependencies |
 | **Deno** | `deno.json`, `deno.jsonc`, or `deno.lock` present |
 | **Playwright** | `playwright.config.ts`, `playwright.config.js`, or `"@playwright/test"` in devDependencies |
-| **Pytest** | `pytest.ini`, `pyproject.toml` with `[tool.pytest.ist-options]`, `setup.cfg` with `[tool:pytest]`, or `pytest` in `requirements*.txt` |
+| **Pytest** | `pytest.ini`, `pyproject.toml` with `[tool.pytest.ini_options]`, `setup.cfg` with `[tool:pytest]`, or `pytest` in `requirements*.txt` |
 | **Maestro** | `.maestro/` directory or `*.yaml` files with Maestro `appId:` keys |
 | **Storybook** | `.storybook/` directory AND (`"@storybook/addon-vitest"` or `"@storybook/test-runner"`) in devDependencies |
 
@@ -65,15 +65,15 @@ If multiple stacks are detected:
 
 ## Step 3 — Load the detector template
 
-Load the matching detector from [`../detectors/`](../detectors/):
+Load the matching detector:
 
-- Vitest → `detectors/vitest.md`
-- Jest → `detectors/jest.md`
-- Deno → `detectors/deno.md`
-- Playwright → `detectors/playwright.md`
-- Pytest → `detectors/pytest.md`
-- Maestro → `detectors/maestro.md`
-- Storybook → `detectors/storybook.md`
+- Vitest → [`../detectors/vitest.md`](../detectors/vitest.md)
+- Jest → [`../detectors/jest.md`](../detectors/jest.md)
+- Deno → [`../detectors/deno.md`](../detectors/deno.md)
+- Playwright → [`../detectors/playwright.md`](../detectors/playwright.md)
+- Pytest → [`../detectors/pytest.md`](../detectors/pytest.md)
+- Maestro → [`../detectors/maestro.md`](../detectors/maestro.md)
+- Storybook → [`../detectors/storybook.md`](../detectors/storybook.md)
 
 ## Step 4 — Customize the template
 
@@ -90,33 +90,31 @@ Fill in the template's placeholder values based on the detected project:
 
 ## Step 5 — Propose the surface diff and wait for approval
 
-Present the proposed surface file to the user:
-
-```
-Bootstrap detected: <stack>
-Project key: <key>
-Surface file: surfaces/<key>.md
-
-Proposed surface:
----
-<full surface file content>
----
-
-Please review and confirm. You can edit the commands before I write the file.
-Confirm with "yes" or provide corrections.
-```
+Render the proposal block exactly per [`../templates/bootstrap-proposal.md`](../templates/bootstrap-proposal.md).
+The template is the canonical user-facing format; do not improvise the wording.
 
 **Do NOT write the file until the user confirms.**
 If the user provides corrections, apply them and show the updated content before writing.
 
-## Step 6 — Write the surface file
+## Step 6 — Write the surface file (atomic)
 
-After approval:
+After approval, write the file atomically to avoid corruption when two
+`test-autofix` runs touch the same surface concurrently (parallel CI workers,
+interactive + agent session against the same repo):
 
 1. Create the `surfaces/` directory if it does not exist.
-2. Write the surface file to `surfaces/<project-key>.md`.
-3. Confirm:
+2. Write to a temporary sibling first, then rename:
+   ```bash
+   tmp="surfaces/<project-key>.md.tmp.$$"
+   # write content to "$tmp" with the Write tool
+   mv -n "$tmp" "surfaces/<project-key>.md"
    ```
+   `mv -n` (no-clobber) refuses to overwrite if another worker already wrote the
+   target between Step 5's check and Step 6's rename. If the rename is refused,
+   re-read the now-existing surface and re-validate per
+   [`surface-validation.md`](./surface-validation.md) instead of writing.
+3. Confirm:
+   ```text
    Surface written: surfaces/<project-key>.md
    Proceeding to Phase 1.
    ```

--- a/skills/testing/test-autofix/rules/bootstrap.md
+++ b/skills/testing/test-autofix/rules/bootstrap.md
@@ -17,7 +17,7 @@ tags:
 - [Step 3 — Load the detector template](#step-3--load-the-detector-template)
 - [Step 4 — Customize the template](#step-4--customize-the-template)
 - [Step 5 — Propose the surface diff and wait for approval](#step-5--propose-the-surface-diff-and-wait-for-approval)
-- [Step 6 — Write the surface file](#step-6--write-the-surface-file)
+- [Step 6 — Write the surface file (atomic)](#step-6--write-the-surface-file-atomic)
 - [Edge cases](#edge-cases)
 
 Bootstrap runs when no surface file exists for the current project.

--- a/skills/testing/test-autofix/rules/bootstrap.md
+++ b/skills/testing/test-autofix/rules/bootstrap.md
@@ -1,0 +1,131 @@
+---
+title: Bootstrap — First-Run Surface Creation
+impact: HIGH
+tags:
+  - bootstrap
+  - surface
+  - project-setup
+---
+
+# Bootstrap
+
+## Contents
+
+- [When bootstrap runs](#when-bootstrap-runs)
+- [Step 1 — Compute the project key](#step-1--compute-the-project-key)
+- [Step 2 — Detect the stack](#step-2--detect-the-stack)
+- [Step 3 — Load the detector template](#step-3--load-the-detector-template)
+- [Step 4 — Customize the template](#step-4--customize-the-template)
+- [Step 5 — Propose the surface diff and wait for approval](#step-5--propose-the-surface-diff-and-wait-for-approval)
+- [Step 6 — Write the surface file](#step-6--write-the-surface-file)
+- [Edge cases](#edge-cases)
+
+Bootstrap runs when no surface file exists for the current project.
+Its job: detect the test stack, propose a surface file diff, wait for user
+approval, then write the file.
+
+Bootstrap does NOT run the tests. It only creates the surface file that tells
+the skill how to run the tests on subsequent invocations.
+
+## When bootstrap runs
+
+In Phase 0 of [`../SKILL.md`](../SKILL.md), after the project key is computed
+and the surface file is confirmed absent.
+
+## Step 1 — Compute the project key
+
+Per [`project-keying.md`](./project-keying.md).
+The key becomes the filename: `surfaces/<project-key>.md`.
+
+## Step 2 — Detect the stack
+
+Look for these files in the project root (and common subdirectories):
+
+| Stack | Detection signal |
+| --- | --- |
+| **Vitest** | `vitest.config.ts`, `vitest.config.js`, `vitest.config.mts`, or `"vitest"` in `package.json` devDependencies |
+| **Jest** | `jest.config.ts`, `jest.config.js`, `jest.config.cjs`, or `"jest"` in `package.json` devDependencies |
+| **Deno** | `deno.json`, `deno.jsonc`, or `deno.lock` present |
+| **Playwright** | `playwright.config.ts`, `playwright.config.js`, or `"@playwright/test"` in devDependencies |
+| **Pytest** | `pytest.ini`, `pyproject.toml` with `[tool.pytest.ist-options]`, `setup.cfg` with `[tool:pytest]`, or `pytest` in `requirements*.txt` |
+| **Maestro** | `.maestro/` directory or `*.yaml` files with Maestro `appId:` keys |
+| **Storybook** | `.storybook/` directory AND (`"@storybook/addon-vitest"` or `"@storybook/test-runner"`) in devDependencies |
+
+Read `package.json` (or `pyproject.toml`, `deno.json`) to confirm detection.
+For JavaScript/TypeScript monorepos, check the root AND all `apps/*/package.json` files.
+
+### Dominant stack selection
+
+If multiple stacks are detected:
+
+1. Prefer the stack that has the most test files (glob `**/*.test.*`, `**/*.spec.*`).
+2. If Storybook is detected alongside Vitest or Jest, create separate surfaces:
+   one for unit tests and one for Storybook interaction tests.
+3. Note all detected stacks in the surface file's free-text Notes section.
+
+## Step 3 — Load the detector template
+
+Load the matching detector from [`../detectors/`](../detectors/):
+
+- Vitest → `detectors/vitest.md`
+- Jest → `detectors/jest.md`
+- Deno → `detectors/deno.md`
+- Playwright → `detectors/playwright.md`
+- Pytest → `detectors/pytest.md`
+- Maestro → `detectors/maestro.md`
+- Storybook → `detectors/storybook.md`
+
+## Step 4 — Customize the template
+
+Fill in the template's placeholder values based on the detected project:
+
+- `project-key` — from Step 1.
+- `detect-command` — from the project's `package.json` scripts, `Makefile`, or Nx targets (if present).
+  Prefer the project's own canonical test command over a raw runner invocation.
+  Example: if `package.json` has `"test": "vitest run"`, use that form.
+- `single-test-command` — infer from the detect command. Most runners accept a file path and `-t "<name>"`.
+- `failure-parser` — use the stack's canonical regex from the detector file.
+  Adjust if the project uses a custom reporter that changes the output format.
+- `cache-bust-flag` — include if the detect command goes through a caching layer (Nx, Turborepo, Bazel).
+
+## Step 5 — Propose the surface diff and wait for approval
+
+Present the proposed surface file to the user:
+
+```
+Bootstrap detected: <stack>
+Project key: <key>
+Surface file: surfaces/<key>.md
+
+Proposed surface:
+---
+<full surface file content>
+---
+
+Please review and confirm. You can edit the commands before I write the file.
+Confirm with "yes" or provide corrections.
+```
+
+**Do NOT write the file until the user confirms.**
+If the user provides corrections, apply them and show the updated content before writing.
+
+## Step 6 — Write the surface file
+
+After approval:
+
+1. Create the `surfaces/` directory if it does not exist.
+2. Write the surface file to `surfaces/<project-key>.md`.
+3. Confirm:
+   ```
+   Surface written: surfaces/<project-key>.md
+   Proceeding to Phase 1.
+   ```
+
+## Edge cases
+
+| Edge case | Handling |
+| --- | --- |
+| No stack detected | Ask the user which stack to use; fall back to `templates/surface.md` as a blank template |
+| Multiple monorepo packages with different stacks | Create one surface per package; name them `<project-key>-<package>.md` |
+| Private registry / custom runner | Fill `detect-command` with a placeholder and tell the user to complete it |
+| `--surface <path>` passed | Skip bootstrap entirely; use the provided file directly |

--- a/skills/testing/test-autofix/rules/confidence-gate.md
+++ b/skills/testing/test-autofix/rules/confidence-gate.md
@@ -1,0 +1,65 @@
+---
+title: Confidence Gate
+impact: HIGH
+tags:
+  - tests
+  - confidence
+  - quality-gate
+---
+
+# Confidence Gate
+
+A wrong test fix corrupts the suite — the test stops asserting what it was
+written to assert, and the regression it was guarding against can land silently.
+The gate exists to make speculative fixes prove themselves before they touch
+the test file.
+
+The gate is non-negotiable.
+Auto mode does not override it.
+
+## When to run
+
+After the verdict in [`verdicts.md`](./verdicts.md) lands on `test-bug` and the
+plan artifact has been written (see [`../templates/plan-artifact.md`](../templates/plan-artifact.md)).
+Before editing any file.
+
+## How to run
+
+Invoke the `confidence` skill in analysis mode:
+
+```text
+Skill("confidence", "analysis proposed fix: <one-line summary>; verdict: test-bug; surface: <surface-name>; risk: <test-only|prod-touch>")
+```
+
+Record the score in the plan artifact under `## Confidence`.
+
+## Decision matrix
+
+| Score | Action |
+| --- | --- |
+| ≥ 90 | Auto-apply. Continue to Phase 4 in [`../SKILL.md`](../SKILL.md). |
+| 80–89 | Show the diff, ask the user once, apply on approval. |
+| < 80 | Escalate. Do not write. |
+
+## What the score is rating
+
+The `confidence` skill is rating that the proposed fix fully solves the diagnosed
+root cause — not that the verdict was correct.
+If the verdict is wrong, no confidence score saves the run.
+Re-classify before re-scoring.
+
+## Risk tag guidance
+
+The `risk:` tag in the prompt shapes the gate's strictness:
+
+| Risk tag | When to use it | Effect on the gate |
+| --- | --- | --- |
+| `test-only` | Editing only test files and their direct fixtures | Slight downweight — a wrong test change may hide a real prod regression. |
+| `prod-touch` | Editing production source files to fix a `prod-bug` or resolve a `test-bug` misclassification | Strong downweight — production behavior changes need stronger evidence. |
+
+Tiebreaker: if a fix touches both a test file and a production fixture, use `test-only`.
+If it touches a production module under `src/`, `lib/`, `apps/`, use `prod-touch`.
+
+Rationale: a test change that weakens an assertion can silently re-open a regression
+(blast radius: the project's integrity); a production change that misidentifies the root cause
+ships incorrect behavior to users.

--- a/skills/testing/test-autofix/rules/project-keying.md
+++ b/skills/testing/test-autofix/rules/project-keying.md
@@ -100,7 +100,7 @@ The `--surface <path>` flag is the escape hatch for unusual layouts.
 remote=$(git remote get-url origin 2>/dev/null)
 if [[ -n "$remote" ]]; then
   key=$(echo "$remote" \
-    | sed 's|^[a-z+]*://||; s|^git@||; s|:|/|; s|\.git$||' \
+    | sed 's|^[a-z+]*://||; s|^git@||; s|:|/|g; s|\.git$||' \
     | tr '/' '-' \
     | tr '[:upper:]' '[:lower:]')
 else

--- a/skills/testing/test-autofix/rules/project-keying.md
+++ b/skills/testing/test-autofix/rules/project-keying.md
@@ -1,0 +1,115 @@
+---
+title: Project Keying — Stable Surface Identity
+impact: MEDIUM
+tags:
+  - surface
+  - project-key
+  - git
+---
+
+# Project Keying
+
+## Contents
+
+- [Primary: normalised git remote URL](#primary-normalised-git-remote-url)
+- [Fallback: absolute git root path](#fallback-absolute-git-root-path)
+- [Worktree stability](#worktree-stability)
+- [Monorepo subprojects](#monorepo-subprojects)
+- [Computing the key (implementation)](#computing-the-key-implementation)
+
+A project key is the filename used for a project's surface file under
+`surfaces/`.
+It must be stable across `git worktree` checkouts of the same repository and
+unique enough to avoid collisions between different projects.
+
+## Primary: normalised git remote URL
+
+```bash
+git remote get-url origin
+```
+
+Normalise the result to a safe filename:
+
+1. Strip the scheme (`https://`, `git@`, `ssh://`).
+2. Replace `:` (in SSH-style `git@host:owner/repo.git`) with `-`.
+3. Strip the `.git` suffix if present.
+4. Replace `/` with `-`.
+5. Lowercase the entire string.
+
+### Examples
+
+| Raw remote URL | Normalised key |
+| --- | --- |
+| `https://github.com/owner/my-repo.git` | `github.com-owner-my-repo` |
+| `git@github.com:owner/my-repo.git` | `github.com-owner-my-repo` |
+| `https://gitlab.com/group/subgroup/repo` | `gitlab.com-group-subgroup-repo` |
+| `ssh://git@bitbucket.org/team/project.git` | `bitbucket.org-team-project` |
+
+Surface filename: `surfaces/<normalised-key>.md`
+Example: `surfaces/github.com-owner-my-repo.md`
+
+## Fallback: absolute git root path
+
+If `git remote get-url origin` fails (no remote configured, local-only repo):
+
+```bash
+git rev-parse --show-toplevel
+```
+
+Normalise the absolute path:
+
+1. Strip the leading `/`.
+2. Replace `/` with `-`.
+3. Lowercase.
+
+Example: `/Users/alice/work/my-project` → `users-alice-work-my-project`
+
+Surface filename: `surfaces/users-alice-work-my-project.md`
+
+The absolute-path fallback is less stable (the path changes if the repo moves),
+but is correct for local-only projects where it is the only available identity.
+
+## Worktree stability
+
+Both primary and fallback keys are **stable across git worktrees** of the same
+repository:
+- The remote URL is the same in all worktrees of the same repo.
+- The `--show-toplevel` of a worktree returns the worktree's own path, which
+  differs from the main checkout. Projects using worktrees heavily should prefer
+  the remote URL as the key (which is why the primary method is preferred).
+
+## Monorepo subprojects
+
+For a monorepo where each package has its own test suite, append the
+package name to the key:
+
+```
+<normalised-remote-key>-<package-name>
+```
+
+Example: `github.com-acme-monorepo-packages-api`
+
+The bootstrap step handles this automatically when it detects multiple
+packages with independent test commands.
+The `--surface <path>` flag is the escape hatch for unusual layouts.
+
+## Computing the key (implementation)
+
+```bash
+# Primary
+remote=$(git remote get-url origin 2>/dev/null)
+if [[ -n "$remote" ]]; then
+  key=$(echo "$remote" \
+    | sed 's|^[a-z+]*://||; s|^git@||; s|:|/|; s|\.git$||' \
+    | tr '/' '-' \
+    | tr '[:upper:]' '[:lower:]')
+else
+  # Fallback
+  root=$(git rev-parse --show-toplevel 2>/dev/null)
+  key=$(echo "$root" \
+    | sed 's|^/||' \
+    | tr '/' '-' \
+    | tr '[:upper:]' '[:lower:]')
+fi
+echo "$key"
+```

--- a/skills/testing/test-autofix/rules/regression-detection.md
+++ b/skills/testing/test-autofix/rules/regression-detection.md
@@ -1,0 +1,86 @@
+---
+title: Regression Detection
+impact: HIGH
+tags:
+  - tests
+  - regression
+  - revert
+  - iteration
+---
+
+# Regression Detection
+
+After every fix batch, the new test run is compared against the previous
+failure set.
+The outcome determines whether the loop continues, restarts, or reverts.
+
+Stacking fixes onto a regression is how a 5-iteration loop ships net-negative
+test coverage.
+This rule is non-optional.
+
+## When to run
+
+In Phase 6 of [`../SKILL.md`](../SKILL.md), after each full-surface re-run.
+
+## Decision table
+
+| Outcome | What it means | Action |
+| --- | --- | --- |
+| Same failure(s) as before | The fix did not address the root cause | Go back to verdict classification ([`verdicts.md`](./verdicts.md)). Do not repeat the same fix shape. |
+| Strict subset of the previous failures | Partial progress — the fix worked for what it touched | Continue with the remaining failures (back to verdict classification for the new top failure). |
+| New failure(s) that did NOT exist before this fix | The fix introduced a regression | **Revert the last fix.** Record the attempt in the plan artifact. Re-plan or escalate. |
+
+## How to revert a test-file regression
+
+For a `test-bug` fix, the edit was scoped to a test file.
+Revert using file-level restore (not `git revert` which creates a commit):
+
+```bash
+git restore <test-file>
+```
+
+This undoes the in-progress edit without creating a revert commit.
+Then re-run the single-test command to confirm the file is back to its original state.
+
+If the fix had already been committed (e.g., between batches):
+
+```bash
+git revert HEAD --no-edit
+```
+
+Then sync before re-planning:
+
+```bash
+git pull --rebase origin "<branch>"
+git log -1 --format='Baseline after revert: %H'
+```
+
+Record the printed baseline SHA in the plan artifact's `## Iteration <N> — reverted`
+section so the user can verify the post-revert HEAD matches the expected baseline.
+If the rebase conflicts, stop and report — do not auto-resolve.
+
+## Iteration cap
+
+Maximum 5 iterations (adjustable via `--max-iterations`).
+If still failing after the cap, escalate with the structured exit summary from Phase 9.
+
+## Definition of "new failure"
+
+A failure is "new" if:
+
+- The **test name or file** is different from anything in the previous failure set, OR
+- The test name is the same but the **error message signature** (first ~3 lines) is materially different.
+
+Cosmetic differences (line numbers shifting, timestamps, run IDs) do not count as new.
+When in doubt, treat it as new — false positives revert one extra fix; false negatives
+compound regressions.
+
+## Why `git restore` (not `git reset --hard`)
+
+`git restore <file>` restores a single file to its last committed state.
+It is surgical and does not affect other staged or unstaged changes.
+`git reset --hard HEAD` would discard all uncommitted work across the entire tree —
+wrong scope when multiple fixes are in progress.
+
+For a committed regression, `git revert HEAD` creates a new revert commit —
+non-destructive, traceable, CI-safe, and does not rewrite shared history.

--- a/skills/testing/test-autofix/rules/surface-validation.md
+++ b/skills/testing/test-autofix/rules/surface-validation.md
@@ -58,6 +58,24 @@ which <first-word>
 
 A resolved binary is sufficient — do not run the full detect command during validation.
 
+### Tool-version-manager edge case
+
+If `which <executable>` fails but the project uses a tool-version manager
+(`mise`, `asdf`, `nvm`, `volta`, `pyenv`), the binary is real but not on the
+agent's PATH. Detect this case before treating the surface as stale:
+
+| Signal in repo | Tool manager | Treat `which` miss as |
+| --- | --- | --- |
+| `.tool-versions` / `mise.toml` / `.mise.toml` | mise / asdf | **valid** (suggest `--skip-validation`) |
+| `.nvmrc` | nvm | **valid** (suggest `--skip-validation`) |
+| `package.json#volta` | volta | **valid** (suggest `--skip-validation`) |
+| `.python-version` | pyenv | **valid** (suggest `--skip-validation`) |
+| (none of the above) | — | **stale** (propose update diff) |
+
+When the surface is treated as valid via this exemption, log:
+`Surface validation: binary not on PATH, but <tool-manager> detected. Suggest --skip-validation for this project.`
+Do not auto-add `--skip-validation` to the surface or the invocation — the user owns that choice.
+
 ### Step 3 — Check the single-test-command binary
 
 Same check as Step 2 for the `single-test-command` executable.

--- a/skills/testing/test-autofix/rules/surface-validation.md
+++ b/skills/testing/test-autofix/rules/surface-validation.md
@@ -1,0 +1,110 @@
+---
+title: Surface Validation — Validate on Every Entry
+impact: HIGH
+tags:
+  - surface
+  - validation
+  - staleness
+---
+
+# Surface Validation
+
+## Contents
+
+- [When to run](#when-to-run)
+- [Validation steps](#validation-steps)
+- [On stale or invalid surface](#on-stale-or-invalid-surface)
+- [Skipping validation (not recommended)](#skipping-validation-not-recommended)
+
+Every time the skill enters Phase 0 with an existing surface file, it validates
+that the surface's commands still resolve.
+A stale surface produces misleading "no failures found" results or broken single-test re-runs.
+
+Validation runs fast — it checks whether binaries and scripts resolve, not
+whether the tests actually pass.
+
+## When to run
+
+In Phase 0 of [`../SKILL.md`](../SKILL.md), immediately after loading the
+surface file (or the `--surface` override file).
+
+## Validation steps
+
+### Step 1 — Parse the surface file
+
+Load the YAML frontmatter:
+- `project-key`
+- `stack`
+- `detect-command`
+- `single-test-command`
+- `failure-parser`
+- `cache-bust-flag` (optional)
+
+If the frontmatter is missing required fields, mark the surface invalid immediately.
+Required fields: `project-key`, `stack`, `detect-command`, `single-test-command`, `failure-parser`.
+
+### Step 2 — Check the detect-command binary
+
+Extract the first word (the executable) from `detect-command` and verify it resolves:
+
+```bash
+which <executable>
+```
+
+Or for multi-word invocations (`pnpm exec vitest`, `npx jest`, `deno test`):
+```bash
+which <first-word>
+```
+
+A resolved binary is sufficient — do not run the full detect command during validation.
+
+### Step 3 — Check the single-test-command binary
+
+Same check as Step 2 for the `single-test-command` executable.
+
+### Step 4 — Check the project key matches
+
+Recompute the project key for the current working directory per
+[`project-keying.md`](./project-keying.md) and compare it to the `project-key`
+field in the surface file.
+
+If the keys differ:
+- If `--surface <path>` was passed: the mismatch is intentional. Log a warning and continue.
+- Otherwise: surface a mismatch warning and include it in the proposed update diff.
+
+### Step 5 — Decide: valid or stale
+
+| Check result | Surface state |
+| --- | --- |
+| All checks pass | **Valid** — continue to Phase 1 |
+| Missing required field | **Invalid** — must update before continuing |
+| Binary not found | **Stale** — propose update diff |
+| Project key mismatch (no `--surface` flag) | **Stale** — propose update diff |
+
+## On stale or invalid surface
+
+1. Compute a diff showing only the affected fields.
+2. Present it to the user:
+   ```
+   Surface validation failed: <reason>
+   
+   Proposed update to surfaces/<key>.md:
+   ---
+   <diff>
+   ---
+   
+   Confirm with "yes" to update, or provide corrections.
+   ```
+3. **Ask once.** If the user declines, escalate — do not run with an invalid surface.
+4. On approval, write the updated surface file and re-validate.
+
+## Skipping validation (not recommended)
+
+The user may pass `--skip-validation` to bypass surface validation.
+This is not recommended — use it only when the validation check itself is failing
+due to a PATH issue in the agent's shell environment (e.g., nvm not loaded).
+
+When `--skip-validation` is passed, log:
+```
+Surface validation skipped (--skip-validation). Commands assumed valid.
+```

--- a/skills/testing/test-autofix/rules/verdicts.md
+++ b/skills/testing/test-autofix/rules/verdicts.md
@@ -1,0 +1,72 @@
+---
+title: Failure Verdicts
+impact: HIGH
+tags:
+  - tests
+  - classification
+  - guardrails
+---
+
+# Failure Verdicts
+
+Every failure gets exactly one verdict before any fix is drafted.
+The verdict binds behavior — `prod-bug` and `unsure` escalate; `test-bug` continues to the confidence gate.
+
+Do not skip this step.
+Do not leave the verdict implicit.
+Record it in the plan artifact (see [`../templates/plan-artifact.md`](../templates/plan-artifact.md)).
+
+## Decision table
+
+| Verdict | What it means | Action |
+| --- | --- | --- |
+| `test-bug` | Production code is correct; the test drifted (renamed selector, stale snapshot, changed copy, updated API signature, new required arg, schema change) | Continue to the confidence gate ([`confidence-gate.md`](./confidence-gate.md)) |
+| `prod-bug` | Production code regressed; the test caught it correctly. The test is doing its job | **Escalate.** Do not touch the test. Propose a production-code fix and stop. |
+| `unsure` | Diagnostic confidence < 80%, or the failure could plausibly be in more than one bucket | **Escalate.** Surface what you saw and what you couldn't decide between. Stop. |
+
+## Per-verdict notes
+
+### `test-bug`
+
+Read both the test file and the production module it exercises before proposing a fix.
+Never propose a test change from the error message alone.
+
+Sub-classify the failure shape before fixing:
+
+- **Snapshot drift** — a snapshot was rendered with outdated fixtures or a copy change updated the UI.
+  Only update the snapshot after visually confirming the new output is correct.
+  Never update a snapshot you have not reviewed.
+- **Selector drift** — a `getByRole`, `getByText`, `getByLabelText`, or `testID` no longer matches because
+  the component's copy, role, or accessibility attribute changed.
+- **Type / signature drift** — the production function renamed an argument or changed its return shape;
+  the test is still using the old call signature.
+- **Timing issue** — an async operation completes after the assertion runs; add `findBy*` / `waitFor`
+  instead of `.only` or a sleep.
+- **Import/module drift** — a renamed export or moved file causes the test to import a stale reference.
+- **Mock stub mismatch** — an external dependency mock returns a shape that no longer matches what
+  production sends; update the mock, not the assertion.
+
+A `test-bug` fix may only touch the test file (and its direct test fixtures).
+If fixing the test requires editing production code, stop and re-classify as `prod-bug` or `unsure`.
+
+### `prod-bug`
+
+Escalate.
+Do not auto-apply a production-code fix from this skill — the user must approve before any production edit.
+
+Report:
+1. Which test failed and what the test asserts.
+2. What the production code currently does.
+3. The one-line discrepancy between them.
+4. A proposed production-code fix (for the user to review, not auto-applied).
+
+The test is the specification. Do not weaken the test to match incorrect production behavior.
+
+### `unsure`
+
+Escalate with three things:
+1. The failure message and the two (or more) verdicts that fit.
+2. The section of the test and production code you cannot resolve.
+3. The evidence you would need to decide (e.g., recent commit that changed the contract, missing type annotation, undocumented side effect).
+
+Asking once is cheaper than a wrong fix that corrupts the test suite.

--- a/skills/testing/test-autofix/templates/bootstrap-proposal.md
+++ b/skills/testing/test-autofix/templates/bootstrap-proposal.md
@@ -1,0 +1,11 @@
+Bootstrap detected: <stack>
+Project key: <project-key>
+Surface file: surfaces/<project-key>.md
+
+Proposed surface:
+---
+<full surface file content — frontmatter + ## Notes body>
+---
+
+Please review and confirm. You can edit the commands before I write the file.
+Confirm with "yes" or provide corrections.

--- a/skills/testing/test-autofix/templates/exit-summary.md
+++ b/skills/testing/test-autofix/templates/exit-summary.md
@@ -1,0 +1,42 @@
+# test-autofix exit summary template
+
+Always end a run with this block, regardless of outcome.
+Fill every field; omit optional fields only when clearly not applicable.
+
+```text
+test-autofix run
+  Outcome: <green | escalated | regression-reverted | max-iterations>
+  Resolved: <N> failures
+  Escalated: <N> failures (<comma-separated verdicts, e.g.: prod-bug, unsure>)
+  Iterations: <N>/<max>
+  Surface: <path to surface file>
+  Plan: .agent/{branch}/test-autofix-plan.md
+  Successful run: <detect-command output summary>      # if outcome is green
+  Escalation reason: <one sentence per escalated failure>  # if outcome is not green
+```
+
+## Field guide
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `Outcome` | Always | One of: `green`, `escalated`, `regression-reverted`, `max-iterations` |
+| `Resolved` | Always | Count of failures that went from failing to passing |
+| `Escalated` | Always | Count and verdicts of failures handed back to the user; `0` if none |
+| `Iterations` | Always | `N/max` where max is `--max-iterations` value (default 5) |
+| `Surface` | Always | Full path to the surface file used |
+| `Plan` | Always | Path to the plan artifact written during Phase 1 |
+| `Successful run` | Green only | Brief summary confirming all tests passed |
+| `Escalation reason` | Non-green | One sentence per escalated failure explaining what blocked resolution |
+
+## Outcome definitions
+
+- **`green`** — all tests in the detect-command output are passing.
+- **`escalated`** — one or more failures were `prod-bug` or `unsure` and were handed to the user.
+- **`regression-reverted`** — a fix introduced a new failure; the fix was reverted; the user owns the next step.
+- **`max-iterations`** — the `--max-iterations` cap was reached before all failures were resolved.
+
+On success, also include: which failures were fixed (one line each), confirmation that the
+full surface re-run passed, and any notable observations (e.g., a snapshot was updated).
+
+On escalation, also include: what was tried per iteration (one line per attempt) and
+concrete suggested next steps for the user to investigate manually.

--- a/skills/testing/test-autofix/templates/plan-artifact.md
+++ b/skills/testing/test-autofix/templates/plan-artifact.md
@@ -1,0 +1,45 @@
+# test-autofix run — <branch> — iteration <N>
+
+## Surface
+
+- Surface file: `surfaces/<project-key>.md`
+- Stack: <vitest | jest | deno | playwright | pytest | maestro | storybook>
+- Detect command: <detect-command from surface>
+
+## Failure inventory
+
+| # | File | Test name | Verdict | Confidence | Status |
+| - | ---- | --------- | ------- | ---------- | ------ |
+| 1 | `<file>` | `<test name>` | `<test-bug \| prod-bug \| unsure>` | <score> | <pending \| fixed \| escalated \| reverted> |
+
+## Proposed fix — failure #<N>
+
+- Verdict: `<test-bug | prod-bug | unsure>`
+- Root cause (one sentence): <…>
+- Files touched: <list>
+
+<diff sketch or one-paragraph description>
+
+## Confidence — failure #<N>
+
+- Score: <0–100>
+- Risk tag: <test-only | prod-touch>
+- Action: <auto-apply | ask-once | escalate>
+- Escalation reason: <one sentence — fill in only when Action is `escalate`>
+
+## Iteration <N> — <result>
+
+- Outcome: <green | same-failure | subset | regression-reverted>
+- Notes: <…>
+
+## Iteration <N> — reverted
+
+- Fix that was reverted: <one-line summary>
+- Baseline SHA after revert: <git SHA>
+- Notes: <why the fix introduced a regression>
+
+## Exit
+
+- Resolved: <N> failures
+- Escalated: <N> failures (<verdicts>)
+- Iterations used: <N>/<max>

--- a/skills/testing/test-autofix/templates/surface.md
+++ b/skills/testing/test-autofix/templates/surface.md
@@ -1,0 +1,8 @@
+---
+project-key: <normalised-git-remote-key>
+stack: <vitest | jest | deno | playwright | pytest | maestro | storybook>
+detect-command: <command to run the full test suite>
+single-test-command: <command to run one test — use {file} and {name} as placeholders>
+failure-parser: '<regex with two capture groups: (1) file path, (2) test name>'
+cache-bust-flag: <flag to append when a cached-pass is suspected — leave blank if not applicable>
+---

--- a/skills/testing/test-autofix/templates/surface.md
+++ b/skills/testing/test-autofix/templates/surface.md
@@ -5,4 +5,18 @@ detect-command: <command to run the full test suite>
 single-test-command: <command to run one test — use {file} and {name} as placeholders>
 failure-parser: '<regex with two capture groups: (1) file path, (2) test name>'
 cache-bust-flag: <flag to append when a cached-pass is suspected — leave blank if not applicable>
+notes: <one-line summary, e.g. "Vitest jsdom + separate Storybook surface">
 ---
+
+## Notes
+
+Free-text body for human-readable context the YAML can't capture:
+
+- Other stacks detected alongside the primary (e.g. "Vitest is primary; Storybook
+  interaction tests live in a sibling surface `<key>-storybook.md`").
+- Project-specific quirks (e.g. "tests require `pnpm exec` not bare `vitest` because
+  the binary is hoisted only at the workspace root").
+- Known-flaky tests to escalate rather than auto-heal.
+- Surface-validation overrides (e.g. "binary lives under `mise`; tolerate `which` miss").
+
+This section is read by humans, not parsed by the skill.


### PR DESCRIPTION
## Why

run→classify→confidence-gate→fix→re-run. This PR lifts that loop into a global, stack-agnostic skill (`/test-autofix`) so any project — Vitest, Jest, Deno, Playwright, Pytest, Maestro, or Storybook — can use it without baking project-specific paths into the skill body.

## What changed

- New skill at `skills/testing/test-autofix/` — thin SKILL.md orchestration index (phases 0–9) plus 7 rule files, 7 stack detector files, and 3 templates; mirrors `ci-auto-fix` v3.0.0 structure
- Surface-driven project keying: on first run, bootstrap detects the stack, proposes a surface file diff, and waits for user approval before writing; subsequent runs validate the surface's commands still resolve
- Surface files stored centrally at `skills/testing/test-autofix/surfaces/<git-remote-key>.md` and gitignored — accumulates per-project config centrally without touching consuming repos
- `CLAUDE.md` and `README.md` updated; `.gitignore` covers surfaces directory

## How to verify

```bash
readlink ~/.claude/skills/test-autofix   # → ~/.agents/skills/test-autofix
readlink ~/.agents/skills/test-autofix   # → <repo>/skills/testing/test-autofix
```

Then run `/test-autofix` in any project with failing tests — on first run, bootstrap proposes a surface file before touching any test.

## Notes for reviewers

`templates/surface.md` is intentionally sparse (literal YAML template, no commentary) per the quality-checklist rule that templates must be literal text only.