### PR TITLE
pr-reviewer: link applied LoreKit memories in the review report

### DIFF
--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -95,7 +95,7 @@ rule once at the step that owns it.
 - `agents/shared/rules/verification-receipt.md` — executed proof for behavioral claims; drop on null result (Step 2.6b).
 - `agents/shared/rules/per-comment-confidence.md` — `Skill("confidence", "code")` ≥ profile threshold (Step 2.7).
 - `agents/shared/rules/outcome-learning.md` — resolution-rate feedback loop; runs post-merge via `/review-outcomes`. Promotion reads from the `review-outcomes` candidate bus — the bus is NEVER loaded per-review.
-- `agents/shared/rules/comment-relevance-memory.md` — per-repo LoreKit memories of which comment patterns were relevant (fixed) vs. not-relevant (won't fix / ignored). Read before Step 1.1; written post-merge via `outcome-learning.md` gh-api signals.
+- `agents/shared/rules/comment-relevance-memory.md` — per-repo LoreKit memories of which comment patterns were relevant (fixed) vs. not-relevant (won't fix / ignored). Read before Step 1.1; written post-merge via `outcome-learning.md` gh-api signals. Memories that actually influence the review are rendered as pressable LoreKit links in the review-body diagnostics (Step 4).
 - `agents/shared/rules/comment-shape.md` — ≤ 240 chars, ≤ 2 sentences, no headings or bullets.
 - `agents/shared/rules/conventional-comments.md` — prefix table + decorations.
 - `agents/pr-reviewer/rules/line-validity.md` — RIGHT-side hunk-bounds pre-flight.
@@ -245,6 +245,9 @@ memory.list { scope: "global",               tags: ["loop::reviewer-comment-rele
 
 Derive `{owner}/{repo}` from `RESOLVED_REPO` (set in Step 0), lowercased.
 Merge both lists per tag (`repo::` wins on key collision). Skip expired entries.
+Retain each loaded memory's `url` (LoreKit permalink) alongside its `fingerprint`,
+`relevance`, and `seen_count` — Step 2.2 links every memory that influences the review
+(`agents/shared/rules/comment-relevance-memory.md § Linking applied memories in the report`).
 Announce: `Relevance memories active: <D> suppressions, <P> promotions (repo:<owner>/<repo>).`
 
 ### 1.1 Fetch PR data in parallel
@@ -540,6 +543,11 @@ See `agents/shared/rules/comment-relevance-memory.md § Read`. Apply loaded memo
 - `not-relevant` with `seen_count 1–2` → **DOWNGRADE** to `nitpick`.
 - `relevant` with `seen_count >= 2` → **PROMOTE** (terminal output only).
 
+For every memory that fires (drop / downgrade / promote), append a record —
+`{ fingerprint, action, seen_count, url }` — to `APPLIED_MEMORIES[]` per
+`comment-relevance-memory.md § Linking applied memories in the report`. These become
+the pressable links in the Step 4 review-body diagnostics (`MEMORIES_APPLIED_SECTION`).
+
 Log all applied memories in the Quality Gate summary.
 
 ### 2.3 Filter suppression
@@ -832,6 +840,8 @@ ADDITIONAL_FINDINGS_SECTION
 **Quality Gate:** produced <P>, carried forward <CF>, relevance-memory drops <RM>, dedupe drops <D>,
 grounding drops <G>, confidence drops <C>, shape drops <S>, cleared <CL>, deferred over inline cap <DEF>, posted inline <F>.
 
+MEMORIES_APPLIED_SECTION
+
 **Optimality review (2.4c):** <ran | skipped (reason)> — <UN> unit(s) judged, <UO> optimal, <OP> proposal(s), <OW> withheld.
 
 **Skipped files:** <list or "none">
@@ -868,6 +878,8 @@ ADDITIONAL_FINDINGS_SECTION
 
 **Quality Gate:** produced <P>, carried forward <CF>, relevance-memory drops <RM>, dedupe drops <D>,
 grounding drops <G>, confidence drops <C>, shape drops <S>, cleared <CL>, deferred over inline cap <DEF>, posted inline <F>.
+
+MEMORIES_APPLIED_SECTION
 
 **Optimality review (2.4c):** <ran | skipped (reason)> — <UN> unit(s) judged, <UO> optimal, <OP> proposal(s), <OW> withheld.
 
@@ -937,11 +949,32 @@ One line per deferred finding: path:line, prefix, the one-line body, and the con
 Sort by prefix priority, then descending confidence. This section is the reason a placement cap
 is allowed to exist — never drop a cleared finding instead of listing it here.
 
+`MEMORIES_APPLIED_SECTION` lists the LoreKit comment-relevance memories that actually influenced
+this review — every entry in `APPLIED_MEMORIES[]` (Step 2.2) — each rendered as a pressable link
+so the reader can open the exact memory in LoreKit and see why a finding was dropped, downgraded,
+or promoted. This is the slot inside the `Review diagnostics` block, directly under the numeric
+`Quality Gate` line. Omit the placeholder entirely when `APPLIED_MEMORIES` is empty — a run that
+read memories but applied none shows only the numeric counts. Otherwise substitute, one bullet per
+applied memory:
+
+```
+**Memories applied:** (<N> LoreKit memories influenced this review)
+
+- [`suggestion:null-check-guaranteed-upstream`](<url>) — dropped, seen 4×
+- [`nitpick:map-vs-record-preference`](<url>) — downgraded, seen 2×
+- [`issue:missing-abort-signal`](<url>) — promoted, seen 3×
+```
+
+Resolve each `<url>` per `comment-relevance-memory.md § Linking applied memories in the report`:
+the memory's `url` field first, else a link constructed from the LoreKit workspace base, else a
+plain-text `` `<scope> · <key>` `` identifier when no URL exists — never a fabricated URL. The
+bullet count MUST equal the number of memories that fired this run (drops + downgrades + promotes).
+
 Rules for table cells:
 - Gate 2 (CI) is excluded from the table — GitHub's checks section shows it.
 - Details column: plain text only, max 120 chars per cell. Truncate; the full finding lives in the inline comment.
 - On PASS, omit the Details column (two-column table).
-- Never add rows, sections, or prose outside the template above (except the three `<details>` blocks — diagnostics, `Optimality review`, and `Additional findings` — and the `PARTIAL_REVIEW_BANNER` line, which is a slot in the template, not added prose).
+- Never add rows, sections, or prose outside the template above (except the three `<details>` blocks — diagnostics, `Optimality review`, and `Additional findings` — the `MEMORIES_APPLIED_SECTION` slot inside the diagnostics block, and the `PARTIAL_REVIEW_BANNER` line — all of which are slots in the template, not added prose).
 - Praise findings are dropped entirely — do not add them to the table, inline comments, or body prose.
 
 ### INLINE_COMMENTS_JSON format

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -245,8 +245,9 @@ memory.list { scope: "global",               tags: ["loop::reviewer-comment-rele
 
 Derive `{owner}/{repo}` from `RESOLVED_REPO` (set in Step 0), lowercased.
 Merge both lists per tag (`repo::` wins on key collision). Skip expired entries.
-Retain each loaded memory's `url` (LoreKit permalink) alongside its `fingerprint`,
-`relevance`, and `seen_count` — Step 2.2 links every memory that influences the review
+Retain each loaded memory's `scope` + `key` (its LoreKit coordinates) alongside its
+`fingerprint`, `relevance`, and `seen_count` — Step 2.2 builds a dashboard deep link from
+`scope` + `key` for every memory that influences the review
 (`agents/shared/rules/comment-relevance-memory.md § Linking applied memories in the report`).
 Announce: `Relevance memories active: <D> suppressions, <P> promotions (repo:<owner>/<repo>).`
 
@@ -544,9 +545,9 @@ See `agents/shared/rules/comment-relevance-memory.md § Read`. Apply loaded memo
 - `relevant` with `seen_count >= 2` → **PROMOTE** (terminal output only).
 
 For every memory that fires (drop / downgrade / promote), append a record —
-`{ fingerprint, action, seen_count, url }` — to `APPLIED_MEMORIES[]` per
-`comment-relevance-memory.md § Linking applied memories in the report`. These become
-the pressable links in the Step 4 review-body diagnostics (`MEMORIES_APPLIED_SECTION`).
+`{ fingerprint, action, seen_count, scope, key }` — to `APPLIED_MEMORIES[]` per
+`comment-relevance-memory.md § Linking applied memories in the report`. Its `scope` + `key`
+build the pressable deep link in the Step 4 review-body diagnostics (`MEMORIES_APPLIED_SECTION`).
 
 Log all applied memories in the Quality Gate summary.
 
@@ -965,10 +966,12 @@ applied memory:
 - [`issue:missing-abort-signal`](<url>) — promoted, seen 3×
 ```
 
-Resolve each `<url>` per `comment-relevance-memory.md § Linking applied memories in the report`:
-the memory's `url` field first, else a link constructed from the LoreKit workspace base, else a
-plain-text `` `<scope> · <key>` `` identifier when no URL exists — never a fabricated URL. The
-bullet count MUST equal the number of memories that fired this run (drops + downgrades + promotes).
+Build each `<url>` from the memory's `scope` + `key` per
+`comment-relevance-memory.md § Linking applied memories in the report`: the `lorekit link
+"<scope>" "<key>"` CLI when available, else the documented `{base}/lore?scope=…&lesson=…`
+construction (`base` = `LOREKIT_APP_URL` or `https://lorekit.io`), else a plain-text
+`` `<scope> · <key>` `` identifier — never a fabricated URL. The bullet count MUST equal the
+number of memories that fired this run (drops + downgrades + promotes).
 
 Rules for table cells:
 - Gate 2 (CI) is excluded from the table — GitHub's checks section shows it.

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -117,10 +117,10 @@ memory.list { scope: "global",               tags: ["loop::reviewer-comment-rele
 Merge both lists (`repo::` wins on key collision).
 Skip any entry whose `expires` is in the past.
 
-**Keep the link.** Every memory object the read tools return carries a canonical
-LoreKit permalink in its `url` field. Retain that `url` alongside each entry's
-`fingerprint`, `relevance`, and `seen_count` — the report renders it as a pressable
-link for every memory that actually influences the review (see
+**Keep the coordinates.** Retain each entry's `scope` and `key` (the LoreKit
+memory coordinates) alongside its `fingerprint`, `relevance`, and `seen_count` —
+the report builds a pressable dashboard deep link from `scope` + `key` for every
+memory that actually influences the review (see
 [Linking applied memories in the report](#linking-applied-memories-in-the-report)).
 
 ### How to apply
@@ -152,7 +152,7 @@ DOWNGRADE, or PROMOTE against a real finding this run, append a record to an
 `APPLIED_MEMORIES[]` list:
 
 ```json
-{ "fingerprint": "<category>:<claim-gist>", "action": "drop | downgrade | promote", "seen_count": <n>, "url": "<permalink from read>" }
+{ "fingerprint": "<category>:<claim-gist>", "action": "drop | downgrade | promote", "seen_count": <n>, "scope": "<lorekit scope>", "key": "<lorekit key>" }
 ```
 
 A memory that was loaded but matched nothing is **not** recorded — it did not
@@ -190,20 +190,35 @@ memory-link section at all; the numeric Quality Gate counts stand alone.
 
 ### Resolving each link
 
-For each entry in `APPLIED_MEMORIES[]`, resolve its URL in this order:
+A LoreKit memory's dashboard deep link opens its detail sheet in the `/lore`
+Explorer. It is built from the memory's `scope` + `key` per LoreKit's documented
+[deep-link contract](https://lorekit.io/docs/deep-links). For each entry in
+`APPLIED_MEMORIES[]`, resolve its URL in this order:
 
-1. **Primary — the `url` field.** Use the `url` (or `permalink` / `web_url`) the
-   read tool returned verbatim. This is the canonical, pressable LoreKit permalink;
-   no construction needed.
-2. **Fallback — construct from the workspace base.** If the read result carried no
-   link field, resolve the LoreKit web base — the `LOREKIT_APP_URL` environment
-   variable, else the `web` base printed by `lorekit doctor` — and construct
-   `{base}/memories/{scope}/{key}`, replacing each `::` in the scope with `/` and
-   URL-encoding the key. Construct only when a base is actually known.
-3. **No URL available — plain text.** If neither a link field nor a base can be
-   resolved (e.g. a local `.lorekit/` workspace with no web UI), render the memory
-   as plain text `` `<scope> · <key>` `` with no hyperlink. **Never fabricate a
-   URL** — an unresolvable link is shown as text, not guessed.
+1. **Preferred — let the LoreKit CLI build it.** When the `lorekit` CLI is on
+   `PATH`, run `lorekit link "<scope>" "<key>"` (alias `url`). It prints the exact
+   URL to stdout — nothing else — and honours `LOREKIT_APP_URL` / `--base` for
+   self-hosted dashboards, so encoding is never hand-rolled:
+
+   ```bash
+   lorekit link "repo::acme/widget" "reviewer-comment-relevance::suggestion:null-check-guaranteed-upstream"
+   ```
+
+2. **Fallback — construct the URL directly.** When the CLI is unavailable,
+   build `{base}/lore?scope=<enc(scope)>&lesson=<enc({scope,key})>`, where
+   `enc(v) = encodeURIComponent(JSON.stringify(v))` (the exact inverse of the
+   dashboard's `useUrlState` read — a raw `?scope=global` silently means "all
+   scopes"), and `base` is the `LOREKIT_APP_URL` environment variable, else
+   `https://lorekit.io`. For scope `global`, key
+   `reviewer-comment-relevance::nitpick:map-vs-record-preference` this yields:
+
+   ```text
+   https://lorekit.io/lore?scope=%22global%22&lesson=%7B%22scope%22%3A%22global%22%2C%22key%22%3A%22reviewer-comment-relevance%3A%3Anitpick%3Amap-vs-record-preference%22%7D
+   ```
+
+**Never fabricate a URL** — both paths derive it deterministically from the
+memory's real `scope` + `key`; if neither `scope` nor `key` is known, render the
+memory as plain text `` `<scope> · <key>` `` with no hyperlink.
 
 ### Render shape
 

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -117,6 +117,12 @@ memory.list { scope: "global",               tags: ["loop::reviewer-comment-rele
 Merge both lists (`repo::` wins on key collision).
 Skip any entry whose `expires` is in the past.
 
+**Keep the link.** Every memory object the read tools return carries a canonical
+LoreKit permalink in its `url` field. Retain that `url` alongside each entry's
+`fingerprint`, `relevance`, and `seen_count` — the report renders it as a pressable
+link for every memory that actually influences the review (see
+[Linking applied memories in the report](#linking-applied-memories-in-the-report)).
+
 ### How to apply
 
 For each loaded memory with `relevance: not-relevant` or `relevance: weak-not-relevant`:
@@ -141,6 +147,18 @@ For each loaded memory with `relevance: relevant` and `seen_count >= 2`:
   `suggestion`; add the decoration `(pattern reliably resolved, seen <n>×)` in
   the terminal output only — never posted.
 
+**Record every memory that fires.** Whenever a loaded memory produces a DROP,
+DOWNGRADE, or PROMOTE against a real finding this run, append a record to an
+`APPLIED_MEMORIES[]` list:
+
+```json
+{ "fingerprint": "<category>:<claim-gist>", "action": "drop | downgrade | promote", "seen_count": <n>, "url": "<permalink from read>" }
+```
+
+A memory that was loaded but matched nothing is **not** recorded — it did not
+influence the review. `APPLIED_MEMORIES[]` is what the report links (see
+[Linking applied memories in the report](#linking-applied-memories-in-the-report)).
+
 Log all applied memories in a `Relevance memory` row in the Quality Gate summary:
 
 ```
@@ -154,6 +172,58 @@ Announce active suppression memories in one line before the review pipeline runs
 Relevance memories active: 3 suppressions, 1 promotion (repo:mthines/console)
 ```
 So the user knows the pipeline has been influenced.
+
+---
+
+## Linking applied memories in the report
+
+When a loaded memory actually **influences** the review — it produced a DROP,
+DOWNGRADE, or PROMOTE against a real finding this run — the report MUST make it
+pressable so the reader can open the exact memory in LoreKit and see why the
+pipeline was biased. This turns "relevance-memory drops: 3" from an opaque count
+into three links the user can click through and audit.
+
+**Only applied memories are linked.** Use `APPLIED_MEMORIES[]` from the apply step.
+A memory that was loaded but fired against nothing is never linked — it did not
+influence the review. If `APPLIED_MEMORIES[]` is empty, the report shows no
+memory-link section at all; the numeric Quality Gate counts stand alone.
+
+### Resolving each link
+
+For each entry in `APPLIED_MEMORIES[]`, resolve its URL in this order:
+
+1. **Primary — the `url` field.** Use the `url` (or `permalink` / `web_url`) the
+   read tool returned verbatim. This is the canonical, pressable LoreKit permalink;
+   no construction needed.
+2. **Fallback — construct from the workspace base.** If the read result carried no
+   link field, resolve the LoreKit web base — the `LOREKIT_APP_URL` environment
+   variable, else the `web` base printed by `lorekit doctor` — and construct
+   `{base}/memories/{scope}/{key}`, replacing each `::` in the scope with `/` and
+   URL-encoding the key. Construct only when a base is actually known.
+3. **No URL available — plain text.** If neither a link field nor a base can be
+   resolved (e.g. a local `.lorekit/` workspace with no web UI), render the memory
+   as plain text `` `<scope> · <key>` `` with no hyperlink. **Never fabricate a
+   URL** — an unresolvable link is shown as text, not guessed.
+
+### Render shape
+
+One bullet per applied memory, each a Markdown link whose text names the
+`fingerprint`, the action taken, and the recurrence count — so multiple memories
+render as multiple independently-pressable links:
+
+```markdown
+**Memories applied:** (<N> LoreKit memories influenced this review)
+
+- [`suggestion:null-check-guaranteed-upstream`](https://…) — dropped, seen 4×
+- [`nitpick:map-vs-record-preference`](https://…) — downgraded, seen 2×
+- [`issue:missing-abort-signal`](https://…) — promoted, seen 3×
+```
+
+The bullet count MUST equal the number of memories that fired this run (drops +
+downgrades + promotes). A mismatch means an applied memory was dropped from the
+list instead of linked. Which report surface renders this block is the consuming
+agent's contract — `pr-reviewer` renders it inside the posted review body's
+`Review diagnostics` block (Step 4).
 
 ---
 


### PR DESCRIPTION
## What & why

When the `pr-reviewer` agent reads comment-relevance memories and one **actually influences** the review (a drop, downgrade, or promote), the posted review now lists that memory as a **pressable link** under the **Review diagnostics** section — so you can click straight through to the exact memory in LoreKit and audit why a finding was biased. Multiple applied memories render as multiple independent links; a run that read memories but applied none shows only the numeric counts.

## Changes

**`agents/shared/rules/comment-relevance-memory.md`** (shared single source of truth)
- Read step retains each memory's LoreKit `scope` + `key`.
- Apply step builds an `APPLIED_MEMORIES[]` list of only the memories that fire (read *and* used).
- New **"Linking applied memories in the report"** section defines link resolution and the bullet render shape.

**`agents/pr-reviewer.md`**
- Step 1.0 keeps the coordinates, Step 2.2 populates `APPLIED_MEMORIES[]`, and a new `MEMORIES_APPLIED_SECTION` slot renders inside the Step 4 review-body diagnostics (PASS + FAIL), omitted when nothing fired.

## Deep-link format

Links use LoreKit's real, documented deep-link contract (now published at `lorekit.io/docs/deep-links` via [mthines/lorekit#321](https://github.com/mthines/lorekit/pull/321)): a memory's detail sheet opens at `{base}/lore?scope=<enc>&lesson=<enc>` where `enc = encodeURIComponent(JSON.stringify(value))`. The agent prefers the `lorekit link "<scope>" "<key>"` CLI (guarantees correct encoding, honours `LOREKIT_APP_URL` / `--base`), falls back to the documented URL construction, else plain text — never a fabricated URL.

## Tests

L1 deterministic contract eval: **145/145** pass (link/anchor integrity, forbidden-phrase, and contract guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRtKboZBFfq3mrKWymgYbm)_