### PR TITLE
fix(agents): aw-planner needs memory_write; CLI fallback covers writes

### DIFF
--- a/skills/workflow/autonomous-workflow/rules/self-improvement-loop.md
+++ b/skills/workflow/autonomous-workflow/rules/self-improvement-loop.md
@@ -87,12 +87,14 @@ agents therefore lists the `mcp__lorekit__memory_*` tools it needs. If, despite
 that, the tools are absent (LoreKit not installed, or a host that does not expose
 them), the loop is a no-op — log one line and continue.
 
-**Read-only CLI fallback (reads only).** When the MCP tools are unavailable but a
-shell is (all these agents have `Bash`), lessons can still be *read* with the
-`@lorekit/cli` read commands — `npx @lorekit/cli search "<keywords>" --json` and
-`npx @lorekit/cli list --scope <scope> --json`. The CLI has **no write command**,
-so writes still require the MCP tools; when they are absent, skip the write
-silently.
+**CLI fallback (reads AND writes).** When the MCP tools are unavailable but a
+shell is (all these agents have `Bash`), the whole loop can still run through the
+`@lorekit/cli` commands. Read with `npx @lorekit/cli search "<keywords>" --json`
+and `npx @lorekit/cli list --scope <scope> --json`; write with
+`npx @lorekit/cli write "<scope>::<key>" "<body>" --tags loop::aw-lessons --source-agent <agent> --trigger <slug>`
+(an upsert — same `scope::key` overwrites in place, mirroring `memory.write`).
+Prefer the MCP tools when present; the CLI is the fallback. If neither is
+available, skip silently.
 
 **Scope** is LoreKit's partition axis — `global`, `repo::{owner}/{repo}`, or
 `branch::{owner}/{repo}::{branch}` (`::` is the only separator; segments are

--- a/skills/workflow/autonomous-workflow/templates/aw-planner.agent.md
+++ b/skills/workflow/autonomous-workflow/templates/aw-planner.agent.md
@@ -15,13 +15,17 @@ tools:
   - Skill
   - WebFetch
   - WebSearch
-  # LoreKit self-improvement loop — the planner READS lessons at Phase 1. Sub-agents
-  # do NOT inherit the parent session's MCP tools, so they are granted here by their
-  # Claude Code names (server-prefixed, dots→underscores) or the read silently no-ops.
-  # See rules/self-improvement-loop.md → "LoreKit in one screen".
+  # LoreKit self-improvement loop. The planner READS aw-lessons at Phase 1, and
+  # its Phase-1 companion optimize-approach(plan) WRITES a lesson at O5 — so the
+  # write tool is needed too, or that companion write silently no-ops (the exact
+  # failure this grant set exists to prevent). Sub-agents do NOT inherit the
+  # parent session's MCP tools, so they are granted here by their Claude Code
+  # names (server-prefixed, dots→underscores). See rules/self-improvement-loop.md
+  # → "LoreKit in one screen".
   - mcp__lorekit__memory_list
   - mcp__lorekit__memory_search
   - mcp__lorekit__memory_read
+  - mcp__lorekit__memory_write
 model: opus
 ---
 


### PR DESCRIPTION
## Why

Follow-up to #83. The dash0-dev review flagged two real gaps (both verified against source):

- `aw-planner` invokes `optimize-approach` in `plan` mode at Phase 1, and that companion performs an **O5 `memory.write`** — which silently no-op'd because the planner was granted read-only tools. That's the exact failure #83 exists to fix, still latent on the planner.
- `self-improvement-loop.md` claimed `@lorekit/cli` has **no write command**. It does (`lorekit write <scope::key> <value>` with `--tags`/`--source-agent`/`--trigger`, `bin/lorekit.mjs:711`).

(The review's third, blocking comment — "17 commits behind, rebase" — was already resolved by the pre-merge rebase on #83.)

## What changed

- Grant `mcp__lorekit__memory_write` to `aw-planner` and correct its frontmatter rationale
- Rewrite the CLI-fallback note: the loop can read **and** write via the CLI when MCP tools are absent

## How to verify

- `node scripts/eval/l1.mjs` → 156/156; aw-planner frontmatter parses as valid YAML with all four memory tools