### PR TITLE
fix(agents): grant LoreKit MCP tools to sub-agents with correct names

### DIFF
--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-reviewer
 description: Cross-review code reviewer for someone else's GitHub PR. Runs a structured pre-merge gate check (description vs. code, CI status, unresolved bot feedback, self-review signals, documentation adequacy) then a thorough multi-lens AI persona review (correctness/logic, quality/maintainability, description accuracy, external integration verifier). Incrementally aware — on repeated runs it detects a prior review, computes only the delta since the last reviewed SHA, and chooses a run mode (full / incremental / incremental-quick) so commit-by-commit re-runs stay fast. Posts a single consolidated GitHub review — one gate-status table in the body plus inline findings — directly as a visible COMMENT event; no draft/pending workflow. Uses Lorekit relevance memories to suppress recurring noise patterns per repository. Refuses on own PR (points to `reviewer`). Imports rules from `agents/shared/rules/` and owns its own rules under `agents/pr-reviewer/rules/`. Trigger via slash `/pr-review <PR-URL|#n>` or via `Skill("pr-reviewer", "<PR-URL> [--critical] [--full] [--with <lens1>,<lens2>,<lens3>] [--no-holistic] [--no-escalate] [--no-optimize] [--skip-gates]")`.
-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill, mcp__lorekit__memory_list, mcp__lorekit__memory_search, mcp__lorekit__memory_read, mcp__lorekit__memory_write
 model: opus
 ---
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer
 description: Own-work code reviewer for your own branch or your own pull request. Three sub-modes — Fix Mode (own branch, no PR, auto-fix simple + plan complex), Report Mode (`--report`, propose only, no fixes), and Self-Review (own PR, auto-fix + inline terminal report using pr-comment-card cards). Incrementally aware — on repeated runs it reads a local `.agent/reviewer/{branch}.last-sha` file, computes only the delta since the last reviewed SHA, and chooses a run mode (full / incremental / incremental-quick) so commit-by-commit re-runs stay fast. Never writes to GitHub — for cross-review on a colleague's PR, use the `pr-reviewer` agent (this agent auto-redirects if invoked with a cross-author PR). Imports rules from `agents/shared/rules/` (comment shape, finding grounding, rubric composition, conventional comments, per-comment confidence) and owns its own rules under `agents/reviewer/rules/` (auto-fix policy, self-review report). Trigger via slash `/review-changes [--report] [--full] [--critical] [--with <lens1>,<lens2>,<lens3>]` or via `Skill("reviewer", "...")`. `--critical` runs adversarial pre-mortem via the `critical` skill (auto-engages on high-stakes diffs). `--with <skill1>,<skill2>` loads each skill's `lens.md` as an extra rubric (cap 3).
-tools: Read, Write, Edit, Bash, Glob, Grep, Skill
+tools: Read, Write, Edit, Bash, Glob, Grep, Skill, mcp__lorekit__memory_list, mcp__lorekit__memory_search, mcp__lorekit__memory_read, mcp__lorekit__memory_write
 model: opus
 ---
 

--- a/agents/shared/rules/review-outcomes.md
+++ b/agents/shared/rules/review-outcomes.md
@@ -28,6 +28,14 @@ This separates the high-frequency write path (per-comment, per-PR) from the low-
 `review-outcomes::<fingerprint-slug>` — written via the `memory.*` MCP tools.
 It uses two LoreKit scopes:
 
+> **Tool naming & availability.** `memory.*` is LoreKit's canonical tool name;
+> **Claude Code exposes these as `mcp__lorekit__memory_list` / `_search` /
+> `_read` / `_write`** (server-prefixed, dots→underscores) — there is no literal
+> `mcp__lorekit__memory.*` tool. The `reviewer` / `pr-reviewer` agents grant
+> these in their frontmatter `tools:` because a sub-agent does **not** inherit
+> the parent session's MCP tools. If the tools are absent, the bus is a no-op
+> (see the fallback note near the end of this file).
+
 | LoreKit scope | When written | When read |
 | --- | --- | --- |
 | `global` | Default — every `implement-suggestion` run (universal calibration) | At promotion/consolidation time only |

--- a/skills/workflow/autonomous-workflow/rules/self-improvement-loop.md
+++ b/skills/workflow/autonomous-workflow/rules/self-improvement-loop.md
@@ -65,12 +65,34 @@ LoreKit is a shared, persistent memory for agents, backed by an MCP server, so a
 lesson learned on one machine (or in CI) is available to every agent everywhere
 in the next session. The loop uses four tools:
 
-| Tool | Use |
-|------|-----|
-| `memory.list` | List lessons for one scope (newest first, tag filter) |
-| `memory.search` | Full-text search across scopes (supports `repo::owner/*`) |
-| `memory.read` | Read one lesson by scope + key |
-| `memory.write` | Store or update a lesson (same scope + key updates in place) |
+| Tool | Claude Code name | Use |
+|------|------------------|-----|
+| `memory.list` | `mcp__lorekit__memory_list` | List lessons for one scope (newest first, tag filter) |
+| `memory.search` | `mcp__lorekit__memory_search` | Full-text search across scopes (supports `repo::owner/*`) |
+| `memory.read` | `mcp__lorekit__memory_read` | Read one lesson by scope + key |
+| `memory.write` | `mcp__lorekit__memory_write` | Store or update a lesson (same scope + key updates in place) |
+
+**Tool naming — do not hunt for a literal `memory.*` tool.** The `memory.list`
+form is LoreKit's canonical (protocol-level) tool name and is what the pseudocode
+blocks below use. **Claude Code exposes MCP tools server-prefixed with dots
+replaced by underscores** — the actual callable names are
+`mcp__lorekit__memory_list` / `_search` / `_read` / `_write` (right column).
+There is no tool literally named `mcp__lorekit__memory.*`.
+
+**Availability — sub-agents must be granted these tools explicitly.** A sub-agent
+(`aw`, `aw-planner`, `aw-executor`, `aw-tester`, and the `reviewer` /
+`pr-reviewer` agents) gets **only** the tools listed in its own frontmatter
+`tools:` — it does **not** inherit the parent session's MCP tools. Each of those
+agents therefore lists the `mcp__lorekit__memory_*` tools it needs. If, despite
+that, the tools are absent (LoreKit not installed, or a host that does not expose
+them), the loop is a no-op — log one line and continue.
+
+**Read-only CLI fallback (reads only).** When the MCP tools are unavailable but a
+shell is (all these agents have `Bash`), lessons can still be *read* with the
+`@lorekit/cli` read commands — `npx @lorekit/cli search "<keywords>" --json` and
+`npx @lorekit/cli list --scope <scope> --json`. The CLI has **no write command**,
+so writes still require the MCP tools; when they are absent, skip the write
+silently.
 
 **Scope** is LoreKit's partition axis — `global`, `repo::{owner}/{repo}`, or
 `branch::{owner}/{repo}::{branch}` (`::` is the only separator; segments are

--- a/skills/workflow/autonomous-workflow/templates/aw-executor.agent.md
+++ b/skills/workflow/autonomous-workflow/templates/aw-executor.agent.md
@@ -12,6 +12,15 @@ tools:
   - Edit
   - Write
   - Skill
+  # LoreKit self-improvement loop — the executor READS lessons (no-planner paths)
+  # and WRITES them at stuck-loop escalation (Phase 4) and end-of-run (Phase 7).
+  # Sub-agents do NOT inherit the parent session's MCP tools, so they are granted
+  # here by their Claude Code names (server-prefixed, dots→underscores) or the loop
+  # silently no-ops. See rules/self-improvement-loop.md → "LoreKit in one screen".
+  - mcp__lorekit__memory_list
+  - mcp__lorekit__memory_search
+  - mcp__lorekit__memory_read
+  - mcp__lorekit__memory_write
 model: sonnet
 ---
 

--- a/skills/workflow/autonomous-workflow/templates/aw-planner.agent.md
+++ b/skills/workflow/autonomous-workflow/templates/aw-planner.agent.md
@@ -15,6 +15,13 @@ tools:
   - Skill
   - WebFetch
   - WebSearch
+  # LoreKit self-improvement loop — the planner READS lessons at Phase 1. Sub-agents
+  # do NOT inherit the parent session's MCP tools, so they are granted here by their
+  # Claude Code names (server-prefixed, dots→underscores) or the read silently no-ops.
+  # See rules/self-improvement-loop.md → "LoreKit in one screen".
+  - mcp__lorekit__memory_list
+  - mcp__lorekit__memory_search
+  - mcp__lorekit__memory_read
 model: opus
 ---
 

--- a/skills/workflow/autonomous-workflow/templates/aw-tester.agent.md
+++ b/skills/workflow/autonomous-workflow/templates/aw-tester.agent.md
@@ -12,6 +12,14 @@ tools:
   - Read
   - Bash
   - Skill
+  # LoreKit self-improvement loop — reads cross-run lessons at start, writes
+  # locator-healing lessons at end. Sub-agents do NOT inherit the parent session's
+  # MCP tools, so they are granted here by their Claude Code names (server-prefixed,
+  # dots→underscores) or the loop silently no-ops.
+  - mcp__lorekit__memory_list
+  - mcp__lorekit__memory_search
+  - mcp__lorekit__memory_read
+  - mcp__lorekit__memory_write
 model: sonnet
 ---
 

--- a/skills/workflow/autonomous-workflow/templates/aw.agent.md
+++ b/skills/workflow/autonomous-workflow/templates/aw.agent.md
@@ -22,6 +22,14 @@ tools:
   - Task
   - WebFetch
   - WebSearch
+  # LoreKit self-improvement loop (read at intake, write at exit). Sub-agents do
+  # NOT inherit the parent session's MCP tools — they must be granted here by
+  # their Claude Code names (server-prefixed, dots→underscores) or the loop
+  # silently no-ops. See rules/self-improvement-loop.md → "LoreKit in one screen".
+  - mcp__lorekit__memory_list
+  - mcp__lorekit__memory_search
+  - mcp__lorekit__memory_read
+  - mcp__lorekit__memory_write
 model: opus
 ---
 


### PR DESCRIPTION
## Why

A sub-agent gets only the tools listed in its own frontmatter — it does **not** inherit the parent session's MCP tools. The aw-family agents (`aw`, `aw-planner`, `aw-executor`, `aw-tester`) and the `reviewer` / `pr-reviewer` agents drive the LoreKit self-improvement loop but granted no memory tools, so every `memory.*` call silently no-op'd inside the sub-agent (observed: aw-planner reporting "there's no `mcp__lorekit__memory.*` tool in my tool list").

## What changed

- Grant `mcp__lorekit__memory_{list,search,read,write}` in each agent's frontmatter (aw-planner is read-only: list/search/read)
- Document the Claude Code tool-name transform (canonical `memory.*` → server-prefixed `mcp__lorekit__memory_*`, dots→underscores) and the sub-agent non-inheritance rule in `self-improvement-loop.md` + `review-outcomes.md`
- Note the read-only `@lorekit/cli` fallback for lesson reads (the CLI has no write command)

## How to verify

- `node scripts/eval/l1.mjs` → 145/145; all six agent frontmatters parse as valid YAML with the grants present