### PR TITLE
workflow(aw): sanction single-context Full run when sub-agent dispatch is unavailable

### DIFF
--- a/skills/workflow/autonomous-workflow/CLAUDE.md
+++ b/skills/workflow/autonomous-workflow/CLAUDE.md
@@ -393,7 +393,12 @@ When editing this skill, do not break these — they're load-bearing:
 - **`aw` is a thin, opt-in router.** It detects the tier and routes (single-pass
   for Micro/Lite, planner→executor for Full) and owns the universal lessons loop.
   It must not accrue domain knowledge, must not force Full on light tasks, and
-  must not silently wrap casual edits. The planner/executor split is Full-only.
+  must not silently wrap casual edits. The planner/executor split is Full-only —
+  **except** when the harness disables sub-agent dispatch (`Task`), where `aw`
+  runs the Full phases single-context (planner + executor roles in one window)
+  rather than downgrading to Lite. That fallback preserves the `plan.md` artifact
+  and the `confidence(plan)` gate; it is the one place `aw` uses `Edit`/`Write` on
+  a Full task, and it must never be used to sidestep an *available* split.
 - **Episodic lessons are advisory-only.** An `aw-lessons` lesson biases the plan
   but never silently changes a gate, skips a phase, or alters a cap. The only
   path from a lesson to changed behavior is a confidence-gated, user-approved
@@ -530,6 +535,12 @@ Design rules that keep this from rotting:
   Full (loses the documented context-isolation win), and do not route Micro/Lite
   through the split (pure handoff overhead). The two specialist agents remain
   the Full-tier realization; `aw` is the router + Micro/Lite single-pass runner.
+  **The single-context Full fallback is the sole exception**, and only when the
+  split is *structurally* unavailable (the harness disables `Task`, e.g. Claude
+  Code on the web): there `aw` plays both roles in one window, keeping the
+  `plan.md` artifact + `confidence(plan)` gate but conceding context isolation
+  (which the harness has already made impossible). It is never a license to skip
+  an available split — the check is "can I dispatch?", not "do I feel like it?".
 - **Micro reuses the Lite phase path.** Micro is a routing tier, not a fourth
   set of phase rules — it follows Lite's phase behavior with planning and quality
   companions skipped. This keeps the phase rules from needing a third column.
@@ -714,8 +725,14 @@ they must be exercised live (markdown can't prove them). Run this after editing
 3. **Full routing (nested dispatch — the R1 risk):** invoke `@aw` on a 4-file /
    architectural task. Expect: `Tier: Full`, then `aw` **dispatches `aw-planner`**
    (a gated `plan.md` appears), then **`aw-executor`**. If the harness refuses
-   nested sub-agent dispatch, `aw` must fall back to telling you to run them —
-   confirm it does **not** silently downgrade to single-pass.
+   nested sub-agent dispatch (e.g. Claude Code on the web, where `Task` is
+   disabled), `aw` must run the **single-context Full** fallback: play the planner
+   role in-context to produce a gated `plan.md` + `checks.yaml`, clear
+   `confidence(plan) ≥ 90%`, then play the executor role through Phases 3–7 — all
+   in the one window. Confirm it produces `plan.md` and clears the gate, and that
+   it does **not** silently downgrade to the Lite/Micro single-pass path (no plan,
+   no gate). Only when `Edit`/`Write`/`Bash` are *also* unavailable should it fall
+   back to telling you to run the two agents yourself.
 4. **Universal loop + two-scope writes (the R2 risk):** run two checks against
    LoreKit (`memory.search { q, scopes: ["repo::{owner}/*", "global"], tags: ["loop::aw-lessons"] }` to inspect).
    - **Universal lesson:** after a run where the lesson is generic (e.g. trigger-context like `*.tsx` or `monorepo refactor`), confirm the lesson was written to the **`global`** scope (tag `loop::aw-lessons`) and NOT to `repo::{owner}/{repo}`. If it landed in the repo scope, the classifier mis-routed a universal lesson.
@@ -746,6 +763,31 @@ end-user-facing; this file is contributor-facing.
 ---
 
 ## History
+
+- **v3.19.0** — Single-context Full fallback for harnesses without sub-agent
+  dispatch (e.g. Claude Code on the web, where `Task` is disabled). Before this,
+  `aw`'s Full-tier fallback was under-specified and self-contradictory: the
+  dispatch section said "invoke them yourself if your tools permit" while the Hard
+  rules forbade `aw` from ever using `Edit`/`Write` on a Full task, so an `aw` run
+  in the cloud env hit `Failed to run agent` and had to improvise a justification
+  before doing the work in-context. This makes that emergent behavior the
+  **sanctioned, reproducible path**: when the split is *structurally* unavailable,
+  `aw` runs the Full phases in one window — playing the planner role (Phases 0–2,
+  producing `plan.md` + `checks.yaml`, clearing `confidence(plan) ≥ 90%`) then the
+  executor role (Phases 3–7). It preserves the plan artifact and the confidence
+  gate — the two load-bearing wins of the split — and concedes only context
+  isolation, which the harness has already made impossible. It is explicitly
+  **not** a downgrade to Lite/Micro single-pass, and never a license to skip an
+  *available* split (the guard is "can I dispatch?", not preference). The "tell the
+  user to run the agents themselves" text is demoted to a last resort for when
+  `Edit`/`Write`/`Bash` are *also* unavailable. Coupled surfaces updated in
+  lockstep: `templates/aw.agent.md` (Full-tier dispatch section + the
+  `Edit`/`Write` Hard rule now conditions on dispatch availability), and this
+  file's thin-router invariant, split-is-Full-only design-intent invariant, and
+  the `aw` dispatcher smoke test (step 3 now exercises the single-context path).
+  Deliberately NOT changed: the tier-detection table (L1 Check B keeps it
+  byte-identical to `SKILL.md` Step 1), the preferred dispatch-the-split path when
+  `Task` is available, and every `checks.yaml` / `confidence(plan)` integrity rule.
 
 - **v3.18.0** — Artifact lightening: checks-primary, lean plan, opt-in snapshots.
   Rebalanced the Full-Mode artifacts around the two-jobs distinction above

--- a/skills/workflow/autonomous-workflow/CLAUDE.md
+++ b/skills/workflow/autonomous-workflow/CLAUDE.md
@@ -781,10 +781,14 @@ end-user-facing; this file is contributor-facing.
   *available* split (the guard is "can I dispatch?", not preference). The "tell the
   user to run the agents themselves" text is demoted to a last resort for when
   `Edit`/`Write`/`Bash` are *also* unavailable. Coupled surfaces updated in
-  lockstep: `templates/aw.agent.md` (Full-tier dispatch section + the
-  `Edit`/`Write` Hard rule now conditions on dispatch availability), and this
-  file's thin-router invariant, split-is-Full-only design-intent invariant, and
-  the `aw` dispatcher smoke test (step 3 now exercises the single-context path).
+  lockstep: `templates/aw.agent.md` (Full-tier dispatch section, the Routing
+  table's Full row, and the `Edit`/`Write` Hard rule — all three now condition on
+  dispatch availability), `templates/routing.rule.md` (dispatch-unavailable branch
+  pointing at that section), `SKILL.md` (v3.19.0; the Templates section states the
+  single-context Full fallback and links the agent definition for the procedure),
+  and this file's thin-router invariant, split-is-Full-only design-intent
+  invariant, and the `aw` dispatcher smoke test (step 3 now exercises the
+  single-context path).
   Deliberately NOT changed: the tier-detection table (L1 Check B keeps it
   byte-identical to `SKILL.md` Step 1), the preferred dispatch-the-split path when
   `Task` is available, and every `checks.yaml` / `confidence(plan)` integrity rule.

--- a/skills/workflow/autonomous-workflow/SKILL.md
+++ b/skills/workflow/autonomous-workflow/SKILL.md
@@ -311,6 +311,17 @@ automatically; borderline plans pause for user approval. The design rationale
 the full handoff contract is in
 [`rules/planner-executor-handoff.md`](./rules/planner-executor-handoff.md).
 
+**When the harness disables sub-agent dispatch** (no `Task` tool — e.g. Claude
+Code on the web), the split is structurally unavailable and Full does **not**
+drop to the Micro/Lite single-pass path. `aw` runs a **single-context Full**
+instead: it plays the planner role (Phases 0–2, producing `plan.md` +
+`checks.yaml` and clearing `confidence(plan) ≥ 90%`) then the executor role
+(Phases 3–7) in one window, preserving the plan artifact and the confidence gate
+and conceding only context isolation. The step-by-step procedure — and the rule
+that this is never a licence to skip an *available* split — lives in
+[`templates/aw.agent.md`](./templates/aw.agent.md) under "When sub-agent dispatch
+is unavailable".
+
 **UI verification prerequisite:** run `/aw-setup` once per project before the
 first autonomous UI task. This scaffolds `.claude/aw-targets/local.yml` and
 validates it with a smoke spec. The planner halts and prompts if no aw-target

--- a/skills/workflow/autonomous-workflow/SKILL.md
+++ b/skills/workflow/autonomous-workflow/SKILL.md
@@ -13,7 +13,7 @@ argument-hint: '<task-description> [--no-confirm] [--critical]'
 license: MIT
 metadata:
   author: mthines
-  version: '3.18.0'
+  version: '3.19.0'
   workflow_type: orchestrator
   tags:
     - autonomous

--- a/skills/workflow/autonomous-workflow/templates/aw.agent.md
+++ b/skills/workflow/autonomous-workflow/templates/aw.agent.md
@@ -113,7 +113,7 @@ MODE SELECTION:
 | ---- | ----------- | ------------- | ---------- |
 | **Micro** | **You, single-pass.** Phase 0 (quick confirm) → Phase 2 (worktree) → edit → fast check → `docs update` only if docs drift → `create-pr`. Skip planning and all quality companions. | none | none (except docs-if-needed) |
 | **Lite** | **You, single-pass.** Run the Lite path from `SKILL.md` in this one context (brief mental plan, no `plan.md`); light companions per task signal. `confidence(plan)` does not run — the plan gate is Full-only because there is no `plan.md` to gate. | none | per signal (Phase 5 docs, Phase 6 create-pr always) |
-| **Full** | **Hand off to the split — dispatch only.** Dispatch `aw-planner` (it produces a gated `plan.md`), then on a cleared gate dispatch `aw-executor`. **Never** use `Edit`/`Write`/`Bash` to touch production code, tests, or docs yourself in this tier — that is `aw-executor`'s job. | `plan.md` | all applicable |
+| **Full** | **Hand off to the split — dispatch only, whenever sub-agent dispatch is available.** Dispatch `aw-planner` (it produces a gated `plan.md`), then on a cleared gate dispatch `aw-executor`. While the split is dispatchable, **never** use `Edit`/`Write`/`Bash` to touch production code, tests, or docs yourself in this tier — that is `aw-executor`'s job. When the harness disables `Task`, run the single-context Full fallback instead (see "When sub-agent dispatch is unavailable"), which keeps the `plan.md` artifact and the `confidence(plan)` gate. | `plan.md` | all applicable |
 
 **Why the split is Full-only:** the planner→executor handoff buys context
 isolation + a durable, resumable `plan.md` — documented wins for complex/long

--- a/skills/workflow/autonomous-workflow/templates/aw.agent.md
+++ b/skills/workflow/autonomous-workflow/templates/aw.agent.md
@@ -122,6 +122,8 @@ continuity is better *and* cheaper for Micro/Lite.
 
 ### Full-tier dispatch
 
+**Preferred path — dispatch the split (when sub-agent dispatch is available):**
+
 ```
 Task(subagent_type="aw-planner", prompt=<user request + the lessons you matched in step 2>)
 # wait for the planner's gated handoff (confidence(plan) ≥ 90% or user-approved)
@@ -132,10 +134,41 @@ Pass the matched lessons to the planner so it folds them into `plan.md` under
 `## Lessons applied` — that is the Full-tier specialization of the read; you do
 not need to re-read per phase.
 
-If the harness does not allow you to dispatch sub-agents, fall back to telling
-the user to run `aw-planner` then `aw-executor` (or invoke them yourself if your
-tools permit). Never silently downgrade a Full task to single-pass to avoid the
-handoff.
+#### When sub-agent dispatch is unavailable (e.g. Claude Code on the web)
+
+Some harnesses disable the `Task` tool, so the dispatch above fails outright
+(`Failed to run agent`). This is a **structural** unavailability of the split,
+**not** a signal to abandon the task or to quietly drop to the Lite/Micro
+single-pass path (which would throw away the `plan.md` artifact and the
+`confidence(plan)` gate). Instead, run the Full tier **in your own context**,
+playing the planner then the executor role sequentially — a **single-context
+Full run**. Follow the same phase rules the two agents follow; do not invent a
+new procedure:
+
+1. **Planner role (phases 0–2).** Run Phase 0 validation, Phase 1 planning (with
+   its companions), create the worktree (Phase 2), and produce
+   `.agent/{branch}/plan.md` + `checks.yaml` via `Skill("aw-create-plan")`, folding
+   in the lessons you matched at step 2. **Clear the `confidence(plan) ≥ 90%` gate
+   before writing any production code** — the gate is load-bearing and is NOT
+   waived by the missing split. Below the gate, follow the same
+   iterate-or-escalate flow the planner would.
+2. **Executor role (phases 3–7).** Read the plan, implement against `checks.yaml`,
+   run the Phase 4 executable-checks loop (same mode-aware stuck-loop cap), update
+   docs, open the draft PR, and watch CI.
+
+This preserves everything the split buys **except context isolation** (both roles
+share one window) — which is precisely the part the harness has made impossible.
+The `plan.md` handoff artifact and the `confidence(plan)` gate are fully preserved,
+so this is *not* a downgrade. Log one line to the plan's Progress Log so the
+fallback is auditable:
+
+```markdown
+- [TIMESTAMP] aw: sub-agent dispatch unavailable — running Full tier single-context (planner + executor roles in one window). Plan artifact + confidence gate preserved.
+```
+
+Only if you **also** lack `Edit`/`Write`/`Bash` (you cannot execute at all) fall
+back to telling the user to run `aw-planner` then `aw-executor` themselves. Never
+silently downgrade a Full task to single-pass to avoid the handoff.
 
 ## Self-improvement loop (you own it)
 
@@ -183,11 +216,16 @@ Autonomous writes skip consent, never the privacy pre-flight (no secrets / PII i
 
 - **Stay thin.** You route + own the loop. Do not duplicate planning/coding
   knowledge here — it lives in the skill, companions, planner, and executor.
-- **Your `Edit`/`Write`/`Bash` budget is for Micro/Lite single-pass execution
-  only.** In the **Full** tier you dispatch and never edit source yourself. If
-  you catch yourself reaching for `Edit`/`Write` on a Full task, stop — that work
-  belongs to `aw-executor`. (This is the same instruction-based discipline
-  `aw-planner` follows; respect it.)
+- **Your `Edit`/`Write`/`Bash` budget is for Micro/Lite single-pass execution —
+  *and* for the single-context Full fallback when the harness disables `Task`.**
+  In the **Full** tier you normally dispatch and never edit source yourself; while
+  the split is dispatchable, if you catch yourself reaching for `Edit`/`Write` on a
+  Full task, stop — that work belongs to `aw-executor`. (This is the same
+  instruction-based discipline `aw-planner` follows; respect it.) **The one
+  sanctioned exception is the single-context Full run** (see "When sub-agent
+  dispatch is unavailable"): when dispatch is structurally impossible, running the
+  Full phases yourself — plan artifact and `confidence(plan)` gate intact — is the
+  correct path, not a violation of this rule.
 - **Opt-in, not a wrapper.** You run because the user phrased autonomous work or
   invoked `@aw`. Do not engage on simple questions, reviews, or interactive
   coding the user is actively steering.

--- a/skills/workflow/autonomous-workflow/templates/routing.rule.md
+++ b/skills/workflow/autonomous-workflow/templates/routing.rule.md
@@ -31,6 +31,21 @@ off to `aw-planner` → `aw-executor`. This replaces the old "dispatch the plann
 first" rule — routing through `aw` fixes the case where a Lite task (which has
 no `plan.md`) was sent to the planner anyway.
 
+**If sub-agent dispatch is unavailable (e.g. Claude Code on the web, where the
+`Task` tool is disabled)** you cannot dispatch `aw` as a sub-agent. Do not drop
+the request — load the workflow and play the dispatcher role yourself in-context:
+
+```
+Skill("autonomous-workflow")
+```
+
+Then follow its tier detection and route. Micro/Lite run single-pass as usual;
+for **Full**, run the **single-context Full** path (planner role → gated `plan.md`
++ `checks.yaml` → executor role through Phases 3–7 in the one window), exactly as
+the `aw` agent's "When sub-agent dispatch is unavailable" section prescribes. This
+keeps the plan artifact and the `confidence(plan)` gate; it is not a downgrade to
+Lite.
+
 You may also dispatch `aw-planner` / `aw-executor` directly when you already know
 the task is Full and want to skip tier detection.
 

--- a/skills/workflow/autonomous-workflow/templates/routing.rule.md
+++ b/skills/workflow/autonomous-workflow/templates/routing.rule.md
@@ -44,11 +44,10 @@ for **Full**, run the **single-context Full** path (planner role → gated `plan
 + `checks.yaml` → executor role through Phases 3–7 in the one window). This keeps
 the plan artifact and the `confidence(plan)` gate; it is not a downgrade to Lite.
 
-> `SKILL.md` is a thin index and describes only the preferred Full routing (hand
-> off to `aw-planner` → `aw-executor`). The single-context Full procedure it
-> points at lives in the `aw` agent definition (`templates/aw.agent.md`), section
-> **"When sub-agent dispatch is unavailable"** — read that section, not `SKILL.md`,
-> for the step-by-step fallback.
+> `SKILL.md` is a thin index: it summarises the single-context Full fallback and
+> points onward for the detail. The step-by-step procedure lives in the `aw` agent
+> definition (`templates/aw.agent.md`), section **"When sub-agent dispatch is
+> unavailable"** — read that section for the phase-by-phase fallback.
 
 You may also dispatch `aw-planner` / `aw-executor` directly when you already know
 the task is Full and want to skip tier detection.

--- a/skills/workflow/autonomous-workflow/templates/routing.rule.md
+++ b/skills/workflow/autonomous-workflow/templates/routing.rule.md
@@ -41,10 +41,14 @@ Skill("autonomous-workflow")
 
 Then follow its tier detection and route. Micro/Lite run single-pass as usual;
 for **Full**, run the **single-context Full** path (planner role → gated `plan.md`
-+ `checks.yaml` → executor role through Phases 3–7 in the one window), exactly as
-the `aw` agent's "When sub-agent dispatch is unavailable" section prescribes. This
-keeps the plan artifact and the `confidence(plan)` gate; it is not a downgrade to
-Lite.
++ `checks.yaml` → executor role through Phases 3–7 in the one window). This keeps
+the plan artifact and the `confidence(plan)` gate; it is not a downgrade to Lite.
+
+> `SKILL.md` is a thin index and describes only the preferred Full routing (hand
+> off to `aw-planner` → `aw-executor`). The single-context Full procedure it
+> points at lives in the `aw` agent definition (`templates/aw.agent.md`), section
+> **"When sub-agent dispatch is unavailable"** — read that section, not `SKILL.md`,
+> for the step-by-step fallback.
 
 You may also dispatch `aw-planner` / `aw-executor` directly when you already know
 the task is Full and want to skip tier detection.


### PR DESCRIPTION
In harnesses that disable the Task tool (e.g. Claude Code on the web), the aw
dispatcher cannot hand a Full-tier task off to aw-planner -> aw-executor. The old
fallback was under-specified and self-contradictory: the dispatch section said
"invoke them yourself if your tools permit" while the Hard rules forbade aw from
ever using Edit/Write on a Full task, so an aw run in the cloud env hit
"Failed to run agent" and had to improvise a justification before proceeding.

Make the emergent behavior the sanctioned, reproducible path: when the split is
structurally unavailable, aw runs the Full phases in one window -- planner role
(Phases 0-2, plan.md + checks.yaml, clearing confidence(plan) >= 90%) then
executor role (Phases 3-7). This preserves the plan artifact and the confidence
gate (the two load-bearing wins of the split) and concedes only context
isolation, which the harness has already made impossible. It is explicitly not a
downgrade to Lite/Micro single-pass, and never a license to skip an available
split. The "tell the user to run the agents themselves" text is demoted to a
last resort for when Edit/Write/Bash are also unavailable.

Four files change:

- aw.agent.md: rewrite the Full-tier dispatch fallback; condition the
  Edit/Write/Bash Hard rule on dispatch availability; condition the Routing
  table's Full row the same way, so the summary table no longer states an
  unconditional "dispatch only" / "Never use Edit/Write/Bash in this tier".
- routing.rule.md: matching outer-layer fallback -- when the main session cannot
  dispatch aw, load the workflow and play the dispatcher role in-context -- plus
  a pointer to the aw agent definition for the step-by-step procedure.
- SKILL.md: version 3.18.0 -> 3.19.0, and the Templates section now states the
  single-context Full fallback and links templates/aw.agent.md for the
  procedure. Without this, a reader following the routing rule's own
  "Skill(autonomous-workflow)" instruction landed on a document that described
  the split as the only Full route.
- CLAUDE.md: update the thin-router invariant, the split-is-Full-only
  design-intent invariant, the smoke test (step 3), and add a v3.19.0 history
  entry enumerating all four coupled surfaces.

Tier-detection table unchanged (L1 Check B keeps it byte-identical to SKILL.md
Step 1); checks.yaml / confidence(plan) integrity rules unchanged. L1: 171/171.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HFbsywyxg9JDS53F5Nvwbw
