### PR TITLE
feat(ideate): gate finalists on quality, not a fixed count

### DIFF
--- a/skills/analysis/ideate/SKILL.md
+++ b/skills/analysis/ideate/SKILL.md
@@ -16,7 +16,7 @@ argument-hint: '[quick|deep] [--n <count>] [--no-framing] [<problem statement>]'
 license: MIT
 metadata:
   author: mthines
-  version: '1.0.1'
+  version: '1.1.0'
   workflow_type: orchestrator
   tags:
     - ideation
@@ -61,7 +61,7 @@ Parse `$ARGUMENTS`:
 
 | Flag           | Default | Meaning                                                  |
 | -------------- | ------- | -------------------------------------------------------- |
-| `--n <count>`  | 3       | Number of finalists in the report.                       |
+| `--n <count>`  | unset   | Optional **cap** on the Lead-finalists list. Unset by default — the finalist count is emergent from the quality bar (see [`idea-scoring.md`](./rules/idea-scoring.md) § Selection rules). `--n` only narrows; it never manufactures finalists the bar did not admit. |
 | `--no-framing` | off     | Skip Phase 1 (problem is already well-framed).           |
 
 Everything else in `$ARGUMENTS` is the problem statement.
@@ -79,7 +79,7 @@ First match wins:
 | 4 | User is mid-conversation and wants options fast ("any ideas?", "what do you think?").                   | `quick` |
 | 5 | Unsure.                                                                                                 | `quick`, and name the escalation path: "run `/ideate deep <problem>` for the full pipeline". |
 
-Cost expectation: a deep `--n 3` run dispatches ~17 subagents (2 bursts × 5 generators, 1 pool judge, 1 breeder, 1 variant judge, 3 panel judges, 1 pre-mortem) — prefer `quick` for casual or budget-sensitive asks.
+Cost expectation: a deep run with a typical 2–4-idea finalist band dispatches ~17 subagents (2 bursts × 5 generators, 1 pool judge, 1 breeder, 1 variant judge, 3 panel judges, 1 pre-mortem) — prefer `quick` for casual or budget-sensitive asks. A richer pool that admits more finalists adds only panel-judge cost, not generation cost.
 
 ---
 
@@ -93,7 +93,7 @@ Cost expectation: a deep `--n 3` run dispatches ~17 subagents (2 bursts × 5 gen
 | 3     | Score            | [`rules/idea-scoring.md`](./rules/idea-scoring.md)                      | Every pooled idea scored on 4 independent axes by a non-generator judge.                    |
 | 4     | Evolve           | [`rules/evolution-loop.md`](./rules/evolution-loop.md)                  | ≤ 3 rounds; stopped on flat external scores, never on self-assessed improvement.           |
 | 5     | Validate         | [`rules/idea-scoring.md`](./rules/idea-scoring.md) § Finalist validation | Every finalist has an executability probe; `confidence(analysis)` ≥ 70 on the recommendation. |
-| 6     | Report           | [`templates/ideation-report.md`](./templates/ideation-report.md)        | Report emitted; high-novelty wildcard included; verdict question asked.                     |
+| 6     | Report           | [`templates/ideation-report.md`](./templates/ideation-report.md)        | Report emitted; finalist count reflects the quality bar; high-novelty wildcard included; "Ideas worth revisiting" filled; verdict question asked. |
 | 7     | Learn            | [`rules/self-improvement-loop.md`](./rules/self-improvement-loop.md)    | Lessons written — mechanics only, never idea content.                                       |
 
 ### Phase 0 — Intake & triage
@@ -152,9 +152,10 @@ Problem framing measurably shapes ideation breadth and direction (§2.5) — ski
 3. **Diversity comes from personas and prompts, not temperature.** Temperature is a weak novelty lever with a coherence cost (§4.6).
 4. **The judge is never the generator.** Self-scoring amplifies self-bias per iteration (§4.7, §5.1).
 5. **Protect novelty at selection.** Default selection sacrifices originality for feasibility and performs near-randomly; always carry one high-novelty pick (§3.2).
-6. **Iterate by recombination across lineages, not polishing.** Cap at 3 rounds; stop on flat external scores (§5.1–§5.3).
-7. **The obvious ideas come first.** Always run a second burst seeded with "what has NOT been said yet" (§1.5).
-8. **Pre-execution novelty is inflated.** Every finalist needs a concrete first-step probe before it is recommended (§4.2).
+6. **Gate finalists on quality, not quantity.** The finalist count is emergent: report every idea that clears the admission bar, not a fixed top-3. A fixed count drops deserving ideas from a rich pool and pads a thin one (§3.2).
+7. **Iterate by recombination across lineages, not polishing.** Cap at 3 rounds; stop on flat external scores (§5.1–§5.3).
+8. **The obvious ideas come first.** Always run a second burst seeded with "what has NOT been said yet" (§1.5).
+9. **Pre-execution novelty is inflated.** Every finalist needs a concrete first-step probe before it is recommended (§4.2).
 
 ---
 
@@ -174,6 +175,8 @@ Lessons may inform mechanics — depth triage, operator effectiveness, judge cal
 - Scoring or feasibility talk during a generation pass.
 - Letting the generation context judge its own output.
 - Averaging the four axes into one number before selection, then picking the top-n — this silently discards every high-novelty idea.
+- Capping the report at a fixed 3–4 finalists regardless of how many ideas cleared the quality bar — the count is emergent, not a target.
+- Treating the "Ideas worth revisiting" section as a throwaway list — it must name why each near-miss missed and what would flip it; that is the inspiring part.
 - A 4th evolution round because it "still feels like it's improving" — self-assessed improvement is the signal that lies.
 - Storing user idea-taste as a lesson.
 
@@ -185,5 +188,6 @@ Lessons may inform mechanics — depth triage, operator effectiveness, judge cal
 - [ ] Generation and evaluation never co-occurred in one pass.
 - [ ] Pool met the unique-idea gate for the chosen depth.
 - [ ] Every finalist has all four axis scores, an executability probe, and the confidence gate result.
-- [ ] Report includes the high-novelty wildcard and the run stats (bursts, non-duplicate yield, evolution rounds, score trajectory).
+- [ ] The finalist count reflects the quality bar, not a fixed target — every idea that cleared the admission bar is reported (or capped only by an explicit `--n`).
+- [ ] Report includes the high-novelty wildcard, the run stats (bursts, non-duplicate yield, evolution rounds, score trajectory), and an "Ideas worth revisiting" section that names, per near-miss, why it missed and what would flip it.
 - [ ] User verdict requested; lessons written per the loop contract.

--- a/skills/analysis/ideate/references/ideation-research.md
+++ b/skills/analysis/ideate/references/ideation-research.md
@@ -121,7 +121,7 @@ Source: [Double Diamond](https://en.wikipedia.org/wiki/Double_Diamond_(design_pr
 Rietzschel, Nijstad & Stroebe (2010): after generating, people select ideas **barely better than random**, systematically preferring feasible/desirable over original — selected sets are *less original than the average of the generated pool*.
 Instructing selectors to "select creative ideas" partially corrects this.
 Sources: [Rietzschel et al. 2010, BJP](https://bpspsychub.onlinelibrary.wiley.com/doi/10.1348/000712609X414204), [review](https://research.rug.nl/en/publications/why-great-ideas-are-often-overlooked-a-review-and-theoretical-ana/) — strong (replicated line).
-**Skill consequence:** the verbatim "select the most creative" instruction, the novelty-protection wildcard, and axes scored separately — finalists are never chosen on a single averaged number alone (the composite orders the pool; the selection rules and wildcard override it).
+**Skill consequence:** the verbatim "select the most creative" instruction, the novelty-protection wildcard, and axes scored separately — finalists are never chosen on a single averaged number alone (the composite orders the pool; the selection rules and wildcard override it). The finalist *count* is likewise gated on a quality bar rather than a fixed top-N, since an arbitrary cutoff is itself a selection distortion that drops deserving ideas from a rich pool.
 
 ### §3.3 Dot voting / impact-effort
 
@@ -240,7 +240,7 @@ They are listed here so no number in the skill silently masquerades as evidence.
 | Composite weights 0.30 N / 0.25 F / 0.30 I / 0.15 Fit           | Novelty and impact weighted above feasibility to lean against the §3.2 bias; composite orders the pool only — selection rules override it. |
 | Wildcard floor: Feasibility ≥ 4                                 | Excludes only outright-impossible ideas from novelty protection; any higher floor would re-create the §3.2 bias inside the wildcard rule. |
 | Panel of 3 finalist judges (deep)                               | Smallest odd panel; §4.7 motivates panels but names no size, and same-model panels approximate — not achieve — the diversity §4.7 means. |
-| `--n 3` finalists; 3–5 HMW framings                             | Presentation-size choices.                                                                            |
+| Quality-gated finalist set (emergent count); 3–5 HMW framings   | The finalist count follows the admission bar (on-target floor + leading-tier composite + Phase 5), not a fixed N — a fixed top-N re-imposes the §3.2 arbitrary cutoff. `--n` is an optional user cap only. Admission thresholds (`Fit`/`Impact` ≥ 6, `C* − 1.0`, absolute ≥ 7.0) and the HMW count are operationalizations, not study values. |
 | Pairwise refinement for pools > 10, top half only               | Cost bound; direct rubric scoring suffices for small pools.                                           |
 | ≤ 2 finalists per niche                                         | Structural diversity guard at selection, mirroring the per-niche elitism of §5.2.                     |
 | Evolution skip: pool ≤ 6 or top composite ≥ 8.5                 | Skip when there is nothing to breed or little headroom.                                               |

--- a/skills/analysis/ideate/rules/diagnostic-surface.md
+++ b/skills/analysis/ideate/rules/diagnostic-surface.md
@@ -52,7 +52,7 @@ The contract spec lives at [`skills/authoring/create-skill/rules/diagnostic-surf
 | 0     | Depth-triage table; missing-problem refusal.                             | Ambiguous asks triaged quick when the user wanted depth.                    |
 | 1     | Width-varied framings; autonomous default (one step wider than literal). | Framing chosen re-states the literal ask five ways (no real width variance). |
 | 2     | Persona-per-call; mandatory burst 2; gate-met/yield/4-burst stopping rule. | Personas too similar; operators assigned but ignored by generators.         |
-| 3     | Anonymization; order-swap pairs; length normalization.                   | Composite used for selection despite the selection rules.                   |
+| 3     | Anonymization; order-swap pairs; length normalization; quality-gated finalist admission (emergent count). | Composite used for selection despite the selection rules; finalist list truncated to a fixed count instead of following the admission bar. |
 | 4     | Niche elitism; 3-round cap; external re-scoring.                         | Niches drawn too coarsely (everything lands in 2 buckets).                   |
 | 5     | Executability probe; confidence thresholds.                              | Probe written as marketing prose instead of a first concrete step.           |
 | 6     | Template with run stats + verdict question.                              | Wildcard silently dropped when it scored poorly.                             |

--- a/skills/analysis/ideate/rules/divergence.md
+++ b/skills/analysis/ideate/rules/divergence.md
@@ -32,7 +32,7 @@ A burst is one round of generation across all generators.
 | 1    | Burst 1 — broad: each generator gets the selected framing, its persona, and one operator. No other context.     |
 | 2    | Pool and dedupe (below). Log the unique count.                                                                  |
 | 3    | Burst 2 — reseed: same personas, rotated operators, plus an exclusion list of the pooled ideas as *title + one-line mechanism* and the instruction "propose only what has NOT been said yet". Originality rises with extended effort — the obvious ideas came first (§1.5). Bare titles under-specify what is taken — generators re-invent the same mechanism under a new name; the one-line mechanism is what steers them off it. |
-| 4    | Stop generating at the first of: (a) ≥ 2 bursts done AND the pool gate met, (b) the previous burst's non-duplicate yield < 20% (the pool has plateaued, §4.1), or (c) 4 bursts (hard cap). A high yield alone never justifies another burst once the gate is met — the pool only needs to feed `--n` finalists, not maximize coverage. |
+| 4    | Stop generating at the first of: (a) ≥ 2 bursts done AND the pool gate met, (b) the previous burst's non-duplicate yield < 20% (the pool has plateaued, §4.1), or (c) 4 bursts (hard cap). A high yield alone never justifies another burst once the gate is met — the pool only needs to surface a strong leading tier for the quality-gated selection, not maximize coverage. |
 
 Burst 2 is mandatory in both modes.
 Never skip it because burst 1 "looks sufficient" — burst 1 is where the obvious ideas live.

--- a/skills/analysis/ideate/rules/idea-scoring.md
+++ b/skills/analysis/ideate/rules/idea-scoring.md
@@ -103,8 +103,9 @@ Then apply, in order:
    Ties on Novelty break by composite.
    Label it the **wildcard** in the report.
    It never consumes a "slot" — there are no slots — so it appears in the report's Wildcard section additionally, and is *also* flagged a finalist if it cleared the bar on its own.
-6. **Niche diversity:** among admitted finalists, keep at most 2 per niche (see [`evolution-loop.md`](./evolution-loop.md) for niche construction).
-   A 3rd+ from the same niche is **not discarded** — it drops to the *strong contenders* tier the report surfaces under "Ideas worth revisiting", so a productive niche is shown, not hidden.
+6. **Niche diversity:** at most 2 admitted finalists per niche appear in the **Lead finalists** list (see [`evolution-loop.md`](./evolution-loop.md) for niche construction).
+   A 3rd+ from the same niche is **not discarded and not demoted to the bench** — it *cleared the bar*, so it is still a finalist and appears under **Also cleared the bar** (a Finalists sub-section), so a productive niche is shown, not hidden.
+   Only ideas that missed the bar go to "Ideas worth revisiting".
 7. Deep mode: the admitted finalist set is confirmed by a panel of 3 fresh judge subagents voting independently; majority keeps a finalist, and any panel member may promote one bar-missing idea back for a revote (§4.7 proposes diverse judge panels as a bias mitigation; three independent fresh contexts approximate this within a single-model setup — see the same-model caveat above).
 
 ### Count bounds

--- a/skills/analysis/ideate/rules/idea-scoring.md
+++ b/skills/analysis/ideate/rules/idea-scoring.md
@@ -129,7 +129,7 @@ Pre-execution novelty scores are systematically inflated — idea rankings can f
 Before recommending, run each finalist through:
 
 1. **Executability probe.** Write one concrete paragraph: the first real step, the core mechanism, and the riskiest assumption.
-   A finalist that cannot produce a concrete first step is downgraded and replaced from the ranked pool.
+   A finalist that cannot produce a concrete first step fails admission clause 3 and simply **drops out of the finalist set** — there is no fixed count to backfill, so nothing is promoted in its place (it may still surface under "Ideas worth revisiting" if notable).
 2. **Confidence gate.** Run `Skill("confidence", "analysis")` on the recommendation package (finalists + scores + probes).
    Apply the confidence skill's thresholds:
 

--- a/skills/analysis/ideate/rules/idea-scoring.md
+++ b/skills/analysis/ideate/rules/idea-scoring.md
@@ -82,15 +82,45 @@ Disagreement between the two orderings of a pair = a tie; do not silently pick o
 
 ## Selection rules
 
-Select `--n` finalists (default 3) from the ranked pool:
+The finalist list is **gated on quality, not truncated to a fixed count** — its size is emergent from the pool.
+Selecting a fixed top-`k` re-imposes the arbitrary cutoff §3.2 warns against: a rich pool has deserving ideas silently dropped to hit the number, and a thin pool gets padded with mediocre ones to reach it.
+Instead, admit every idea that clears an explicit bar and let the count fall out.
 
-1. Instruct the selector verbatim: **"select the most creative ideas that satisfy the success criterion"** — the explicit "creative" instruction partially corrects the feasibility bias (§3.2).
-2. **Novelty protection:** at least one finalist must be the pool's highest-Novelty idea with Feasibility ≥ 4, even when its composite loses to safer ideas.
+### Admission bar
+
+An idea from the ranked pool is a **finalist** when it clears **all** of:
+
+1. **On-target floor** — `Fit ≥ 6` **and** `Impact ≥ 6`.
+   It must answer the selected framing and move the success criterion; this stops a novel idea that solves a *different* problem from being promoted.
+2. **Leading-tier quality** — `Composite ≥ C* − 1.0` (where `C*` is the pool's top composite) **and** `Composite ≥ 7.0` absolute.
+   The relative band keeps the set to ideas genuinely competitive with the best; the absolute floor stops a weak pool from promoting its own mediocre top.
+3. **Survives Phase 5** — produces a concrete executability probe and is not downgraded by the confidence gate (see [Finalist validation](#finalist-validation-phase-5)).
+
+Then apply, in order:
+
+4. Instruct the selector verbatim: **"select the most creative ideas that satisfy the success criterion"** — the explicit "creative" instruction partially corrects the feasibility bias (§3.2).
+5. **Novelty protection (always):** the pool's highest-Novelty idea with `Feasibility ≥ 4` is always carried, even when it misses the admission bar.
    Ties on Novelty break by composite.
    Label it the **wildcard** in the report.
-   With `--n 1`, the wildcard does not consume the single finalist slot — report it additionally in the report's Wildcard section.
-3. Never fill the finalist list with ideas from a single niche (see [`evolution-loop.md`](./evolution-loop.md) for niche construction) — two finalists max per niche.
-4. Deep mode: the finalist set is confirmed by a panel of 3 fresh judge subagents voting independently; majority keeps a finalist, and any panel member may promote one discarded idea back for a revote (§4.7 proposes diverse judge panels as a bias mitigation; three independent fresh contexts approximate this within a single-model setup — see the same-model caveat above).
+   It never consumes a "slot" — there are no slots — so it appears in the report's Wildcard section additionally, and is *also* flagged a finalist if it cleared the bar on its own.
+6. **Niche diversity:** among admitted finalists, keep at most 2 per niche (see [`evolution-loop.md`](./evolution-loop.md) for niche construction).
+   A 3rd+ from the same niche is **not discarded** — it drops to the *strong contenders* tier the report surfaces under "Ideas worth revisiting", so a productive niche is shown, not hidden.
+7. Deep mode: the admitted finalist set is confirmed by a panel of 3 fresh judge subagents voting independently; majority keeps a finalist, and any panel member may promote one bar-missing idea back for a revote (§4.7 proposes diverse judge panels as a bias mitigation; three independent fresh contexts approximate this within a single-model setup — see the same-model caveat above).
+
+### Count bounds
+
+The bar sets the count; these bounds only handle the extremes.
+
+- **Floor — always at least 1.**
+  If the bar admits nothing (thin or off-target pool), carry the single top-composite idea plus the wildcard, and state plainly in the report that no idea cleared the quality bar.
+  An honest "nothing strong yet — here is the closest" beats padding the list to look productive.
+- **No fixed ceiling; a readability tier instead.**
+  When more than 5 ideas clear the bar, the pool is genuinely rich — keep them **all**, but present the highest-composite ~5 as **Lead finalists** and the remainder as **Also cleared the bar**, both inside the report's Finalists section.
+  This split is presentation only: nothing that cleared the bar is demoted to "revisit".
+- **`--n` is an optional user cap, never the default count.**
+  With `--n k`, the Lead-finalists list is truncated to the `k` highest-composite admitted finalists (the wildcard still always appears); everything else that cleared the bar moves to "Also cleared the bar".
+  Without `--n`, the count is fully emergent.
+  `--n` can only *narrow* the lead list — it never manufactures finalists the bar did not admit.
 
 ## Finalist validation (Phase 5)
 
@@ -116,6 +146,7 @@ Before recommending, run each finalist through:
 ## Common mistakes
 
 - Selecting the top-3 composite scores. **Fix:** apply the selection rules — composite ranking alone re-creates the feasibility bias the rubric exists to counter (§3.2).
+- Truncating the finalist list to a fixed count (3–4) when more ideas clear the bar, or padding it to that count when fewer do. **Fix:** the count is emergent from the admission bar; report every idea that clears it, and be honest when few (or none) do.
 - Letting judges see persona or seed-idea labels. **Fix:** anonymize and shuffle before judging; self-preference and social signals bias verdicts (§4.7).
 - Reporting axis scores as precise truth. **Fix:** treat scores as ordering devices; surface the confidence gate result as the reliability statement (§4.1).
 - Judging each idea once, in pool order. **Fix:** per-axis passes plus order-swapped pairs for the top half.

--- a/skills/analysis/ideate/templates/ideation-report.md
+++ b/skills/analysis/ideate/templates/ideation-report.md
@@ -7,7 +7,9 @@
 
 ## Finalists
 
-> **Quality bar:** {count} idea(s) cleared the admission bar (`Fit ≥ 6`, `Impact ≥ 6`, composite in the leading tier, survived Phase 5). The count is emergent — not a fixed target.{ Cap applied: `--n {k}`. | No `--n` cap — every idea that cleared the bar is shown.}
+> **Quality bar** (`Fit ≥ 6`, `Impact ≥ 6`, composite in the leading tier, survived Phase 5). The count is emergent — not a fixed target.
+> {When ≥ 1 cleared: **{count} idea(s) cleared the admission bar.**{ Cap applied: `--n {k}` — the rest appear under "Also cleared the bar". | No `--n` cap — every idea that cleared the bar is shown.}}
+> {When 0 cleared: **No idea cleared the admission bar this run.** The single closest idea is shown below as the floor-of-1 finalist, plus the novelty wildcard — treat both as "closest, not validated".}
 
 ### Lead finalists
 

--- a/skills/analysis/ideate/templates/ideation-report.md
+++ b/skills/analysis/ideate/templates/ideation-report.md
@@ -28,9 +28,9 @@
 
 ### Also cleared the bar
 
-{Only present when > 5 ideas cleared the bar. Same per-idea structure as a lead finalist, but the compact table only. These are full finalists — the split from the lead list is readability, not quality.}
+{Present whenever more ideas cleared the admission bar than appear in Lead finalists — i.e. the lead list was capped by the ~5 readability limit, an explicit `--n k`, or the 2-per-niche guard. These are full finalists; the split from the lead list is readability and diversity, not quality. Compact table only. Omit this section only when every cleared-bar idea is already a Lead finalist.}
 
-- **{idea title}** — {composite}, {one-line mechanism}. {First concrete step in one sentence.}
+- **{idea title}** — {composite}, {capped by: readability | `--n` | niche}, {one-line mechanism}. {First concrete step in one sentence.}
 
 ### Wildcard — {idea title}
 

--- a/skills/analysis/ideate/templates/ideation-report.md
+++ b/skills/analysis/ideate/templates/ideation-report.md
@@ -7,7 +7,11 @@
 
 ## Finalists
 
-### 1. {idea title}
+> **Quality bar:** {count} idea(s) cleared the admission bar (`Fit ≥ 6`, `Impact ≥ 6`, composite in the leading tier, survived Phase 5). The count is emergent — not a fixed target.{ Cap applied: `--n {k}`. | No `--n` cap — every idea that cleared the bar is shown.}
+
+### Lead finalists
+
+#### 1. {idea title}
 
 {2–3 sentence mechanism.}
 
@@ -18,13 +22,19 @@
 - **First concrete step:** {one paragraph — first real step, core mechanism, riskiest assumption.}
 - **Origin:** {burst {n} | evolution round {n} crossover of "{parent A}" × "{parent B}"}
 
-### 2. {idea title}
+#### 2. {idea title}
 
-{same structure}
+{same structure — repeat for every lead finalist; the number of entries follows the bar, not a fixed 3}
+
+### Also cleared the bar
+
+{Only present when > 5 ideas cleared the bar. Same per-idea structure as a lead finalist, but the compact table only. These are full finalists — the split from the lead list is readability, not quality.}
+
+- **{idea title}** — {composite}, {one-line mechanism}. {First concrete step in one sentence.}
 
 ### Wildcard — {idea title}
 
-{Highest-novelty pick, carried per the novelty-protection rule even if its composite lost.}
+{Highest-novelty pick, carried per the novelty-protection rule even if its composite lost. Note whether it also cleared the admission bar on its own.}
 
 {same structure}
 
@@ -38,9 +48,18 @@
 | ------------------- | ----- | -------------------------- |
 | {approach family}   | {n}   | {idea title}               |
 
-## Discarded but notable
+## Ideas worth revisiting
 
-- **{idea title}** — {one line on why it lost, and what would revive it.}
+The strongest ideas that did **not** clear the bar this run — kept here because a near-miss is often the most inspiring input for the next round or a shifted context.
+List up to 5, highest-potential first. For each, name the *one thing* holding it back and the concrete change that would flip it into a finalist.
+
+| Idea | Standout axis | Why it missed the bar | What would flip it |
+| ----- | -------------- | ---------------------- | ------------------- |
+| {title} | {e.g. Novelty 9/10 — highest of the non-finalists} | {the single blocking axis or gate, e.g. "Feasibility 3 — needs a capability we don't have yet"} | {the concrete unlock: a dependency shipping, a wider framing, more time, pairing with finalist X} |
+
+- **Highest-novelty near-miss:** {title} — {why it is exciting despite missing the bar, and the smallest experiment that would de-risk it}.
+- **Best cross-pollination candidate:** {title} — {which finalist it could merge with, and what the hybrid would gain}.
+- **Revisit trigger:** {the specific future condition — a launch, a constraint lifting, a budget change — under which this bench becomes worth a fresh run}.
 
 ## Run stats
 
@@ -48,6 +67,7 @@
 | -------------------------------- | ------------------------------------------ |
 | Bursts                           | {n}                                        |
 | Raw / unique ideas               | {n} / {n}                                  |
+| Finalists (cleared bar) / pool   | {n} / {n} ({emergent — `--n` cap: none | {k}}) |
 | Non-duplicate yield per burst    | {b1: n%}, {b2: n%}{, …}                    |
 | Evolution rounds                 | {n} (stopped: {round cap | flat scores | duplicate variants}) |
 | Top composite trajectory         | {r0: n.n} → {r1: n.n}{ → …}                |


### PR DESCRIPTION
The finalist list was capped at a fixed `--n` (default 3), so a rich pool
had deserving ideas silently dropped and a thin pool got padded. Replace
the fixed top-N with a quality-gated admission bar and let the count be
emergent:

- On-target floor (Fit >= 6, Impact >= 6), leading-tier composite
  (>= C* - 1.0 and >= 7.0 absolute), and Phase 5 survival.
- `--n` demoted to an optional cap that only narrows, never manufactures.
- Novelty wildcard and deep-mode 3-judge panel preserved; a niche's 3rd
  idea drops to the bench instead of being discarded.
- Readability tier ("Also cleared the bar") when > 5 admit, honest floor
  of 1 when none do.

Enrich the report's not-picked insights: rename "Discarded but notable" to
"Ideas worth revisiting" with a Standout axis / Why it missed / What would
flip it table, plus near-miss, cross-pollination, and revisit-trigger
callouts. Surface the emergent Finalists/pool count in run stats.

Propagate across SKILL.md (flag, cost line, principle, anti-patterns, DoD,
Phase 6 gate), divergence stopping rule, research defaults table + §3.2
consequence, and the diagnostic surface. Bump 1.0.1 -> 1.1.0.

Validated: /create-skill review PASS, L1 145/145.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L2ANTS1GjqdZwiS1JehaJS