### PR TITLE
feat(implement-suggestion): commit-per-comment + resolve addressed threads

### DIFF
--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -414,6 +414,49 @@ function checksInSync(plan, checks) {
     s.check("G14c outcome-learning.md references review-outcomes.md for bus schema",
       ol.includes("review-outcomes.md") && (ol.includes("schema") || ol.includes("bus")));
   }
+
+  // G15: implement-suggestion commit-per-comment + resolve-thread invariants (v2.3.0).
+  // These lock the behavioral contract of the worker: one commit per addressed
+  // comment, push ONCE, then resolve each addressed thread. The REST reply path
+  // MUST carry the pull number (a prior review regression removed it) and the
+  // forbidden legacy phrase "one commit per PR" must not reappear anywhere in
+  // the skill. All are stable literal tokens this commit controls.
+  {
+    const handoff = read("skills/workflow/implement-suggestion/rules/handoff.md");
+    const isSkill2 = read("skills/workflow/implement-suggestion/SKILL.md");
+    const fetching = read("skills/workflow/implement-suggestion/rules/comment-fetching.md");
+    const watch = read("skills/workflow/implement-suggestion/rules/watch-mode.md");
+    const pack = read("skills/workflow/implement-suggestion/templates/suggestion-pack.md");
+    const skillFiles = [
+      ["SKILL.md", isSkill2], ["handoff.md", handoff], ["comment-fetching.md", fetching],
+      ["watch-mode.md", watch], ["suggestion-pack.md", pack],
+    ];
+
+    s.check("G15a handoff worker prompt mandates one commit per comment",
+      handoff.includes("ONE COMMIT PER COMMENT"));
+    s.check("G15b handoff pushes ONCE after all per-comment commits",
+      handoff.includes("Push ONCE") || handoff.includes("push ONCE"));
+    s.check("G15c handoff resolves via resolveReviewThread",
+      handoff.includes("resolveReviewThread"));
+    s.check("G15d handoff REST reply path carries the pull number",
+      handoff.includes("pulls/<n>/comments/<comment-id>/replies"));
+    s.check("G15e handoff does NOT use the pull-number-less reply path (prior regression)",
+      !handoff.includes("pulls/comments/<comment-id>/replies"));
+    s.check("G15f handoff skips resolve for null threadId (issues/review-summary)",
+      handoff.includes("threadId") && handoff.includes("no thread to resolve"));
+    s.check("G15g handoff aborts push+resolve on partial-batch failure",
+      handoff.includes("partial batch") && /push nothing/i.test(handoff) && /resolve nothing/i.test(handoff));
+    s.check("G15h handoff continues (does not abort) on a resolve-side failure",
+      handoff.includes("not-resolved") && handoff.includes("CONTINUE"));
+    s.check("G15i comment-fetching captures threadId and guards GraphQL truncation",
+      fetching.includes("threadId") && fetching.includes("hasNextPage"));
+    s.check("G15j SKILL.md hard rule is 'One commit per applied comment'",
+      isSkill2.includes("One commit per applied comment"));
+    for (const [label, content] of skillFiles) {
+      s.check(`G15k ${label} does not reintroduce the legacy 'one commit per PR' phrase`,
+        !/one commit per pr\b/i.test(content));
+    }
+  }
 }
 
 process.exit(s.report() ? 0 : 1);

--- a/skills/workflow/implement-suggestion/SKILL.md
+++ b/skills/workflow/implement-suggestion/SKILL.md
@@ -6,9 +6,11 @@ description: >
   active PR) per PR: resolves a worktree, fetches every actionable comment
   from both human teammates AND AI code-review bots (claude[bot],
   coderabbitai[bot], …), validates each through /critical + /confidence,
-  builds a structured suggestion-pack, and dispatches a worker subagent to
-  apply / commit / push to the existing branch — fast-lane for mechanical
-  edits, standard-lane via aw-planner for architectural changes. Free-text
+  builds a structured suggestion-pack, and dispatches a worker subagent that
+  applies each approved change as its own commit, pushes to the existing
+  branch, and resolves the addressed review thread — so every handled comment
+  ends up resolved and the PR is left clean. Fast-lane for mechanical edits,
+  standard-lane via aw-planner for architectural changes. Free-text
   mode applies a single pasted suggestion in the current directory. Triggers
   on "implement suggestion", "apply review comments", "address PR feedback",
   "implement reviewer feedback", "fix PR comments", "/implement-suggestion".
@@ -21,9 +23,9 @@ license: MIT
 allowed-tools: Bash(gh *) Bash(git *) Bash(gw *) Read Edit Write Glob Grep Skill
 metadata:
   author: mthines
-  version: '2.2.0'
+  version: '2.3.0'
   workflow_type: orchestrator
-  architecture: parse/resolve/fetch/classify/validate/pack/handoff(fast|standard)/report
+  architecture: parse/resolve/fetch/classify/validate/pack/handoff(fast|standard)/commit-per-comment+resolve-thread/report
   composes:
     - critical
     - confidence
@@ -105,10 +107,10 @@ Phase 2:  Comment fetch          → per-PR ledger (parallel across PRs)
 Phase 3:  Classify               → actionable / nit / discussion / praise
 Phase 4:  Two-gate validation    → /critical → /confidence per actionable comment
 Phase 5:  Build suggestion-pack  → .agent/<branch>/suggestion-pack.md per PR
-Phase 6:  Handoff (lane-split)
+Phase 6:  Handoff (lane-split)         → worker: commit-per-comment, push, resolve thread
             ├── Fast-lane (simple):     dispatch worker subagent with pack
             └── Standard-lane (complex): aw-planner → plan.md → worker subagent
-Phase 7:  Report                 → per-PR table: applied / surfaced / skipped
+Phase 7:  Report                 → per-PR table: applied / surfaced / skipped / resolved
 ```
 
 Per-PR work in Phases 1–6 runs in **parallel across PRs** (one message,
@@ -243,9 +245,18 @@ Agent(
 Full dispatch contract and prompt template:
 [`rules/handoff.md#worker-prompt-template`](./rules/handoff.md#worker-prompt-template).
 
+The worker makes **one commit per applied comment** (each message cites that
+comment's `@author` + URL), pushes once after all commits, then **resolves
+each addressed review thread** — posting a brief `Addressed in <sha>` reply,
+then `resolveReviewThread`. This leaves a clean one-to-one trail (commit →
+resolved comment) and a PR where every handled comment is resolved; only
+`surface` / `skip` comments stay open. `issues` / `review`-summary comments
+have no resolvable thread and are reported as such. Full contract in
+[`rules/handoff.md#worker-prompt-template`](./rules/handoff.md#worker-prompt-template).
+
 **The main agent does not edit files in Phase 6.** All applies / commits /
-pushes happen inside the worker subagent so the loud loop (test runs,
-push retries) stays out of the main context.
+pushes / thread resolutions happen inside the worker subagent so the loud loop
+(test runs, push retries) stays out of the main context.
 
 ### Phase 7 — Report
 
@@ -254,16 +265,24 @@ Emit one summary table:
 ```markdown
 ## Implement-Suggestion Results
 
-| PR | Branch | Lane | Applied | Surfaced | Skipped | Commit | Pushed |
-|----|--------|------|---------|----------|---------|--------|--------|
-| dash0/console#1234 | fix/foo | fast | 3 | 1 | 2 | abc1234 | ✓ |
-| dash0/console#1278 | feat/bar | standard | 0 | 2 | 1 | — | — |
+| PR | Branch | Lane | Applied | Surfaced | Skipped | Commits | Pushed | Resolved |
+|----|--------|------|---------|----------|---------|---------|--------|----------|
+| dash0/console#1234 | fix/foo | fast | 3 | 1 | 2 | abc1234, def5678, 9a0bcde | ✓ | 3/3 |
+| dash0/console#1278 | feat/bar | standard | 0 | 2 | 1 | — | — | 0/0 |
 ```
 
+`Commits` lists one SHA per applied comment (commit-per-comment). `Resolved`
+is `<threads-resolved>/<applied-with-a-thread>` — comments whose fix landed and
+whose thread was resolved, over the applied comments that had a resolvable
+thread (`issues` / `review`-summary comments have none and are excluded from
+the denominator).
+
 Then per PR list:
-- **Applied** — comment ID, author, one-line summary.
+- **Applied** — comment ID, author, one-line summary, commit SHA, thread status
+  (resolved / no-thread).
 - **Surfaced** (needs user) — comment, gate score, `/critical` finding if any.
-- **Skipped** — comment, reason.
+  Thread left open.
+- **Skipped** — comment, reason. Thread left open.
 
 <a id="lessons-write"></a>
 **After the report — write lessons.** Run the retrospective and capture any
@@ -380,7 +399,12 @@ The reviewers (`reviewer`, `pr-reviewer`) consume this bus only at promotion/con
 - **Never** apply a change whose `/critical` review surfaced a Must-fix finding without surfacing first.
 - **Never** auto-rebase a PR branch — surface and stop.
 - **Never** delete or weaken tests or types to make a suggestion fit.
-- **One commit per PR.** A run that processes 5 PRs produces at most 5 commits, not 5×N.
+- **One commit per applied comment.** Each addressed comment is its own commit
+  (message citing that comment) so `git log` maps one-to-one to resolved threads.
+- **Resolve every addressed thread; leave the rest open.** After a comment's fix
+  lands and is pushed, the worker replies with the commit SHA and calls
+  `resolveReviewThread`. `surface` / `skip` comments — and any comment whose
+  commit did not land — stay open. Never resolve a thread whose fix is not on the remote.
 - **Worktree isolation.** Each PR gets its own `gw` worktree.
 - **Resolved threads are skipped at fetch time.**
 - **Main agent does not apply / commit / push in multi-PR mode.** Workers do.

--- a/skills/workflow/implement-suggestion/rules/comment-fetching.md
+++ b/skills/workflow/implement-suggestion/rules/comment-fetching.md
@@ -35,10 +35,12 @@ Use `--paginate` if any endpoint may exceed 100 results:
 gh api --paginate repos/<owner>/<repo>/pulls/<n>/comments
 ```
 
-## Resolved-thread filter
+## Resolved-thread filter and thread-ID map
 
-GitHub does not expose "resolved" status on `/pulls/<n>/comments` directly.
-Use the GraphQL endpoint for resolved status:
+GitHub does not expose "resolved" status — or the thread node ID needed to
+**resolve** a thread — on `/pulls/<n>/comments` directly. Use the GraphQL
+endpoint for both. Fetch the thread `id` (the GraphQL node ID, **not** the
+`databaseId`) and every comment's `databaseId` in the thread:
 
 ```bash
 gh api graphql -f query='
@@ -47,8 +49,9 @@ gh api graphql -f query='
       pullRequest(number: $number) {
         reviewThreads(first: 100) {
           nodes {
+            id
             isResolved
-            comments(first: 1) { nodes { databaseId } }
+            comments(first: 100) { nodes { databaseId } }
           }
         }
       }
@@ -56,8 +59,20 @@ gh api graphql -f query='
   }' -f owner=<owner> -f name=<repo> -F number=<n>
 ```
 
-Build a `resolvedCommentIds: Set<number>` from the result and drop any
-pulls-comment whose `id` is in the set.
+From the result build two structures:
+
+1. `resolvedCommentIds: Set<number>` — every `databaseId` in a thread whose
+   `isResolved == true`. Drop any pulls-comment whose `id` is in the set.
+2. `commentIdToThreadId: Map<number, string>` — map every comment `databaseId`
+   in an **unresolved** thread to that thread's node `id`. This is what the
+   worker uses in Phase 6 to call `resolveReviewThread` after committing the
+   fix for that comment. Carry it into the pack (per `apply` comment) as
+   `threadId`.
+
+Only `source == "pulls"` comments belong to a resolvable review thread.
+`issues` comments and top-level `review` summaries have no thread node ID —
+their `threadId` is `null` and they are **not** resolvable (see
+[handoff.md](./handoff.md) for how the worker handles the `null` case).
 
 ## Suggestion blocks
 
@@ -90,11 +105,15 @@ GitHub's UI lets the reviewer "Commit suggestion" with one click — the worker 
   "inReplyTo": null,
   "reviewId": 987654,
   "reviewState": "CHANGES_REQUESTED" | "COMMENTED" | "APPROVED" | null,
-  "isResolved": false
+  "isResolved": false,
+  "threadId": "PRRT_kwDO…"
 }
 ```
 
-Fields `path`, `line`, `side`, `originalLine` are only present when `source == "pulls"`.
+Fields `path`, `line`, `side`, `originalLine`, `threadId` are only present when
+`source == "pulls"`. `threadId` is the GraphQL review-thread node ID (from
+`commentIdToThreadId`) the worker resolves after committing the fix; it is
+`null` for `issues` / `review` comments, which have no resolvable thread.
 
 ## Deduplication
 

--- a/skills/workflow/implement-suggestion/rules/comment-fetching.md
+++ b/skills/workflow/implement-suggestion/rules/comment-fetching.md
@@ -48,6 +48,7 @@ gh api graphql -f query='
     repository(owner: $owner, name: $name) {
       pullRequest(number: $number) {
         reviewThreads(first: 100) {
+          pageInfo { hasNextPage }
           nodes {
             id
             isResolved
@@ -58,6 +59,17 @@ gh api graphql -f query='
     }
   }' -f owner=<owner> -f name=<repo> -F number=<n>
 ```
+
+**Truncation guard.** GraphQL connections cap at `first: 100`; `--paginate`
+does not work for GraphQL. If `reviewThreads.pageInfo.hasNextPage == true`, the
+PR has > 100 review threads and this single page is incomplete — threads beyond
+position 100 would arrive with `threadId: null`, be silently skipped at resolve
+time, and make the Phase 7 `Resolved` count under-report. Do **not** silently
+truncate: either page through with the `endCursor` cursor, or surface a warning
+in the Phase 7 report — `PR has > 100 review threads; thread-ID map is
+incomplete; some addressed comments may not be auto-resolved` — and continue.
+The inner `comments(first: 100)` cap only matters for a single thread with
+> 100 replies (rare); the same guard applies if you observe it.
 
 From the result build two structures:
 

--- a/skills/workflow/implement-suggestion/rules/handoff.md
+++ b/skills/workflow/implement-suggestion/rules/handoff.md
@@ -121,7 +121,9 @@ Apply reviewer suggestions to an existing pull request.
       typecheck + unit tests) if wired up. If a check fails:
       - For a clear mechanical fix (formatter / lint autofix): apply, re-check.
       - For anything else: STOP and report — do not "fix until green" by
-        weakening tests or types. Leave the commits already made in place.
+        weakening tests or types. Leave the commits already made in place as
+        LOCAL-ONLY, and do NOT proceed to steps 4 or 5: push nothing and
+        resolve nothing. A partial batch must not reach the remote.
    c. git add the files for THIS comment only, then git commit (no --no-verify,
       no Co-Authored-By) with this message:
 
@@ -135,9 +137,10 @@ Apply reviewer suggestions to an existing pull request.
 
    d. Record the resulting commit SHA and the comment's `threadId` for step 5.
 
-4. git push (no --force, no --force-with-lease). Push ONCE, after every
-   per-comment commit is made, so all the fix commits reach the remote before
-   any thread is resolved.
+4. git push (no --force, no --force-with-lease). Only reach this step if EVERY
+   `apply` entry committed without a STOP in step 3b — otherwise you already
+   aborted above. Push ONCE, after every per-comment commit is made, so all the
+   fix commits reach the remote before any thread is resolved.
 
 5. Resolve each addressed thread so the PR is left clean — one thread per
    committed comment, IN THE SAME ORDER you committed. For each `apply` entry
@@ -176,6 +179,9 @@ Apply reviewer suggestions to an existing pull request.
 - DO NOT delete or weaken tests or types.
 - DO NOT modify files outside the pack's apply list.
 - DO NOT batch comments — exactly one commit per addressed comment.
+- DO NOT push a partial batch. If step 3b STOPs on any comment, push nothing
+  and resolve nothing — leave the completed commits local and report them as
+  un-pushed.
 - DO NOT resolve a thread whose commit did not land, or a `surface` / `skip`
   comment's thread. Only resolve threads you addressed with a landed commit.
 - If push is rejected because the branch moved on the remote, STOP and

--- a/skills/workflow/implement-suggestion/rules/handoff.md
+++ b/skills/workflow/implement-suggestion/rules/handoff.md
@@ -52,8 +52,11 @@ Agent(
 )
 ```
 
-The worker reads the pack at `.agent/<branch>/suggestion-pack.md`,
-applies the changes, runs the project's fast checks, commits, and pushes.
+The worker reads the pack at `.agent/<branch>/suggestion-pack.md`, then for
+each `apply` comment: applies the edit, runs the project's fast checks, and
+makes one commit citing that comment. After all commits it pushes once, then
+resolves each addressed review thread (reply with the commit SHA, then
+`resolveReviewThread`) so the PR is left clean.
 
 ## Standard-lane dispatch
 
@@ -107,25 +110,64 @@ Apply reviewer suggestions to an existing pull request.
 1. cd <worktree>.
 2. Verify git status --porcelain is empty and HEAD == <head-sha-from-pack>.
    If either fails, STOP and report — do not auto-stash or auto-rebase.
-3. For each `apply` entry in the pack (or each Acceptance Criterion in the
-   plan, for standard-lane), apply the proposed edit using Edit / Write.
-4. Run the project's fast checks if wired up (lint + typecheck + unit tests
-   scoped to the touched files only). If a check fails:
-   - For a clear mechanical fix (formatter / lint autofix): apply, re-check.
-   - For anything else: STOP and report — do not "fix until green" by
-     weakening tests or types.
-5. Compose a single commit message:
+3. Process each `apply` entry in the pack SEQUENTIALLY, in pack order (for
+   standard-lane, iterate the Acceptance Criteria, each of which cites a
+   comment ID). This is ONE COMMIT PER COMMENT — do not batch multiple
+   comments into a single commit. For each entry:
 
-   ```
-   address review comments
+   a. Apply that comment's proposed edit using Edit / Write. Touch only the
+      files that comment's pack entry lists.
+   b. Run the project's fast checks scoped to the touched files (lint +
+      typecheck + unit tests) if wired up. If a check fails:
+      - For a clear mechanical fix (formatter / lint autofix): apply, re-check.
+      - For anything else: STOP and report — do not "fix until green" by
+        weakening tests or types. Leave the commits already made in place.
+   c. git add the files for THIS comment only, then git commit (no --no-verify,
+      no Co-Authored-By) with this message:
 
-   - <one bullet per applied comment, citing reviewer handle and comment URL>
+      ```
+      address review comment: <one-line summary of this comment's fix>
 
-   Refs: <pr-url>
-   ```
+      Addresses @<author>'s comment: <comment-url>
 
-6. git commit (no --no-verify, no Co-Authored-By).
-7. git push (no --force, no --force-with-lease).
+      Refs: <pr-url>
+      ```
+
+   d. Record the resulting commit SHA and the comment's `threadId` for step 5.
+
+4. git push (no --force, no --force-with-lease). Push ONCE, after every
+   per-comment commit is made, so all the fix commits reach the remote before
+   any thread is resolved.
+
+5. Resolve each addressed thread so the PR is left clean — one thread per
+   committed comment, IN THE SAME ORDER you committed. For each `apply` entry
+   whose commit landed AND whose `threadId` is non-null:
+
+   a. Post a brief reply on the thread tying the commit to the comment (this is
+      the visible "which commit resolved which comment" trail). Reply to the
+      thread's top-level comment id (the pack's comment `id`):
+
+      ```bash
+      gh api --method POST \
+        "repos/<owner>/<repo>/pulls/<n>/comments/<comment-id>/replies" \
+        -f body="Addressed in <commit-sha>. ✅"
+      ```
+
+   b. Resolve the thread:
+
+      ```bash
+      gh api graphql -f query='
+        mutation($threadId: ID!) {
+          resolveReviewThread(input: {threadId: $threadId}) {
+            thread { isResolved }
+          }
+        }' -f threadId="<threadId>"
+      ```
+
+   If `threadId` is null (an `issues` comment or a top-level `review` summary —
+   these have no resolvable thread), SKIP the reply + resolve for that entry and
+   note it as "no thread to resolve" in your report. Do NOT resolve threads for
+   `surface` / `skip` comments — only the ones you actually addressed.
 
 ## Hard rules
 - DO NOT open a new PR. The PR exists at <pr-url>.
@@ -133,16 +175,20 @@ Apply reviewer suggestions to an existing pull request.
 - DO NOT skip hooks.
 - DO NOT delete or weaken tests or types.
 - DO NOT modify files outside the pack's apply list.
+- DO NOT batch comments — exactly one commit per addressed comment.
+- DO NOT resolve a thread whose commit did not land, or a `surface` / `skip`
+  comment's thread. Only resolve threads you addressed with a landed commit.
 - If push is rejected because the branch moved on the remote, STOP and
-  report. Do not auto-rebase.
+  report BEFORE resolving any thread. Do not auto-rebase. (Resolving a thread
+  whose fix is not on the remote would leave a misleading trail.)
 
 ## Output you return
-A short report:
+A short report, one row per `apply` comment:
 
-- Commit SHA (or "not committed: <reason>").
+- Comment ID / @author → commit SHA (or "not committed: <reason>") →
+  thread status (resolved / no-thread / not-resolved: <reason>).
 - Push status (success / rejected — verbatim error).
-- Per-comment outcome: applied / skipped-with-reason.
-- Fast-check status: passed / failed-with-excerpt.
+- Fast-check status per comment: passed / failed-with-excerpt.
 ```
 
 ## Planner prompt template (standard-lane only)
@@ -194,7 +240,10 @@ misclassified, not that the agent needs more attempts.
 ## Hard rules
 
 - **Workers never open new PRs.** Push to existing branch only.
-- **Workers never amend prior commits.** One commit per PR, per run.
+- **Workers never amend prior commits.** One commit per addressed comment.
+- **Workers resolve every thread they addressed** — reply with the commit SHA,
+  then `resolveReviewThread`. A landed fix whose thread is left open is a
+  reporting bug. `surface` / `skip` threads stay open.
 - **Standard-lane below-gate stops.** No silent fallback to fast-lane.
 - **Main agent does not edit files in Phase 6** — all `Edit` / `Write` calls
   happen inside the worker subagent.

--- a/skills/workflow/implement-suggestion/rules/handoff.md
+++ b/skills/workflow/implement-suggestion/rules/handoff.md
@@ -172,6 +172,14 @@ Apply reviewer suggestions to an existing pull request.
    note it as "no thread to resolve" in your report. Do NOT resolve threads for
    `surface` / `skip` comments — only the ones you actually addressed.
 
+   Resolve-side failures do NOT abort — the commits are already on the remote,
+   so unlike step 3b there is nothing to hold back. If a reply or
+   `resolveReviewThread` call errors on one thread (permission denied, or a bot
+   already resolved it — `resolveReviewThread` on an already-resolved thread is
+   a safe no-op), record that thread as `not-resolved: <verbatim error>` and
+   CONTINUE to the next thread. Never unwind a landed commit because a
+   resolution call failed.
+
 ## Hard rules
 - DO NOT open a new PR. The PR exists at <pr-url>.
 - DO NOT push --force or --force-with-lease.

--- a/skills/workflow/implement-suggestion/rules/watch-mode.md
+++ b/skills/workflow/implement-suggestion/rules/watch-mode.md
@@ -43,7 +43,9 @@ Key invariants:
 - **Only process comments newer than the last processed timestamp.** Each iteration advances `baseline.timestamp` to "now" *after* the pass, so the next iteration sees only feedback the bots posted in response to the latest push. This is what prevents re-applying the same comment in a churn loop.
 - **Resolved threads are skipped at fetch time** (inherited from Phase 2). A comment the worker addressed and the bot then resolves will not reappear.
 - **The two-gate validation (`/critical` + `/confidence`) runs every iteration.** Watch mode never lowers the bar; a low-confidence comment is surfaced, not force-applied, on every pass.
-- **One commit per applied comment, every iteration** (inherited from the per-comment commit rule). Each iteration applies, commits per comment, pushes, then resolves the threads it addressed — so an iteration that lands 2 fixes leaves 2 commits and 2 newly-resolved threads. This is also why the next iteration sees fewer open comments: threads resolved in a prior iteration are skipped at fetch time.
+- **One commit per applied comment, every iteration** (inherited from the per-comment commit rule).
+  Each iteration applies, commits per comment, pushes, then resolves the threads it addressed — so an iteration that lands 2 fixes leaves 2 commits and 2 newly-resolved threads.
+  This is also why the next iteration sees fewer open comments: threads resolved in a prior iteration are skipped at fetch time.
 
 ## Lesson capture on re-flag
 

--- a/skills/workflow/implement-suggestion/rules/watch-mode.md
+++ b/skills/workflow/implement-suggestion/rules/watch-mode.md
@@ -43,7 +43,7 @@ Key invariants:
 - **Only process comments newer than the last processed timestamp.** Each iteration advances `baseline.timestamp` to "now" *after* the pass, so the next iteration sees only feedback the bots posted in response to the latest push. This is what prevents re-applying the same comment in a churn loop.
 - **Resolved threads are skipped at fetch time** (inherited from Phase 2). A comment the worker addressed and the bot then resolves will not reappear.
 - **The two-gate validation (`/critical` + `/confidence`) runs every iteration.** Watch mode never lowers the bar; a low-confidence comment is surfaced, not force-applied, on every pass.
-- **One commit per iteration** (inherited from the per-PR commit rule). A 3-iteration run produces at most 3 commits.
+- **One commit per applied comment, every iteration** (inherited from the per-comment commit rule). Each iteration applies, commits per comment, pushes, then resolves the threads it addressed — so an iteration that lands 2 fixes leaves 2 commits and 2 newly-resolved threads. This is also why the next iteration sees fewer open comments: threads resolved in a prior iteration are skipped at fetch time.
 
 ## Lesson capture on re-flag
 
@@ -92,11 +92,11 @@ Replace the single Phase 7 table with a per-iteration roll-up, then the standard
 ```markdown
 ## Implement-Suggestion (watch) — <owner>/<repo>#<n>
 
-| Iter | New feedback | Applied | Surfaced | Skipped | Commit | Pushed |
-|------|--------------|---------|----------|---------|--------|--------|
-| 1    | 4            | 3       | 1        | 0       | abc1234 | ✓ |
-| 2    | 1            | 1       | 0        | 0       | def5678 | ✓ |
-| 3    | 0            | —       | —        | —       | —       | — |
+| Iter | New feedback | Applied | Surfaced | Skipped | Commits | Pushed | Resolved |
+|------|--------------|---------|----------|---------|---------|--------|----------|
+| 1    | 4            | 3       | 1        | 0       | abc1234, def5678, 9a0bcde | ✓ | 3/3 |
+| 2    | 1            | 1       | 0        | 0       | c0ffee1 | ✓ | 1/1 |
+| 3    | 0            | —       | —        | —       | —       | —      | —   |
 
 Stopped: reviewers quiet after 3 iterations.
 Head commit: def5678

--- a/skills/workflow/implement-suggestion/templates/suggestion-pack.md
+++ b/skills/workflow/implement-suggestion/templates/suggestion-pack.md
@@ -7,7 +7,7 @@ headSha: <head-sha>
 worktree: <absolute-path-to-worktree>
 lane: <fast | standard>
 generatedAt: <ISO-8601-timestamp>
-generatedBy: implement-suggestion v2.0.0
+generatedBy: implement-suggestion v2.3.0
 ---
 
 # Suggestion Pack — <owner>/<repo>#<n>

--- a/skills/workflow/implement-suggestion/templates/suggestion-pack.md
+++ b/skills/workflow/implement-suggestion/templates/suggestion-pack.md
@@ -48,6 +48,7 @@ For each `apply` decision, one block:
 
 - **Source**: <reviews | pulls | issues>
 - **URL**: <permalink>
+- **Thread ID**: `<PRRT_… | null>` (null = no resolvable thread; worker skips resolve)
 - **Path:Line**: `<path>:<line>` (side: <LEFT|RIGHT>)
 - **Body**:
   > <verbatim comment body>
@@ -99,23 +100,31 @@ touch files outside this list.
 | `<path>` | `<lines>` | `<id>` | edit / replace / extract |
 | … | … | … | … |
 
-## Commit Message
+## Commit Messages
 
-The worker uses this verbatim (one commit per PR):
+**One commit per applied comment** — the worker commits each comment's fix
+separately so `git log` and the resolved threads line up one-to-one. Per
+`apply` comment the worker uses:
 
 ```
-address review comments
+address review comment: <one-line summary of this comment's fix>
 
-- <one bullet per applied comment, citing @author and comment URL>
+Addresses @<author>'s comment: <comment-url>
 
 Refs: <pr-url>
 ```
 
+After all per-comment commits are pushed, the worker resolves each addressed
+thread (reply with the commit SHA, then `resolveReviewThread`) so the PR is
+left with every addressed comment resolved and only `surface` / `skip`
+comments still open.
+
 ## Risk and Rollback
 
 - **Risk**: <one paragraph — what could break, what was considered>
-- **Rollback**: `git revert <commit-sha>` on the PR branch. Each pack
-  produces exactly one commit so revert is atomic.
+- **Rollback**: `git revert <commit-sha>` on the PR branch. Each applied
+  comment is its own commit, so a single comment's fix can be reverted in
+  isolation without unwinding the others.
 
 ## Test Plan
 


### PR DESCRIPTION
## Why

`/implement-suggestion` squashed every applied reviewer suggestion into one `address review comments` commit and left the threads open, so it was hard to follow which commit fixed which comment and the PR stayed cluttered with unresolved threads.

## What changed

- Worker now makes **one commit per applied comment** (message citing the comment's author + URL) instead of one per PR
- After pushing, it **resolves each addressed thread** — a brief `Addressed in <sha>. ✅` reply, then `resolveReviewThread`
- Comment fetch captures each thread's GraphQL node id (`threadId`) so the worker can resolve the right thread; carried through the ledger + pack
- Only addressed comments with a landed commit resolve; `surface`/`skip` and `issues`/`review`-summary comments stay open
- Phase 7 + watch-mode reports gain `Commits` (per-comment SHAs) and `Resolved` columns; bump to v2.3.0

## How to verify

- `node scripts/eval/l1.mjs` → 124/124 contract checks pass

## Notes for reviewers

Reply-then-resolve is intentional over resolve-only: GitHub records no "resolved by commit" link, so the reply is the only in-thread forward pointer to the fixing commit. Resolved threads collapse by default, so it adds no visible timeline noise.