### PR TITLE
feat(video-analyser): default to a tiled contact sheet for frame delivery

### DIFF
--- a/skills/analysis/video-analyser/SKILL.md
+++ b/skills/analysis/video-analyser/SKILL.md
@@ -14,7 +14,7 @@ argument-hint: '<video-path|linear-url|video-url>'
 license: MIT
 metadata:
   author: mthines
-  version: '1.0.0'
+  version: '1.1.0'
   workflow_type: analysis
   tags:
     - video
@@ -31,6 +31,10 @@ metadata:
 Analyse a video file to extract bugs, errors, UI state, and reproduction steps.
 The pipeline uses `ffmpeg` for frame extraction, optional `tesseract` OCR for text, and optional `whisper` for audio narration.
 The default path (8 keyframes at 768 px) is the Pareto-optimal setting for screen recordings: best quality-per-token on the legibility curve.
+
+By default the selected frames are packed into a single tiled **contact sheet** and sent to the analysis prompt as one image.
+This is cheaper on vision tokens and gives a temporal overview at a glance.
+An opt-in **split** mode keeps the legacy behaviour of one full-resolution image block per frame — use it when small UI text must be read (see [Frame Delivery Mode](#frame-delivery-mode)).
 
 ## Prerequisites
 
@@ -185,6 +189,27 @@ Proceed? (yes/no)
 Wait for explicit confirmation.
 If the user does not confirm, fall back to N=16.
 
+## Frame Delivery Mode
+
+Decide how the selected frames reach the analysis prompt.
+Set `DELIVERY_MODE` before extraction; it changes only Step 5d and Step 8 — frame selection (Step 5a–c) and OCR (Step 6) are identical in both modes.
+
+| Mode | `DELIVERY_MODE` | What is sent to vision | Default? |
+|---|---|---|---|
+| Contact sheet | `sheet` | One tiled montage of all N frames (cheaper, temporal overview at a glance) | Yes |
+| Split | `split` | N separate full-resolution image blocks (today's behaviour) | No — opt-in |
+
+Select `split` when ANY of the following holds:
+- The user says "split", "per-frame", "full-res", or "text is too small to read".
+- The user's goal is reading small UI text or OCR-grade detail (e.g., "read the terminal output", "what does the console say", "transcribe the error dialog").
+  In this case, if the user did not ask for `split` explicitly, proceed in `split` mode and note that the contact sheet would not have rendered the small text legibly.
+
+Otherwise use `sheet`.
+
+```bash
+DELIVERY_MODE=sheet   # default; set to "split" per the rules above
+```
+
 ## Step 5 — Extract Frames
 
 Use the keyframe-first strategy.
@@ -236,6 +261,50 @@ Do not bail on a low frame count.
 
 If `scale=768:-2` produces an error (odd-dimension video), use `scale=768:trunc(ow/a/2)*2` instead.
 
+### Step 5d — Build the contact sheet (sheet mode only)
+
+Skip this step when `DELIVERY_MODE=split`.
+
+Build the sheet **from the frames already selected** in Step 5c — do not re-sample the video, so the keyframe-first selection is preserved.
+The grid holds exactly the chosen N frames.
+
+1. Pick the grid so `COLS × ROWS ≥ N`.
+   Under-fill (grid larger than the frame count) pads the trailing cells with black; that is fine.
+
+   | N | Grid (`COLS`×`ROWS`) |
+   |---|---|
+   | 8 (default) | 4×2 |
+   | 16 | 4×4 |
+   | 24 | 6×4 |
+
+   For any other N, use `COLS = ceil(sqrt(N))`, `ROWS = ceil(N / COLS)`.
+
+2. Build the montage. Each cell is scaled to ~240 px wide (`CELL_W`) and stamped with its index so a finding can cite a specific cell.
+
+```bash
+COLS=4; ROWS=2   # from the grid table for N=8; COLS*ROWS must be >= N
+CELL_W=240
+ffmpeg -framerate 1 -pattern_type glob -i "$WORK_DIR/selected_*.jpg" \
+  -vf "scale=${CELL_W}:-2,drawtext=text='%{n}':x=4:y=4:fontsize=16:fontcolor=yellow:box=1:boxcolor=black@0.5,tile=${COLS}x${ROWS}" \
+  -frames:v 1 "$WORK_DIR/contact_sheet.png" -y 2>/dev/null
+```
+
+Required flags and why:
+- `-frames:v 1` is **required**. The `tile` filter emits one image per full grid; without it ffmpeg errors with `Use a pattern such as %03d … or -update`.
+- `scale=${CELL_W}:-2` uses `-2` (not `-1`) to force an even output dimension that the tile / h264 path needs.
+- `drawtext=text='%{n}'` stamps each cell with its 0-based index (yellow on a translucent black box) before `tile`, so findings can reference "cell 3".
+- The cell index `%{n}` maps to the same ordering as the split-mode frames (Step 5c order), so citations stay consistent across modes.
+
+Alternative one-shot recipe (samples straight from the video, bypassing the Step 5a–c selection — use only when the keyframe selection is not needed):
+
+```bash
+ffmpeg -i "$VIDEO_PATH" \
+  -vf "fps=${FPS},scale=${CELL_W}:-2,drawtext=text='%{n}':x=4:y=4:fontsize=16:fontcolor=yellow:box=1:boxcolor=black@0.5,tile=${COLS}x${ROWS}" \
+  -frames:v 1 "$WORK_DIR/contact_sheet.png" -y 2>/dev/null
+```
+
+At ~240 px per cell the sheet is legible for scene-level overview, but small terminal / UI text will **not** be readable in the grid — that is exactly when to use `split` mode.
+
 ## Step 6 — OCR (conditional)
 
 Run OCR when ALL of the following are true:
@@ -254,6 +323,10 @@ done
 Store OCR output in `$WORK_DIR/ocr_selected_*.txt`.
 Pass OCR text to the analysis prompt as `<ocr_frame_N>TEXT</ocr_frame_N>` blocks, one per frame.
 OCR text is cheaper context than asking vision to re-read the same text.
+
+**OCR always runs on the full-resolution individual frames** (`selected_*.jpg`), never on the shrunk contact sheet — in both `sheet` and `split` modes.
+The contact sheet is built only for the vision block; the small per-cell text would be unreadable to tesseract.
+This is why OCR matters most in `sheet` mode: it recovers the small text the montage cannot render.
 
 **Non-English UI text.**
 The default language is `-l eng`.
@@ -278,11 +351,41 @@ Append the transcript to the analysis prompt as `<audio_transcript>TEXT</audio_t
 
 ## Step 8 — Assemble Analysis Prompt
 
-Use the cheapest delivery mechanism for the chosen frame count.
-For N ≤ 16, inline base64 is typically cheapest; for N > 16, prefer the Files API if the runtime supports it.
-The executor decides at runtime.
+The image payload depends on `DELIVERY_MODE`.
 
-Construct the prompt as follows:
+### Sheet mode (default)
+
+Send the single contact sheet as one image block, followed by the per-frame OCR blocks.
+The cell index stamped in Step 5d maps each OCR block to a cell.
+
+```
+System:
+  You are analysing a screen recording of a software application.
+  Your goal: <USER_GOAL> (default: "identify bugs, errors, UI state issues, and reproduction steps").
+  You will receive ONE contact-sheet image tiling <N> frames in reading order (left-to-right,
+  top-to-bottom). Each cell is stamped with its 0-based index in the top-left corner.
+  Cite cells by index (e.g., "cell 3") in your findings.
+  Cross-reference the OCR text blocks with what you see in each cell — the OCR was run on the
+  full-resolution frames, so trust it over the montage for small text.
+  Do not hallucinate text — if OCR and vision disagree, note both.
+
+  [image content block — contact_sheet.png]
+
+For each frame (in cell-index order):
+  [if OCR enabled: <ocr_frame_N>OCR TEXT HERE</ocr_frame_N>]
+
+[if audio transcription enabled:]
+  <audio_transcript>TRANSCRIPT TEXT HERE</audio_transcript>
+
+Request:
+  Return findings in the structured format specified in Step 9.
+```
+
+### Split mode (opt-in)
+
+Send N separate full-resolution image blocks, interleaved with their OCR text.
+Use the cheapest delivery mechanism for the chosen frame count: for N ≤ 16, inline base64 is typically cheapest; for N > 16, prefer the Files API if the runtime supports it.
+The executor decides at runtime.
 
 ```
 System:
@@ -315,6 +418,7 @@ Do not omit sections; use "None detected" for sections with no findings.
 - Duration: <X> seconds
 - Resolution: <W>×<H>
 - Frames analysed: <N> (<method: keyframe | uniform | hybrid>)
+- Frame delivery: <sheet | split>
 - OCR: <enabled | disabled>
 - Audio transcription: <enabled | disabled>
 
@@ -335,23 +439,36 @@ Do not omit sections; use "None detected" for sections with no findings.
 
 ## Token Budget
 
-The default setting (8 frames, 768 px) is the Pareto-optimal point on the quality-vs-token curve for screen recordings.
-
-768 px is the curve knee for screen-recording legibility.
-UI text (error messages, stack traces, console output) is fully legible at 768 px.
-Going lower (512 px) risks misreading small-font terminal output.
-Going higher (1568 px) roughly doubles token cost with no meaningful legibility gain for screen content.
+The default `sheet` mode collapses all N frames into a single tiled image, so the image token cost is roughly one image regardless of N — an order of magnitude cheaper than the per-frame `split` payload.
+`split` mode trades those tokens for per-frame legibility: each frame is a full-resolution 768 px image block.
 
 8 frames is the sweet spot for recordings under 3 min.
 I-frame sampling captures the scene transitions that carry the diagnostic signal.
 Beyond ~10 frames, incremental frames are typically near-duplicates that add tokens without adding context.
 
+**Sheet mode (default).**
+The sheet packs ~240 px cells into a `COLS × ROWS` grid; the token cost tracks the final montage dimensions (≈ `width × height / 750`).
+
+| Frames | Grid | Sheet size (16:9 cells) | Image tokens | Cost (Sonnet 4.6, $3/M) | Use when |
+|---|---|---|---|---|---|
+| 8 (default) | 4×2 | ~960×272 | ~350 | ~$0.001 | Standard bug recording; scene-level overview |
+| 16 (escalation) | 4×4 | ~960×544 | ~700 | ~$0.002 | User says "fine-grained" or "detailed" |
+| 24 (long clip opt-in) | 6×4 | ~1440×544 | ~1,050 | ~$0.003 | Clip 181–600 s + user explicitly opts in after cost warning |
+
+**Split mode (opt-in).**
+768 px is the curve knee for screen-recording legibility.
+UI text (error messages, stack traces, console output) is fully legible at 768 px.
+Going lower (512 px) risks misreading small-font terminal output.
+Going higher (1568 px) roughly doubles token cost with no meaningful legibility gain for screen content.
+
 | Frames | Resolution | Tokens/frame | Total image tokens | Cost (Sonnet 4.6, $3/M) | Use when |
 |---|---|---|---|---|---|
-| 8 (default) | 768 px | ~786 | ~6,288 | ~$0.019 | Standard bug recording; Pareto-optimal default |
+| 8 (default) | 768 px | ~786 | ~6,288 | ~$0.019 | Small UI text must be read per frame; OCR-grade detail |
 | 16 (escalation) | 768 px | ~786 | ~12,576 | ~$0.038 | User says "fine-grained" or "detailed" |
 | 24 (long clip opt-in) | 768 px | ~786 | ~18,864 | ~$0.057 | Clip 181–600 s + user explicitly opts in after cost warning |
 | 8 | 1568 px (cap) | ~1,568 | ~12,544 | ~$0.038 | Only if user reports text still unreadable at 768 px |
+
+Note: `split` mode costs roughly N× the sheet — the premium buys per-frame legibility the montage cannot deliver.
 
 For clips longer than 10 min (after the user trims), or for frame counts > 24, consider Gemini's native video API as an escalation path.
 Gemini charges per-second rather than per-frame and handles long clips natively.
@@ -373,4 +490,6 @@ Gemini charges per-second rather than per-frame and handles long clips natively.
 | Tesseract produces garbage on non-English UI text | Medium | Default is `-l eng`; user can override with a language code. |
 | Very short clips (< 1 s) yield 0 frames | Low | Bail gate in Step 3. |
 | Claude vision hallucinates text not in frames | Low | Cross-reference OCR output when available; note disagreements. |
+| Small UI text unreadable in the ~240 px contact-sheet cells | Medium | Default `sheet` mode is scene-level; switch to `split` mode (and lean on OCR, which runs on full-res frames) when text legibility matters. |
+| `tile` filter errors without `-frames:v 1` | Low | `-frames:v 1` is mandatory in the Step 5d command; the filter emits one image per full grid. |
 | Linear attachment URL requires authenticated download | Medium | Use the Linear MCP tool to obtain a pre-signed URL rather than a raw `curl`. |


### PR DESCRIPTION
## Why

Sending N separate full-res frames to vision is the costly path when most bug recordings only need a scene-level overview. Packing the selected frames into one tiled contact sheet cuts image tokens ~10× and gives a temporal overview at a glance, while the old per-frame behaviour stays available for reading small UI text.

## What changed

- Add a Frame Delivery Mode section: `sheet` (default) vs `split` (opt-in on "split"/"per-frame"/"full-res"/"text too small", auto-suggested for OCR-grade goals)
- Add Step 5d building the sheet from the already-selected frames (grid = chosen N) with index-stamped cells and the required `-frames:v 1` / `scale=W:-2` flags
- Keep OCR (Step 6) on the full-res individual frames, never the shrunk sheet
- Branch Step 8 on the mode; refresh the Step 9 summary and the Token Budget table (sheet vs split) with the tokens-for-legibility note

## How to verify

- `node scripts/eval/l1.mjs` (144/144 deterministic contract checks pass)

## Notes for reviewers

Source-resolution, bail-gate, and audio steps are untouched. The `tile` filter is fed from the keyframe-selected frames, not re-sampled, so Step 5a–c selection is preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_017R4akk53nBgaUDzxKbqD5J)_