### PR TITLE
fix(aw): repair spec-emission anchor links so L1 link check passes

### DIFF
--- a/skills/workflow/autonomous-workflow/rules/phase-1-planning.md
+++ b/skills/workflow/autonomous-workflow/rules/phase-1-planning.md
@@ -27,7 +27,7 @@ inside the worktree, never on the main branch.
 - [Complex Task Detection](#complex-task-detection)
 - [Step 2: Draft Technical Design](#step-2-draft-technical-design)
 - [Design Quality](#design-quality)
-- [Spec Emission (UI tasks)](#spec-emission-anchor)
+- [Spec Emission (UI tasks)](#spec-emission-ui-tasks)
 - [Confidence Gate](#confidence-gate)
 - [Planner-Executor Handoff](#planner-executor-handoff)
 - [Planning Checklist](#planning-checklist)

--- a/skills/workflow/autonomous-workflow/rules/phase-4-spec-verification.md
+++ b/skills/workflow/autonomous-workflow/rules/phase-4-spec-verification.md
@@ -36,7 +36,7 @@ a middle layer between English acceptance criteria in `plan.md` and saved
 Playwright test files.
 
 Specs are authored by the planner in `specs.md` alongside `plan.md` (see
-[`phase-1-planning.md` — Spec Emission](#spec-emission-anchor)). Most specs
+[`phase-1-planning.md` — Spec Emission](./phase-1-planning.md#spec-emission-ui-tasks)). Most specs
 are `verify-only` (ephemeral); a small subset are `critical-path` and get
 promoted to saved `*.spec.ts` via the `e2e-testing` skill's Generator.
 


### PR DESCRIPTION
Fixes a pre-existing L1 link-check failure that has been red on `main` (and every branch since): two Markdown links pointed at `#spec-emission-anchor`, which no heading produces, so Check A's baseline-ratchet counted them as 2 new broken anchors.

Repointed both links at the real heading slug `spec-emission-ui-tasks` (the `## Spec Emission (UI tasks)` heading); the cross-file link in `phase-4-spec-verification.md` also gains the `./phase-1-planning.md` path it was missing. `node scripts/eval/l1.mjs` is now all-green, which unblocks other PRs' CI.