### PR TITLE
fix(pr-reviewer): make LoreKit memory READ a mandatory real tool call

### DIFF
--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -437,7 +437,8 @@ In incremental modes (non-empty delta), Gate 4 (self-review signals) scans `REVI
 The two broad `mcp__lorekit__memory_list` calls in Step 1.0 are capped at 50 per tag; on a large repository the lesson most relevant to *these* changed files can fall outside that window.
 Now that the changed-file list is known (Step 1.1 command A and Step 1.2), run one targeted `mcp__lorekit__memory_search` to pull those in.
 Issue this as a real `mcp__lorekit__memory_search` tool call.
-If the call errors and `LOREKIT_CONNECTED` is already `false`, skip this step; otherwise treat an error here as a non-blocking addend miss (do not flip `LOREKIT_CONNECTED`).
+Skip this step when `LOREKIT_CONNECTED` is already `false` — the Step 1.0 attempt failed, so there is no backend to search.
+Otherwise issue the call, and treat an error here as a non-blocking addend miss (do not flip `LOREKIT_CONNECTED`).
 
 Build the query from the diff's own vocabulary — the changed top-level directories, the changed file basenames (without extension), and any dependency-manifest filenames present in the diff (`package.json`, `go.mod`, `Cargo.toml`, `requirements.txt`, …).
 In `incremental` and `incremental-quick` modes, key on `REVIEW_DIFF`'s paths, not the full PR.

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -272,18 +272,24 @@ While fetching, **also identify open unresolved bot-authored comments** for Gate
 - Store these as `OPEN_BOT_COMMENTS[]`.
 - If `OPEN_BOT_COMMENTS[]` is empty, Gate 3 passes.
 
-Also load **comment-relevance memories** and **reviewer-lessons** (narrow-to-broad fan-out,
-silent no-op if `memory.*` not connected):
+Also load **comment-relevance memories** and **reviewer-lessons** via a narrow-to-broad fan-out.
+**This read is a mandatory attempt.**
+Issue each line below as a real `mcp__lorekit__memory_list` tool call — these are not documentation shorthand.
+Only a real tool error (thrown exception, or tool not in the agent's `tools:` grant) may cause you to set `LOREKIT_CONNECTED=false`; never infer "not connected" without attempting the call.
+When this agent runs as a sub-agent, it does NOT receive the SessionStart memory-load priming that the main session gets, so it MUST perform this Step 1.0 read itself — never assume memories were pre-loaded.
 
-```
-memory.list { scope: "repo::{owner}/{repo}", tags: ["loop::reviewer-lessons"],           limit: 50 }
-memory.list { scope: "global",               tags: ["loop::reviewer-lessons"],           limit: 50 }
-memory.list { scope: "repo::{owner}/{repo}", tags: ["loop::reviewer-comment-relevance"], limit: 50 }
-memory.list { scope: "global",               tags: ["loop::reviewer-comment-relevance"], limit: 50 }
+```text
+# Issue each as a real mcp__lorekit__memory_list tool call (narrow-to-broad).
+# repo:: wins on key collision. Skip expired entries.
+mcp__lorekit__memory_list: scope="repo::{owner}/{repo}" tags=["loop::reviewer-lessons"]           limit=50
+mcp__lorekit__memory_list: scope="global"               tags=["loop::reviewer-lessons"]           limit=50
+mcp__lorekit__memory_list: scope="repo::{owner}/{repo}" tags=["loop::reviewer-comment-relevance"] limit=50
+mcp__lorekit__memory_list: scope="global"               tags=["loop::reviewer-comment-relevance"] limit=50
 ```
 
 Derive `{owner}/{repo}` from `RESOLVED_REPO` (set in Step 0), lowercased.
-Merge both lists per tag (`repo::` wins on key collision). Skip expired entries.
+Merge both lists per tag (`repo::` wins on key collision).
+Skip expired entries.
 
 **Apply `reviewer-lessons`.**
 Match each loaded lesson's `trigger-context` (the shared lesson-scope schema — file globs, task type, integration/tech names) against this run's changed paths, synthesized intent, and detected integrations.
@@ -306,9 +312,9 @@ Retain each loaded memory's LoreKit `scope` and `key` alongside its
 `fingerprint`, `relevance`, and `seen_count` — Step 2.2 builds a deep link from
 `scope` + `key` for every memory that influences the review
 (`agents/shared/rules/comment-relevance-memory.md § Linking applied memories in the report`).
+Set `LOREKIT_CONNECTED` = `true` when the `mcp__lorekit__memory_list` call returned without a tool error (i.e., the attempt was made and succeeded); set `false` only when the tool call itself threw an error or the tool is not in the agent's `tools:` grant — never infer `false` without attempting the call.
 Set `MEMORIES_READ_COUNT` = the number of `reviewer-comment-relevance` memories retained after
-this merge/dedup (0 when connected but none matched), and `LOREKIT_CONNECTED` = whether the
-`memory.*` backend was reachable at all this run.
+this merge/dedup (0 when connected but none matched).
 **This definition is authoritative and no later step widens it** — including the Step 1.2c addend.
 `MEMORIES_READ_COUNT` counts `reviewer-comment-relevance` memories only, never `reviewer-lessons`,
 because its partner `MEMORIES_USED_COUNT` is `|APPLIED_MEMORIES|`, built at Step 2.2 from relevance
@@ -406,7 +412,8 @@ echo "$DELTA_JSON" | jq '.files' > /tmp/pr-delta.json
 - `11 <= DELTA_LINES <= 100`: keep `RUN_MODE = "incremental"`.
 
 Announce the result:
-```
+
+```text
 Delta: <DELTA_LINES> lines changed, <NEW_FILES> new files, <HIGH_STAKES> high-stakes paths.
 Run mode: <RUN_MODE> (prior SHA: ${PRIOR_SHA:0:7} → current: ${HEAD_SHA:0:7}).
 ```
@@ -427,15 +434,17 @@ In incremental modes (non-empty delta), Gate 4 (self-review signals) scans `REVI
 
 ### 1.2c Diff-keyed lesson search (all modes)
 
-The two broad `memory.list` calls in Step 1.0 are capped at 50 per tag; on a large repository the lesson most relevant to *these* changed files can fall outside that window.
-Now that the changed-file list is known (Step 1.1 command A and Step 1.2), run one targeted `memory.search` to pull those in.
-Silent no-op if `memory.*` is not connected.
+The two broad `mcp__lorekit__memory_list` calls in Step 1.0 are capped at 50 per tag; on a large repository the lesson most relevant to *these* changed files can fall outside that window.
+Now that the changed-file list is known (Step 1.1 command A and Step 1.2), run one targeted `mcp__lorekit__memory_search` to pull those in.
+Issue this as a real `mcp__lorekit__memory_search` tool call.
+If the call errors and `LOREKIT_CONNECTED` is already `false`, skip this step; otherwise treat an error here as a non-blocking addend miss (do not flip `LOREKIT_CONNECTED`).
 
 Build the query from the diff's own vocabulary — the changed top-level directories, the changed file basenames (without extension), and any dependency-manifest filenames present in the diff (`package.json`, `go.mod`, `Cargo.toml`, `requirements.txt`, …).
 In `incremental` and `incremental-quick` modes, key on `REVIEW_DIFF`'s paths, not the full PR.
 
-```
-memory.search { q: "<changed dirs + basenames + manifest names>", scopes: ["repo::{owner}/{repo}", "global"], limit: 10 }
+```text
+# Issue as a real mcp__lorekit__memory_search tool call.
+mcp__lorekit__memory_search: q="<changed dirs + basenames + manifest names>" scopes=["repo::{owner}/{repo}", "global"] limit=10
 ```
 
 Keep only returned hits carrying the tag `loop::reviewer-lessons` or `loop::reviewer-comment-relevance`, then merge them into the pools loaded at Step 1.0 (dedupe by `scope` + `key`; `repo::` wins; skip expired).
@@ -450,7 +459,7 @@ in Step 1.0's announce line.
 
 Produce a 2–3 line intent summary from PR title, body, commit messages, and branch name.
 
-```
+```text
 Intent: This change [verb] [what] so that [why].
 [Optional second line on scope or constraint.]
 ```
@@ -638,7 +647,7 @@ Persona 3 findings are deduped at Step 2.5 rather than posted twice.
 After rubric + persona findings are collected, the pipeline runs through these gates in
 strict order. Each gate is a drop point; no retries.
 
-```
+```text
 rubrics + personas produce raw findings
   → 2.2  comment-relevance-memory.md  (drop/downgrade not-relevant patterns; promote reliably-resolved ones)
   → 2.3  review-config.md § Filters   (drop findings in categories suppressed by review config)
@@ -793,7 +802,8 @@ Always include the run mode and delta context in the header:
 Pick the presentation by verdict (see *Gate states*): **PASS** (all clear) when every gate is ✅; **WARN** when no hard gate fails (Gates 2/3/4/5 all ✅) and the Code review gate is not ❌, but at least one soft gate — Description vs. code or Code review — is ⚠️ (still a PASS verdict); **FAIL** when any of Gates 2/3/4/5 fails or the Code review gate is ❌.
 
 On PASS — all clear (every gate ✅):
-```
+
+```markdown
 ## PR Review — PR #<n> (<repo>)
 
 **Title**: <PR title>
@@ -818,7 +828,8 @@ On PASS — all clear (every gate ✅):
 ```
 
 On WARN — soft warnings only (hard Gates 2/3/4/5 ✅, at least one of Description vs. code / Code review is ⚠️, none ❌):
-```
+
+```markdown
 ## PR Review — PR #<n> (<repo>)
 
 **Title**: <PR title>
@@ -843,7 +854,8 @@ On WARN — soft warnings only (hard Gates 2/3/4/5 ✅, at least one of Descript
 ```
 
 On FAIL (any of Gates 2/3/4/5 fails, or Code review is ❌):
-```
+
+```markdown
 ## PR Review — PR #<n> (<repo>)
 
 **Title**: <PR title>
@@ -870,7 +882,8 @@ On FAIL (any of Gates 2/3/4/5 fails, or Code review is ❌):
 `FAILING_GATE_COUNT` counts only hard-failing gates — a ⚠️ row (Description vs. code or Code review) is never included, even when another gate is ❌.
 
 Both PASS and FAIL continue with:
-```
+
+```markdown
 ### Inline Findings Summary
 
 | #  | File:Line          | Category    | Conf | Anchor |
@@ -1004,7 +1017,7 @@ Pick the body by verdict, exactly as in Step 3 (see *Gate states*): **PASS** (al
 
 **On PASS** — all clear (every gate ✅):
 
-```
+```markdown
 <!-- PR_REVIEWER_REPORT -->
 PARTIAL_REVIEW_BANNER
 Reviewed your changes and found no issues ready for human review.
@@ -1049,7 +1062,7 @@ MEMORIES_SECTION
 
 **On WARN** — soft warnings only (hard Gates 2/3/4/5 ✅, at least one of Description vs. code / Code review is ⚠️, none ❌):
 
-```
+```markdown
 <!-- PR_REVIEWER_REPORT -->
 PARTIAL_REVIEW_BANNER
 No blocking issues — <WARN_GATE_COUNT> gate(s) flagged a warning; details below.
@@ -1094,7 +1107,7 @@ MEMORIES_SECTION
 
 **On FAIL** (any of Gates 2/3/4/5 fails, or Code review is ❌):
 
-```
+```markdown
 <!-- PR_REVIEWER_REPORT -->
 PARTIAL_REVIEW_BANNER
 Found <FAILING_GATE_COUNT> gate(s) that need attention before human review.
@@ -1141,7 +1154,7 @@ MEMORIES_SECTION
 placeholder entirely on a complete run — the line disappears and the body starts at the summary
 sentence. When the budget was exhausted, substitute exactly one line, followed by a blank line:
 
-```
+```markdown
 ⚠️ **Partial review — tool budget exhausted after \<N\> calls; \<M\> of \<T\> files scanned.**
 ```
 
@@ -1153,7 +1166,7 @@ both the terminal report and the review body.
 `OPTIMALITY_SECTION` renders the Step 2.4c proposals. Omit the placeholder entirely when there
 are no proposals — the quiet early-exit must stay quiet. Otherwise substitute:
 
-```
+```markdown
 <details>
 <summary>Optimality review (<OP>) — is this the best approach?</summary>
 
@@ -1184,7 +1197,7 @@ are **never** posted as inline comments and never affect the gate table or the v
 cleared every quality gate but did not fit the inline caps. Omit the placeholder entirely when
 `DEF == 0`; otherwise substitute:
 
-```
+```markdown
 <details>
 <summary>Additional findings (<DEF>) — cleared review, not inlined</summary>
 
@@ -1203,11 +1216,11 @@ applied-only list). It **always renders** — never omit the slot. `LOREKIT_CONN
 of the two shapes below it takes, so a reader always sees either both counts or an explicit
 `not connected`, not only when something fired.
 
-- **Connected** — a header line, followed (only when `MEMORIES_USED_COUNT > 0`) by one bullet per
+- **Connected** (`LOREKIT_CONNECTED=true` — the `mcp__lorekit__memory_list` attempt succeeded) — a header line, followed (only when `MEMORIES_USED_COUNT > 0`) by one bullet per
   entry in `APPLIED_MEMORIES[]` (Step 2.2), each a pressable LoreKit link so the reader can open the
   exact memory and see why a finding was dropped, downgraded, or promoted:
 
-  ```
+  ```text
   **Memories** — <MEMORIES_READ_COUNT> read · <MEMORIES_USED_COUNT> used
 
   - [`issue:missing-abort-signal`](<url>) — promoted, seen 3×
@@ -1215,7 +1228,8 @@ of the two shapes below it takes, so a reader always sees either both counts or 
   ```
 
   When `MEMORIES_USED_COUNT` is 0, render only the header line (`… read · 0 used`), no bullets.
-- **Not connected** (`memory.*` unreachable) — render exactly `**Memories** — not connected`, no bullets.
+- **Not connected** (`LOREKIT_CONNECTED=false` — the `mcp__lorekit__memory_list` tool call itself errored, or the tool is not in the agent's `tools:` grant) — render exactly `**Memories** — not connected`, no bullets.
+  This shape MUST NOT appear when the read was merely skipped or assumed; it only appears after a genuine failed attempt.
 
 `MEMORIES_READ_COUNT` (Step 1.0) is how many memories were loaded; `MEMORIES_USED_COUNT` =
 `|APPLIED_MEMORIES|`, how many actually fired (drops + downgrades + promotes). Read is always ≥
@@ -1306,7 +1320,7 @@ in the Step 5 report.
 
 After posting:
 
-```
+```text
 Posted review on PR #<n> — gate table + <N> inline comments.
 ```
 

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -58,7 +58,7 @@ No git remote → use `global` only.
 
 ### Key format
 
-```
+```text
 reviewer-comment-relevance::<category>:<claim-gist>
 ```
 
@@ -105,13 +105,17 @@ fixed in a later PR) are flagged as contradictions, not silently overwritten.
 Both `reviewer` (Step 0.7) and `pr-reviewer` (equivalent step before Step 1.1)
 read comment-relevance memories as part of their lesson-read fan-out.
 
-Add these two calls to the existing narrow-to-broad lesson read:
+Add these two calls to the existing narrow-to-broad lesson read.
+**This read is a mandatory attempt — issue it as a real `mcp__lorekit__memory_list` tool call, not documentation shorthand.**
+Only a real tool error (thrown exception, or tool not listed in the agent's `tools:` grant) may suppress the call; never infer "not connected" without attempting it.
+When this rule is applied inside a sub-agent, the sub-agent does NOT receive the SessionStart memory-load priming that the main session gets, so it MUST perform this read itself — never assume memories were pre-loaded.
 
-```
+```text
 # Narrow-to-broad fan-out — repo-specific wins over global on conflict.
-# Silent no-op if memory.* not connected.
-memory.list { scope: "repo::{owner}/{repo}", tags: ["loop::reviewer-comment-relevance"], limit: 50 }
-memory.list { scope: "global",               tags: ["loop::reviewer-comment-relevance"], limit: 50 }
+# Issue each line as a real mcp__lorekit__memory_list tool call.
+# If the call itself errors, treat the backend as not connected for this run.
+mcp__lorekit__memory_list: scope="repo::{owner}/{repo}" tags=["loop::reviewer-comment-relevance"] limit=50
+mcp__lorekit__memory_list: scope="global"               tags=["loop::reviewer-comment-relevance"] limit=50
 ```
 
 Merge both lists (`repo::` wins on key collision).
@@ -163,14 +167,15 @@ influence the review. `APPLIED_MEMORIES[]` is what the report links (see
 
 Log all applied memories in a `Relevance memory` row in the Quality Gate summary:
 
-```
+```text
 Relevance-memory drops:      <D>  (not-relevant, seen ≥ 3)
 Relevance-memory downgrades: <DG> (not-relevant, seen 1–2)
 Relevance-memory promotes:   <P>  (relevant, seen ≥ 2)
 ```
 
 Announce active suppression memories in one line before the review pipeline runs:
-```
+
+```text
 Relevance memories active: 3 suppressions, 1 promotion (repo:mthines/console)
 ```
 So the user knows the pipeline has been influenced.
@@ -352,7 +357,7 @@ regardless of what Phase 4 decided for that comment.
 
 Write the memory:
 
-```
+```text
 # Classify scope: almost always repo-specific.
 # Universal pattern (e.g. "defensive null-checks are always over-flagged"
 # regardless of codebase) → global; anything citing a repo-specific
@@ -399,7 +404,7 @@ When a `fingerprint` accumulates **≥ 3 concordant `not-relevant`** records
 
 Surface a one-line suggestion — never act silently:
 
-```
+```text
 Relevance memory "<fingerprint>" has been suppressed 3+ times in <repo>.
 Promote to a permanent repo filter?  Consider adding to .github/review.yaml:
   filters:
@@ -410,7 +415,7 @@ Promote to a permanent repo filter?  Consider adding to .github/review.yaml:
 When a `fingerprint` accumulates **≥ 3 concordant `relevant`** records, it is
 **reinforcement-eligible**:
 
-```
+```text
 Relevance memory "<fingerprint>" has been resolved 3+ times in <repo>.
 Pattern reliably gets fixed — confidence threshold can be lowered for this class.
 ```

--- a/agents/shared/rules/prior-comment-awareness.md
+++ b/agents/shared/rules/prior-comment-awareness.md
@@ -67,7 +67,7 @@ The `± 2` tolerance handles minor line-number drift from the author's subsequen
 
 Log dedup drops:
 
-```
+```text
 [prior-comment] DROP src/foo.ts:42 — suggestion: already posted in prior review (comment #12345)
 ```
 
@@ -98,7 +98,7 @@ The agent must evaluate: "Does my new finding contradict a prior finding that wa
 If yes → **DROP** the new finding unconditionally.
 Log the drop:
 
-```
+```text
 [anti-flip-flop] DROP src/foo.ts:55 — new suggestion contradicts resolved prior comment #12345 (previously suggested `Map`, author applied it; now re-suggesting `Record`)
 ```
 
@@ -117,6 +117,14 @@ The finding may be surfaced in the terminal output for human review, but it is n
 | Author replied with acknowledgement text | Yes |
 | Author replied with disagreement / explanation and no fix | **No** — the author challenged the finding; re-flagging in a later pass is allowed |
 | 👎 reaction by the author | **No** — dismissal means the finding was wrong, not accepted; the noise lesson fires, but re-flagging is not prevented (the agent should have dropped it originally, and the outcome-learning loop handles that) |
+
+---
+
+## Sub-agent re-runs
+
+When this rule executes inside a sub-agent (e.g., a review dispatched by an orchestrator), the sub-agent does NOT receive the SessionStart memory-load priming that the main session gets.
+The sub-agent MUST therefore perform the Step 1.0 memory read itself — never assume the relevance and lesson memories were pre-loaded.
+The companion relevance-memory read (see `comment-relevance-memory.md § Read`) is a mandatory real `mcp__lorekit__memory_list` tool call; treat a thrown tool error as "not connected" for this run, but never infer disconnection without attempting the call.
 
 ---
 
@@ -159,7 +167,7 @@ A finding can therefore be deferred across several incremental runs, but it can 
 
 The Quality Gate summary adds three rows:
 
-```
+```text
 Prior-comment dedup drops: N  (already said in a prior review pass)
 Anti-flip-flop drops:      M  (would contradict a resolved prior suggestion)
 Carried forward:           K  (deferred by a prior incremental run, re-admitted)

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -588,9 +588,15 @@ function checksInSync(plan, checks) {
     const crm = read("agents/shared/rules/comment-relevance-memory.md");
     const pca = read("agents/shared/rules/prior-comment-awareness.md");
 
-    // G18a: pr-reviewer.md names the real mcp__lorekit__memory_list tool at the Step 1.0 read.
-    s.check("G18a pr-reviewer.md names mcp__lorekit__memory_list at the Step 1.0 read fan-out",
-      prReviewer.includes("mcp__lorekit__memory_list"));
+    // G18a: pr-reviewer.md issues the Step 1.0 read as a real mcp__lorekit__memory_list call.
+    // A bare includes("mcp__lorekit__memory_list") is tautological here: the base file already
+    // matches it once, in the `tools:` frontmatter (line 4), so it asserts nothing about the new
+    // Step 1.0 fan-out. Same shape as the G17c/G17e fixes above — assert a literal sentence from
+    // the rewritten block plus an occurrence floor the base revision cannot reach.
+    const memoryListMentions = prReviewer.split("mcp__lorekit__memory_list").length - 1;
+    s.check("G18a pr-reviewer.md issues the Step 1.0 read as a real mcp__lorekit__memory_list call (literal sentence + >= 5 mentions)",
+      prReviewer.includes("Issue each line below as a real `mcp__lorekit__memory_list` tool call — these are not documentation shorthand.") &&
+      memoryListMentions >= 5);
 
     // G18b: comment-relevance-memory.md names the real mcp__lorekit__memory_list tool at the read.
     s.check("G18b comment-relevance-memory.md names mcp__lorekit__memory_list at the read call site",

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -579,6 +579,46 @@ function checksInSync(plan, checks) {
     s.check("G17h README.md mentions standards-conformance + --no-standards in pr-reviewer context",
       readme.includes("standards-conformance") && readme.includes("--no-standards"));
   }
+
+  // G18: the pr-reviewer memory-read call sites name the real mcp__lorekit__memory_list
+  // tool and state a mandatory-attempt policy; the shared read rules mirror the same.
+  // Mirrors the G16/G17 guard shape — reads the REAL shipped files and asserts literal anchors.
+  // Never re-encode expected prose inside the eval (aw-lessons::mock-that-reimplements-the-thing-under-test).
+  {
+    const crm = read("agents/shared/rules/comment-relevance-memory.md");
+    const pca = read("agents/shared/rules/prior-comment-awareness.md");
+
+    // G18a: pr-reviewer.md names the real mcp__lorekit__memory_list tool at the Step 1.0 read.
+    s.check("G18a pr-reviewer.md names mcp__lorekit__memory_list at the Step 1.0 read fan-out",
+      prReviewer.includes("mcp__lorekit__memory_list"));
+
+    // G18b: comment-relevance-memory.md names the real mcp__lorekit__memory_list tool at the read.
+    s.check("G18b comment-relevance-memory.md names mcp__lorekit__memory_list at the read call site",
+      crm.includes("mcp__lorekit__memory_list"));
+
+    // G18c: pr-reviewer.md states a mandatory-attempt policy (the word "mandatory" near the read).
+    s.check("G18c pr-reviewer.md states mandatory-attempt policy at the Step 1.0 read",
+      /mandatory attempt/i.test(prReviewer));
+
+    // G18d: comment-relevance-memory.md states a mandatory-attempt policy.
+    s.check("G18d comment-relevance-memory.md states mandatory-attempt policy at the read",
+      /mandatory attempt/i.test(crm));
+
+    // G18e: pr-reviewer.md carries the sub-agent + SessionStart priming statement.
+    s.check("G18e pr-reviewer.md states sub-agent SessionStart priming caveat",
+      prReviewer.includes("sub-agent") && prReviewer.includes("SessionStart"));
+
+    // G18f: at least one shared rule carries the sub-agent + SessionStart statement
+    //       (comment-relevance-memory.md or prior-comment-awareness.md).
+    s.check("G18f at least one shared rule states sub-agent SessionStart priming caveat",
+      (crm.includes("sub-agent") && crm.includes("SessionStart")) ||
+      (pca.includes("sub-agent") && pca.includes("SessionStart")));
+
+    // G18g: scope/tag regression lock — the existing read semantics are unchanged.
+    //       Both repo:: and the loop::reviewer-comment-relevance tag still appear.
+    s.check("G18g comment-relevance-memory.md still carries repo:: and loop::reviewer-comment-relevance",
+      crm.includes("repo::") && crm.includes("loop::reviewer-comment-relevance"));
+  }
 }
 
 process.exit(s.report() ? 0 : 1);


### PR DESCRIPTION
## Why

The `pr-reviewer` agent was reporting "Memories — not connected" even when LoreKit was fully connected and a *write* on the same run had succeeded (confirmed in dash0 PR #16285: 0 read calls, 1 successful write call). The read call sites used pseudo-syntax shorthand (`memory.list {…}`) that sub-agents read as documentation, and a "silent no-op if not connected" escape hatch let the agent declare disconnection without ever attempting a call. Sub-agents also don't receive the SessionStart memory-load priming the main session gets, so there was no ambient signal that memories existed.

## What changed

- Rewrites every memory-read call site in `pr-reviewer.md`, `comment-relevance-memory.md`, and `prior-comment-awareness.md` to name the real `mcp__lorekit__memory_list` tool explicitly.
- Makes the read a **mandatory attempt**: only a real tool error may set `LOREKIT_CONNECTED=false` and render "not connected"; skipping the call is no longer valid.
- Adds an explicit sub-agent/SessionStart priming statement so sub-agent reviews know to perform their own Step 1.0 read.
- Adds G18 L1 eval guard (7 sub-checks) reading the real shipped files; L1 is now 163/163.
- Fixes all pre-existing bare code fences in the three edited markdown files.

## How to verify

```bash
node scripts/eval/l1.mjs   # should print 163/163
```

After CI green: run `pr-reviewer` on this PR itself and check the posted "Review diagnostics → Memories" line — it should show `Memories — N read · M used`, not "not connected".

## Follow-up (out of scope for this PR)

The same pseudo-syntax pattern affects `agents/reviewer.md` Step 0.7, `agents/shared/rules/review-outcomes.md`, and loop `self-improvement-loop.md` files. These carry the same latent instruction-adherence bug but are kept for a follow-up PR to keep this diff reviewable.