### PR TITLE
pr-reviewer: memories used/read in diagnostics + ?memoryId= deep links

### DIFF
--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -270,9 +270,9 @@ memory.list { scope: "global",               tags: ["loop::reviewer-comment-rele
 
 Derive `{owner}/{repo}` from `RESOLVED_REPO` (set in Step 0), lowercased.
 Merge both lists per tag (`repo::` wins on key collision). Skip expired entries.
-Retain each loaded memory's `scope` + `key` (its LoreKit coordinates) alongside its
-`fingerprint`, `relevance`, and `seen_count` — Step 2.2 builds a dashboard deep link from
-`scope` + `key` for every memory that influences the review
+Retain each loaded memory's LoreKit `id`, `scope`, and `key` alongside its
+`fingerprint`, `relevance`, and `seen_count` — Step 2.2 builds a `?memoryId=` deep link from
+the `id` for every memory that influences the review
 (`agents/shared/rules/comment-relevance-memory.md § Linking applied memories in the report`).
 Set `MEMORIES_READ_COUNT` = the number of `reviewer-comment-relevance` memories retained after
 this merge/dedup (0 when connected but none matched), and `LOREKIT_CONNECTED` = whether the
@@ -583,9 +583,9 @@ See `agents/shared/rules/comment-relevance-memory.md § Read`. Apply loaded memo
 - `relevant` with `seen_count >= 2` → **PROMOTE** (terminal output only).
 
 For every memory that fires (drop / downgrade / promote), append a record —
-`{ fingerprint, action, seen_count, scope, key }` — to `APPLIED_MEMORIES[]` per
-`comment-relevance-memory.md § Linking applied memories in the report`. Its `scope` + `key`
-build the pressable deep link in the Step 4 review-body diagnostics (`MEMORIES_SECTION`).
+`{ id, fingerprint, action, seen_count, scope, key }` — to `APPLIED_MEMORIES[]` per
+`comment-relevance-memory.md § Linking applied memories in the report`. Its `id`
+builds the pressable `?memoryId=` deep link in the Step 4 review-body diagnostics (`MEMORIES_SECTION`).
 
 Log all applied memories in the Quality Gate summary.
 
@@ -1093,10 +1093,10 @@ were actually **used** — not only when something fired.
 `|APPLIED_MEMORIES|`, how many actually fired (drops + downgrades + promotes). Read is always ≥
 used — a run can read memories and apply none. The bullet count MUST equal `MEMORIES_USED_COUNT`.
 
-Build each `<url>` from the memory's `scope` + `key` per
-`comment-relevance-memory.md § Linking applied memories in the report`: the `lorekit link
-"<scope>" "<key>"` CLI when available, else the documented `{base}/lore?scope=…&lesson=…`
-construction (`base` = `LOREKIT_APP_URL` or `https://lorekit.io`), else a plain-text
+Build each `<url>` as `{base}/lore?memoryId=<id>` from the memory's retained `id`
+(`base` = `LOREKIT_APP_URL` or `https://lorekit.io`), per
+`comment-relevance-memory.md § Linking applied memories in the report`. When no `id` is
+available, fall back to the `lorekit link "<scope>" "<key>"` CLI, else a plain-text
 `` `<scope> · <key>` `` identifier — never a fabricated URL.
 
 `MEMORIES_USED_SUFFIX` is the tag appended to the `Review diagnostics` `<summary>` title so the

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -275,8 +275,10 @@ Retain each loaded memory's `scope` + `key` (its LoreKit coordinates) alongside 
 `scope` + `key` for every memory that influences the review
 (`agents/shared/rules/comment-relevance-memory.md § Linking applied memories in the report`).
 Set `MEMORIES_READ_COUNT` = the number of `reviewer-comment-relevance` memories retained after
-this merge/dedup (0 when `memory.*` is not connected or none matched). It surfaces in the Step 4
-`Review diagnostics` block title — see *Review body format*.
+this merge/dedup (0 when connected but none matched), and `LOREKIT_CONNECTED` = whether the
+`memory.*` backend was reachable at all this run. Both feed the Step 4 `Review diagnostics`
+**Memories** line; the collapsed title headlines the **used** count (`MEMORIES_USED_COUNT`,
+computed at Step 2.2) — see *Review body format*.
 Announce: `Relevance memories active: <D> suppressions, <P> promotions (repo:<owner>/<repo>).`
 
 ### 1.1 Fetch PR data in parallel
@@ -583,7 +585,7 @@ See `agents/shared/rules/comment-relevance-memory.md § Read`. Apply loaded memo
 For every memory that fires (drop / downgrade / promote), append a record —
 `{ fingerprint, action, seen_count, scope, key }` — to `APPLIED_MEMORIES[]` per
 `comment-relevance-memory.md § Linking applied memories in the report`. Its `scope` + `key`
-build the pressable deep link in the Step 4 review-body diagnostics (`MEMORIES_APPLIED_SECTION`).
+build the pressable deep link in the Step 4 review-body diagnostics (`MEMORIES_SECTION`).
 
 Log all applied memories in the Quality Gate summary.
 
@@ -900,19 +902,21 @@ OPTIMALITY_SECTION
 ADDITIONAL_FINDINGS_SECTION
 
 <details>
-<summary>Review diagnosticsMEMORIES_READ_SUFFIX</summary>
+<summary>Review diagnosticsMEMORIES_USED_SUFFIX</summary>
 
-**Run mode:** <full | incremental | incremental-quick> — <DELTA_LINES> lines in delta (or "no code changes" for zero-delta)
-**Integrations checked:** <list of name + version + spec URL, or "not activated", or "skipped (incremental-quick)">
+**Run mode** — <full | incremental | incremental-quick> · <DELTA_LINES> lines in delta (or "no code changes" for zero-delta)
 
-**Quality Gate:** produced <P>, carried forward <CF>, relevance-memory drops <RM>, dedupe drops <D>,
-grounding drops <G>, confidence drops <C>, shape drops <S>, cleared <CL>, deferred over inline cap <DEF>, posted inline <F>.
+MEMORIES_SECTION
 
-MEMORIES_APPLIED_SECTION
+**Quality** — produced <P> → posted inline <F> · cleared <CL> · carried forward <CF> · deferred <DEF>
 
-**Optimality review (2.4c):** <ran | skipped (reason)> — <UN> unit(s) judged, <UO> optimal, <OP> proposal(s), <OW> withheld.
+- dropped: relevance <RM> · dedupe <D> · grounding <G> · confidence <C> · shape <S>
 
-**Skipped files:** <list or "none">
+**Integrations** — <list of name + version + spec URL, or "not activated", or "skipped (incremental-quick)">
+
+**Optimality (2.4c)** — <ran | skipped (reason)> · <UN> judged · <UO> optimal · <OP> proposal(s) · <OW> withheld
+
+**Skipped files** — <list or "none">
 
 <sup>Reviewed by the [`pr-reviewer`](https://github.com/mthines/agent-skills/blob/main/agents/pr-reviewer.md) agent — open it to read how these gates and findings are produced.</sup>
 
@@ -941,19 +945,21 @@ OPTIMALITY_SECTION
 ADDITIONAL_FINDINGS_SECTION
 
 <details>
-<summary>Review diagnosticsMEMORIES_READ_SUFFIX</summary>
+<summary>Review diagnosticsMEMORIES_USED_SUFFIX</summary>
 
-**Run mode:** <full | incremental | incremental-quick> — <DELTA_LINES> lines in delta (or "no code changes" for zero-delta)
-**Integrations checked:** <list of name + version + spec URL, or "not activated", or "skipped (incremental-quick)">
+**Run mode** — <full | incremental | incremental-quick> · <DELTA_LINES> lines in delta (or "no code changes" for zero-delta)
 
-**Quality Gate:** produced <P>, carried forward <CF>, relevance-memory drops <RM>, dedupe drops <D>,
-grounding drops <G>, confidence drops <C>, shape drops <S>, cleared <CL>, deferred over inline cap <DEF>, posted inline <F>.
+MEMORIES_SECTION
 
-MEMORIES_APPLIED_SECTION
+**Quality** — produced <P> → posted inline <F> · cleared <CL> · carried forward <CF> · deferred <DEF>
 
-**Optimality review (2.4c):** <ran | skipped (reason)> — <UN> unit(s) judged, <UO> optimal, <OP> proposal(s), <OW> withheld.
+- dropped: relevance <RM> · dedupe <D> · grounding <G> · confidence <C> · shape <S>
 
-**Skipped files:** <list or "none">
+**Integrations** — <list of name + version + spec URL, or "not activated", or "skipped (incremental-quick)">
+
+**Optimality (2.4c)** — <ran | skipped (reason)> · <UN> judged · <UO> optimal · <OP> proposal(s) · <OW> withheld
+
+**Skipped files** — <list or "none">
 
 <sup>Reviewed by the [`pr-reviewer`](https://github.com/mthines/agent-skills/blob/main/agents/pr-reviewer.md) agent — open it to read how these gates and findings are produced.</sup>
 
@@ -982,19 +988,21 @@ OPTIMALITY_SECTION
 ADDITIONAL_FINDINGS_SECTION
 
 <details>
-<summary>Review diagnosticsMEMORIES_READ_SUFFIX</summary>
+<summary>Review diagnosticsMEMORIES_USED_SUFFIX</summary>
 
-**Run mode:** <full | incremental | incremental-quick> — <DELTA_LINES> lines in delta (or "no code changes" for zero-delta)
-**Integrations checked:** <list of name + version + spec URL, or "not activated", or "skipped (incremental-quick)">
+**Run mode** — <full | incremental | incremental-quick> · <DELTA_LINES> lines in delta (or "no code changes" for zero-delta)
 
-**Quality Gate:** produced <P>, carried forward <CF>, relevance-memory drops <RM>, dedupe drops <D>,
-grounding drops <G>, confidence drops <C>, shape drops <S>, cleared <CL>, deferred over inline cap <DEF>, posted inline <F>.
+MEMORIES_SECTION
 
-MEMORIES_APPLIED_SECTION
+**Quality** — produced <P> → posted inline <F> · cleared <CL> · carried forward <CF> · deferred <DEF>
 
-**Optimality review (2.4c):** <ran | skipped (reason)> — <UN> unit(s) judged, <UO> optimal, <OP> proposal(s), <OW> withheld.
+- dropped: relevance <RM> · dedupe <D> · grounding <G> · confidence <C> · shape <S>
 
-**Skipped files:** <list or "none">
+**Integrations** — <list of name + version + spec URL, or "not activated", or "skipped (incremental-quick)">
+
+**Optimality (2.4c)** — <ran | skipped (reason)> · <UN> judged · <UO> optimal · <OP> proposal(s) · <OW> withheld
+
+**Skipped files** — <list or "none">
 
 <sup>Reviewed by the [`pr-reviewer`](https://github.com/mthines/agent-skills/blob/main/agents/pr-reviewer.md) agent — open it to read how these gates and findings are produced.</sup>
 
@@ -1062,44 +1070,48 @@ One line per deferred finding: path:line, prefix, the one-line body, and the con
 Sort by prefix priority, then descending confidence. This section is the reason a placement cap
 is allowed to exist — never drop a cleared finding instead of listing it here.
 
-`MEMORIES_APPLIED_SECTION` lists the LoreKit comment-relevance memories that actually influenced
-this review — every entry in `APPLIED_MEMORIES[]` (Step 2.2) — each rendered as a pressable link
-so the reader can open the exact memory in LoreKit and see why a finding was dropped, downgraded,
-or promoted. This is the slot inside the `Review diagnostics` block, directly under the numeric
-`Quality Gate` line. Omit the placeholder entirely when `APPLIED_MEMORIES` is empty — a run that
-read memories but applied none shows only the numeric counts. Otherwise substitute, one bullet per
-applied memory:
+`MEMORIES_SECTION` is the persistent memory block inside `Review diagnostics` (replacing the old
+applied-only list). It **always renders when the LoreKit backend was reachable this run**
+(`LOREKIT_CONNECTED`), so a reader can always see both how many memories were **read** and how many
+were actually **used** — not only when something fired.
 
-```
-**Memories applied:** (<N> LoreKit memories influenced this review)
+- **Connected** — a header line, followed (only when `MEMORIES_USED_COUNT > 0`) by one bullet per
+  entry in `APPLIED_MEMORIES[]` (Step 2.2), each a pressable LoreKit link so the reader can open the
+  exact memory and see why a finding was dropped, downgraded, or promoted:
 
-- [`suggestion:null-check-guaranteed-upstream`](<url>) — dropped, seen 4×
-- [`nitpick:map-vs-record-preference`](<url>) — downgraded, seen 2×
-- [`issue:missing-abort-signal`](<url>) — promoted, seen 3×
-```
+  ```
+  **Memories** — <MEMORIES_READ_COUNT> read · <MEMORIES_USED_COUNT> used
+
+  - [`issue:missing-abort-signal`](<url>) — promoted, seen 3×
+  - [`nitpick:map-vs-record-preference`](<url>) — downgraded, seen 2×
+  ```
+
+  When `MEMORIES_USED_COUNT` is 0, render only the header line (`… read · 0 used`), no bullets.
+- **Not connected** (`memory.*` unreachable) — render exactly `**Memories** — not connected`, no bullets.
+
+`MEMORIES_READ_COUNT` (Step 1.0) is how many memories were loaded; `MEMORIES_USED_COUNT` =
+`|APPLIED_MEMORIES|`, how many actually fired (drops + downgrades + promotes). Read is always ≥
+used — a run can read memories and apply none. The bullet count MUST equal `MEMORIES_USED_COUNT`.
 
 Build each `<url>` from the memory's `scope` + `key` per
 `comment-relevance-memory.md § Linking applied memories in the report`: the `lorekit link
 "<scope>" "<key>"` CLI when available, else the documented `{base}/lore?scope=…&lesson=…`
 construction (`base` = `LOREKIT_APP_URL` or `https://lorekit.io`), else a plain-text
-`` `<scope> · <key>` `` identifier — never a fabricated URL. The bullet count MUST equal the
-number of memories that fired this run (drops + downgrades + promotes).
+`` `<scope> · <key>` `` identifier — never a fabricated URL.
 
-`MEMORIES_READ_SUFFIX` is the read-count tag appended to the `Review diagnostics` `<summary>`
-title, so the reader can tell from the collapsed label whether memory informed the review:
-- When `MEMORIES_READ_COUNT > 0` (Step 1.0), substitute ` (<MEMORIES_READ_COUNT> memories read)` —
-  e.g. `Review diagnostics (2 memories read)`. Use the singular `memory` when the count is exactly 1.
-- When `MEMORIES_READ_COUNT` is 0, substitute nothing — the title stays the bare `Review diagnostics`.
-
-This is the count of memories **read** (loaded in Step 1.0), which is always ≥ the number
-**applied** shown in `MEMORIES_APPLIED_SECTION`; a run can read memories and apply none.
+`MEMORIES_USED_SUFFIX` is the tag appended to the `Review diagnostics` `<summary>` title so the
+collapsed label headlines how many memories **influenced** the review:
+- **Connected** — substitute ` (<MEMORIES_USED_COUNT> memories used)` — e.g.
+  `Review diagnostics (2 memories used)`. Use the singular `memory` at exactly 1; keep
+  `(0 memories used)` when nothing fired.
+- **Not connected** — substitute nothing; the title stays the bare `Review diagnostics`.
 
 Rules for table cells:
 - Gate 2 (CI) is excluded from the table — GitHub's checks section shows it.
 - Details column: plain text only, max 120 chars per cell. Truncate; the full finding lives in the inline comment.
 - On the all-clear PASS body (every gate ✅), omit the Details column (two-column table). The WARN body (any soft gate ⚠️ — Description vs. code and/or Code review) and the FAIL body keep the three-column table.
 - `WARN_GATE_COUNT` = the number of soft gates showing ⚠️ on a WARN body — Description vs. code and/or Code review, so 1 or 2. Same value in the Step 3 terminal WARN verdict line and the Step 4 body WARN header. It counts gates, not findings, so it stays correct whether the warning is a description mismatch, non-blocking code findings, or both.
-- Never add rows, sections, or prose outside the template above (except the three `<details>` blocks — diagnostics, `Optimality review`, and `Additional findings` — the `MEMORIES_APPLIED_SECTION` slot inside the diagnostics block, and the `PARTIAL_REVIEW_BANNER` line — all of which are slots in the template, not added prose).
+- Never add rows, sections, or prose outside the template above (except the three `<details>` blocks — diagnostics, `Optimality review`, and `Additional findings` — the `MEMORIES_SECTION` slot inside the diagnostics block, and the `PARTIAL_REVIEW_BANNER` line — all of which are slots in the template, not added prose).
 - Praise findings are dropped entirely — do not add them to the table, inline comments, or body prose.
 
 ### INLINE_COMMENTS_JSON format

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -270,9 +270,9 @@ memory.list { scope: "global",               tags: ["loop::reviewer-comment-rele
 
 Derive `{owner}/{repo}` from `RESOLVED_REPO` (set in Step 0), lowercased.
 Merge both lists per tag (`repo::` wins on key collision). Skip expired entries.
-Retain each loaded memory's LoreKit `id`, `scope`, and `key` alongside its
-`fingerprint`, `relevance`, and `seen_count` — Step 2.2 builds a `?memoryId=` deep link from
-the `id` for every memory that influences the review
+Retain each loaded memory's LoreKit `scope` and `key` alongside its
+`fingerprint`, `relevance`, and `seen_count` — Step 2.2 builds a deep link from
+`scope` + `key` for every memory that influences the review
 (`agents/shared/rules/comment-relevance-memory.md § Linking applied memories in the report`).
 Set `MEMORIES_READ_COUNT` = the number of `reviewer-comment-relevance` memories retained after
 this merge/dedup (0 when connected but none matched), and `LOREKIT_CONNECTED` = whether the
@@ -583,9 +583,9 @@ See `agents/shared/rules/comment-relevance-memory.md § Read`. Apply loaded memo
 - `relevant` with `seen_count >= 2` → **PROMOTE** (terminal output only).
 
 For every memory that fires (drop / downgrade / promote), append a record —
-`{ id, fingerprint, action, seen_count, scope, key }` — to `APPLIED_MEMORIES[]` per
-`comment-relevance-memory.md § Linking applied memories in the report`. Its `id`
-builds the pressable `?memoryId=` deep link in the Step 4 review-body diagnostics (`MEMORIES_SECTION`).
+`{ fingerprint, action, seen_count, scope, key }` — to `APPLIED_MEMORIES[]` per
+`comment-relevance-memory.md § Linking applied memories in the report`. Its `scope` + `key`
+build the pressable deep link in the Step 4 review-body diagnostics (`MEMORIES_SECTION`).
 
 Log all applied memories in the Quality Gate summary.
 
@@ -1093,11 +1093,12 @@ were actually **used** — not only when something fired.
 `|APPLIED_MEMORIES|`, how many actually fired (drops + downgrades + promotes). Read is always ≥
 used — a run can read memories and apply none. The bullet count MUST equal `MEMORIES_USED_COUNT`.
 
-Build each `<url>` as `{base}/lore?memoryId=<id>` from the memory's retained `id`
-(`base` = `LOREKIT_APP_URL` or `https://lorekit.io`), per
-`comment-relevance-memory.md § Linking applied memories in the report`. When no `id` is
-available, fall back to the `lorekit link "<scope>" "<key>"` CLI, else a plain-text
-`` `<scope> · <key>` `` identifier — never a fabricated URL.
+Build each `<url>` from the memory's retained `scope` + `key`, per
+`comment-relevance-memory.md § Linking applied memories in the report` — the
+`lorekit link "<scope>" "<key>"` CLI when it is on `PATH`, else the documented
+`{base}/lore?scope=<enc>&lesson=<enc>` construction (`base` = `LOREKIT_APP_URL` or
+`https://lorekit.io`), else a plain-text `` `<scope> · <key>` `` identifier — never a
+fabricated URL.
 
 `MEMORIES_USED_SUFFIX` is the tag appended to the `Review diagnostics` `<summary>` title so the
 collapsed label headlines how many memories **influenced** the review:

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1071,9 +1071,9 @@ Sort by prefix priority, then descending confidence. This section is the reason 
 is allowed to exist — never drop a cleared finding instead of listing it here.
 
 `MEMORIES_SECTION` is the persistent memory block inside `Review diagnostics` (replacing the old
-applied-only list). It **always renders when the LoreKit backend was reachable this run**
-(`LOREKIT_CONNECTED`), so a reader can always see both how many memories were **read** and how many
-were actually **used** — not only when something fired.
+applied-only list). It **always renders** — never omit the slot. `LOREKIT_CONNECTED` selects which
+of the two shapes below it takes, so a reader always sees either both counts or an explicit
+`not connected`, not only when something fired.
 
 - **Connected** — a header line, followed (only when `MEMORIES_USED_COUNT > 0`) by one bullet per
   entry in `APPLIED_MEMORIES[]` (Step 2.2), each a pressable LoreKit link so the reader can open the

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -187,8 +187,9 @@ into three links the user can click through and audit.
 
 **Only applied memories are linked.** Use `APPLIED_MEMORIES[]` from the apply step.
 A memory that was loaded but fired against nothing is never linked — it did not
-influence the review. If `APPLIED_MEMORIES[]` is empty, the report shows no
-memory-link section at all; the numeric Quality Gate counts stand alone.
+influence the review. If `APPLIED_MEMORIES[]` is empty, the block still renders
+its header line (`… · 0 used`) and no bullets, per
+[Render shape](#render-shape); the numeric Quality Gate counts stand alone.
 
 ### Resolving each link
 

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -222,23 +222,25 @@ memory as plain text `` `<scope> · <key>` `` with no hyperlink.
 
 ### Render shape
 
-One bullet per applied memory, each a Markdown link whose text names the
-`fingerprint`, the action taken, and the recurrence count — so multiple memories
-render as multiple independently-pressable links:
+A persistent **Memories** block headed by the read and used counts, followed —
+only when at least one memory fired — by one bullet per applied memory. Each bullet is a
+Markdown link whose text names the `fingerprint`, the action taken, and the recurrence count,
+so multiple memories render as multiple independently-pressable links:
 
 ```markdown
-**Memories applied:** (<N> LoreKit memories influenced this review)
+**Memories** — <read> read · <used> used
 
 - [`suggestion:null-check-guaranteed-upstream`](https://…) — dropped, seen 4×
 - [`nitpick:map-vs-record-preference`](https://…) — downgraded, seen 2×
 - [`issue:missing-abort-signal`](https://…) — promoted, seen 3×
 ```
 
-The bullet count MUST equal the number of memories that fired this run (drops +
-downgrades + promotes). A mismatch means an applied memory was dropped from the
-list instead of linked. Which report surface renders this block is the consuming
-agent's contract — `pr-reviewer` renders it inside the posted review body's
-`Review diagnostics` block (Step 4).
+The bullet count MUST equal the `used` count — the number of memories that fired this run (drops +
+downgrades + promotes). A mismatch means an applied memory was dropped from the list instead of
+linked. When nothing fired, render only the header line (`… · 0 used`). Which report surface renders
+this block is the consuming agent's contract — `pr-reviewer` renders it inside the posted review
+body's `Review diagnostics` block (Step 4), where the collapsed title also headlines the `used`
+count.
 
 ---
 

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -117,10 +117,10 @@ memory.list { scope: "global",               tags: ["loop::reviewer-comment-rele
 Merge both lists (`repo::` wins on key collision).
 Skip any entry whose `expires` is in the past.
 
-**Keep the coordinates.** Retain each entry's `scope` and `key` (the LoreKit
-memory coordinates) alongside its `fingerprint`, `relevance`, and `seen_count` —
-the report builds a pressable dashboard deep link from `scope` + `key` for every
-memory that actually influences the review (see
+**Keep the coordinates.** Retain each entry's LoreKit `id`, `scope`, and `key`
+alongside its `fingerprint`, `relevance`, and `seen_count` — the report builds a
+pressable `?memoryId=` deep link from the `id` (falling back to `scope` + `key`)
+for every memory that actually influences the review (see
 [Linking applied memories in the report](#linking-applied-memories-in-the-report)).
 
 ### How to apply
@@ -190,35 +190,35 @@ memory-link section at all; the numeric Quality Gate counts stand alone.
 
 ### Resolving each link
 
-A LoreKit memory's dashboard deep link opens its detail sheet in the `/lore`
-Explorer. It is built from the memory's `scope` + `key` per LoreKit's documented
-[deep-link contract](https://lorekit.io/docs/deep-links). For each entry in
-`APPLIED_MEMORIES[]`, resolve its URL in this order:
+A LoreKit memory's dashboard deep link opens its detail view in the `/lore`
+Explorer. Build it from the memory's **`id`** (retained at read time) via the
+`?memoryId=` route, which resolves straight to that one memory — no `scope`
+selection or URL-encoded JSON to get wrong:
 
-1. **Preferred — let the LoreKit CLI build it.** When the `lorekit` CLI is on
-   `PATH`, run `lorekit link "<scope>" "<key>"` (alias `url`). It prints the exact
-   URL to stdout — nothing else — and honours `LOREKIT_APP_URL` / `--base` for
-   self-hosted dashboards, so encoding is never hand-rolled:
+```text
+{base}/lore?memoryId=<id>
+```
+
+`base` is the `LOREKIT_APP_URL` environment variable, else `https://lorekit.io`.
+A memory with `id` `mem_7f3a92` yields `https://lorekit.io/lore?memoryId=mem_7f3a92`.
+
+Resolve each entry in `APPLIED_MEMORIES[]` in this order:
+
+1. **Preferred — `{base}/lore?memoryId=<id>`.** Use the memory's `id` directly.
+   The `id` is present whenever the read step retained it (it always should be).
+2. **Fallback — the LoreKit CLI.** When no `id` is available but the `lorekit`
+   CLI is on `PATH`, run `lorekit link "<scope>" "<key>"` (alias `url`); it prints
+   the exact URL to stdout and honours `LOREKIT_APP_URL` / `--base`:
 
    ```bash
    lorekit link "repo::acme/widget" "reviewer-comment-relevance::suggestion:null-check-guaranteed-upstream"
    ```
 
-2. **Fallback — construct the URL directly.** When the CLI is unavailable,
-   build `{base}/lore?scope=<enc(scope)>&lesson=<enc({scope,key})>`, where
-   `enc(v) = encodeURIComponent(JSON.stringify(v))` (the exact inverse of the
-   dashboard's `useUrlState` read — a raw `?scope=global` silently means "all
-   scopes"), and `base` is the `LOREKIT_APP_URL` environment variable, else
-   `https://lorekit.io`. For scope `global`, key
-   `reviewer-comment-relevance::nitpick:map-vs-record-preference` this yields:
+3. **Last resort — plain text.** When neither `id` nor `scope`+`key` is known,
+   render the memory as plain text `` `<scope> · <key>` `` with no hyperlink.
 
-   ```text
-   https://lorekit.io/lore?scope=%22global%22&lesson=%7B%22scope%22%3A%22global%22%2C%22key%22%3A%22reviewer-comment-relevance%3A%3Anitpick%3Amap-vs-record-preference%22%7D
-   ```
-
-**Never fabricate a URL** — both paths derive it deterministically from the
-memory's real `scope` + `key`; if neither `scope` nor `key` is known, render the
-memory as plain text `` `<scope> · <key>` `` with no hyperlink.
+**Never fabricate a URL or an `id`** — every link derives deterministically from
+the memory's real identifiers.
 
 ### Render shape
 

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -117,11 +117,13 @@ memory.list { scope: "global",               tags: ["loop::reviewer-comment-rele
 Merge both lists (`repo::` wins on key collision).
 Skip any entry whose `expires` is in the past.
 
-**Keep the coordinates.** Retain each entry's LoreKit `id`, `scope`, and `key`
-alongside its `fingerprint`, `relevance`, and `seen_count` — the report builds a
-pressable `?memoryId=` deep link from the `id` (falling back to `scope` + `key`)
-for every memory that actually influences the review (see
+**Keep the coordinates.** Retain each entry's `scope` and `key` (the LoreKit
+memory coordinates) alongside its `fingerprint`, `relevance`, and `seen_count` —
+the report builds a pressable dashboard deep link from `scope` + `key` for every
+memory that actually influences the review (see
 [Linking applied memories in the report](#linking-applied-memories-in-the-report)).
+`memory.list` / `memory.read` / `memory.search` return no per-memory `id`, so
+`scope` + `key` are the only identifiers a link can be built from.
 
 ### How to apply
 
@@ -190,35 +192,39 @@ memory-link section at all; the numeric Quality Gate counts stand alone.
 
 ### Resolving each link
 
-A LoreKit memory's dashboard deep link opens its detail view in the `/lore`
-Explorer. Build it from the memory's **`id`** (retained at read time) via the
-`?memoryId=` route, which resolves straight to that one memory — no `scope`
-selection or URL-encoded JSON to get wrong:
+A LoreKit memory's dashboard deep link opens its detail sheet in the `/lore`
+Explorer. It is built from the memory's `scope` + `key` per LoreKit's documented
+[deep-link contract](https://lorekit.io/docs/deep-links). That contract
+enumerates every Explorer parameter — `scope`, `q`, `range`, `owner`, `filters`,
+`tags`, `view`, `archived`, and `lesson` — and `lesson` is the only one that
+opens a single memory. There is no `?memoryId=` parameter, and the read tools
+expose no `id` to put in one, so never build a link from either. For each entry
+in `APPLIED_MEMORIES[]`, resolve its URL in this order:
 
-```text
-{base}/lore?memoryId=<id>
-```
-
-`base` is the `LOREKIT_APP_URL` environment variable, else `https://lorekit.io`.
-A memory with `id` `mem_7f3a92` yields `https://lorekit.io/lore?memoryId=mem_7f3a92`.
-
-Resolve each entry in `APPLIED_MEMORIES[]` in this order:
-
-1. **Preferred — `{base}/lore?memoryId=<id>`.** Use the memory's `id` directly.
-   The `id` is present whenever the read step retained it (it always should be).
-2. **Fallback — the LoreKit CLI.** When no `id` is available but the `lorekit`
-   CLI is on `PATH`, run `lorekit link "<scope>" "<key>"` (alias `url`); it prints
-   the exact URL to stdout and honours `LOREKIT_APP_URL` / `--base`:
+1. **Preferred — let the LoreKit CLI build it.** When the `lorekit` CLI is on
+   `PATH`, run `lorekit link "<scope>" "<key>"` (alias `url`). It prints the exact
+   URL to stdout — nothing else — and honours `LOREKIT_APP_URL` / `--base` for
+   self-hosted dashboards, so encoding is never hand-rolled:
 
    ```bash
    lorekit link "repo::acme/widget" "reviewer-comment-relevance::suggestion:null-check-guaranteed-upstream"
    ```
 
-3. **Last resort — plain text.** When neither `id` nor `scope`+`key` is known,
-   render the memory as plain text `` `<scope> · <key>` `` with no hyperlink.
+2. **Fallback — construct the URL directly.** When the CLI is unavailable,
+   build `{base}/lore?scope=<enc(scope)>&lesson=<enc({scope,key})>`, where
+   `enc(v) = encodeURIComponent(JSON.stringify(v))` (the exact inverse of the
+   dashboard's `useUrlState` read — a raw `?scope=global` silently means "all
+   scopes"), and `base` is the `LOREKIT_APP_URL` environment variable, else
+   `https://lorekit.io`. For scope `global`, key
+   `reviewer-comment-relevance::nitpick:map-vs-record-preference` this yields:
 
-**Never fabricate a URL or an `id`** — every link derives deterministically from
-the memory's real identifiers.
+   ```text
+   https://lorekit.io/lore?scope=%22global%22&lesson=%7B%22scope%22%3A%22global%22%2C%22key%22%3A%22reviewer-comment-relevance%3A%3Anitpick%3Amap-vs-record-preference%22%7D
+   ```
+
+**Never fabricate a URL** — both paths derive it deterministically from the
+memory's real `scope` + `key`; if neither `scope` nor `key` is known, render the
+memory as plain text `` `<scope> · <key>` `` with no hyperlink.
 
 ### Render shape
 


### PR DESCRIPTION
## What

Two related improvements to the `pr-reviewer` **Review diagnostics** memory reporting.

## 1. Title shows memories *used*; block always shows read + used

The collapsed title previously showed `(24 memories read)`. It now headlines the count that actually matters — how many memories **influenced** the review:

> **Review diagnostics (2 memories used)**

The expanded block gains a persistent **Memories** section that always renders when LoreKit is connected, showing both counts and the used list:

```
**Memories** — 24 read · 2 used

- [`…stale-pr-body-claim`](url) — promoted, seen 5×
- [`…double-counted-toggle`](url) — promoted, seen 2×
```

`0 used` still renders the header; `not connected` renders when the backend is unreachable. New tokens: `MEMORIES_USED_COUNT` (= `|APPLIED_MEMORIES|`), `MEMORIES_USED_SUFFIX`, `MEMORIES_SECTION` (replaces `MEMORIES_APPLIED_SECTION`), `LOREKIT_CONNECTED`.

## 2. Grouped & tightened diagnostics layout

The block was a dense inline wall. Restructured into scannable bold em-dash groups, with the Quality gate split into a `produced → posted` summary plus a compact `dropped:` breakdown:

```
**Run mode** — full · 127 lines in delta

**Memories** — 24 read · 2 used
- …

**Quality** — produced 7 → posted inline 2 · cleared 2 · carried forward 0 · deferred 0
- dropped: relevance 0 · dedupe 2 · grounding 0 · confidence 3 · shape 0

**Integrations** — supabase-js, Dash0 web SDK (no divergence)
**Optimality (2.4c)** — ran · 1 judged · 1 optimal · 0 proposals · 0 withheld
**Skipped files** — none
```

## 3. Deep links stay on the documented `scope` + `lesson` contract

An earlier revision of this branch switched the applied-memory links to `{base}/lore?memoryId=<id>`. That route does not exist: LoreKit's [deep-link contract](https://lorekit.io/docs/deep-links) enumerates the Explorer parameters (`scope`, `q`, `range`, `owner`, `filters`, `tags`, `view`, `archived`, `lesson`) and `lesson` is the only one that opens a single memory, while the MCP read tools (`memory.list` / `read` / `search`) return no `id` to put in it. Reverted in c99ecba: the `lorekit link` CLI is preferred, the documented `{base}/lore?scope=<enc>&lesson=<enc({scope,key})>` construction is the fallback, and a plain-text `` `<scope> · <key>` `` identifier is the last resort. The section now states explicitly that there is no `?memoryId=` parameter, so the next reader does not re-derive it.

## Files

- `agents/pr-reviewer.md` — diagnostics templates + rules.
- `agents/shared/rules/comment-relevance-memory.md` — Read retention, Render shape, and the link-resolution contract.

## Verification

L1 deterministic contract checks: 155/155 pass (re-run after each of c99ecba, 08efcf6, 9dd0273).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZutnpuj1geCMfczuCB35o

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZutnpuj1geCMfczuCB35o)_
