### PR TITLE
Rename pr-reviewer accordion to "Review details" and move commit line inside it

### DIFF
--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: pr-reviewer
-description: Code reviewer for GitHub PRs — both own PRs (self-relation) and someone else's PRs (cross-relation). Runs a structured pre-merge gate check (description vs. code, CI status, unresolved bot feedback, self-review signals, documentation adequacy) then a thorough multi-lens AI persona review (correctness/logic, quality/maintainability, description accuracy, external integration verifier). Incrementally aware — on repeated runs it detects a prior review, computes only the delta since the last reviewed SHA, and chooses a run mode (full / incremental / incremental-quick) so commit-by-commit re-runs stay fast. Posts a single consolidated GitHub review — a concise headline plus inline findings (gate-status table tucked inside a Review diagnostics accordion) — directly as a visible COMMENT event; no draft/pending workflow. Uses Lorekit relevance memories to suppress recurring noise patterns per repository. Default-on standards-conformance lens (Step 2.4d) enforces the repo's own governing docs (CLAUDE.md, AGENTS.md, .claude/rules/*.md, review-config .github/review.yaml standards:) as real findings — skip with --no-standards. Imports rules from `agents/shared/rules/` and owns its own rules under `agents/pr-reviewer/rules/`. Trigger via slash `/pr-review <PR-URL|#n>` or by dispatching this agent through the Task tool (`Task(subagent_type="pr-reviewer", prompt="<PR-URL> [--critical] [--full] [--with <lens1>,<lens2>,<lens3>] [--no-holistic] [--no-escalate] [--no-optimize] [--no-standards] [--skip-gates]")`). It is an agent, not a skill — `Skill("pr-reviewer", …)` errors with `Unknown skill`.
+description: Code reviewer for GitHub PRs — both own PRs (self-relation) and someone else's PRs (cross-relation). Runs a structured pre-merge gate check (description vs. code, CI status, unresolved bot feedback, self-review signals, documentation adequacy) then a thorough multi-lens AI persona review (correctness/logic, quality/maintainability, description accuracy, external integration verifier). Incrementally aware — on repeated runs it detects a prior review, computes only the delta since the last reviewed SHA, and chooses a run mode (full / incremental / incremental-quick) so commit-by-commit re-runs stay fast. Posts a single consolidated GitHub review — a concise headline plus inline findings (gate-status table tucked inside a Review details accordion) — directly as a visible COMMENT event; no draft/pending workflow. Uses Lorekit relevance memories to suppress recurring noise patterns per repository. Default-on standards-conformance lens (Step 2.4d) enforces the repo's own governing docs (CLAUDE.md, AGENTS.md, .claude/rules/*.md, review-config .github/review.yaml standards:) as real findings — skip with --no-standards. Imports rules from `agents/shared/rules/` and owns its own rules under `agents/pr-reviewer/rules/`. Trigger via slash `/pr-review <PR-URL|#n>` or by dispatching this agent through the Task tool (`Task(subagent_type="pr-reviewer", prompt="<PR-URL> [--critical] [--full] [--with <lens1>,<lens2>,<lens3>] [--no-holistic] [--no-escalate] [--no-optimize] [--no-standards] [--skip-gates]")`). It is an agent, not a skill — `Skill("pr-reviewer", …)` errors with `Unknown skill`.
 tools: Read, Write, Edit, Bash, Glob, Grep, Skill, mcp__lorekit__memory_list, mcp__lorekit__memory_search, mcp__lorekit__memory_read, mcp__lorekit__memory_write
 model: opus
 ---
@@ -8,7 +8,7 @@ model: opus
 # pr-reviewer Agent — Pre-Merge Gate + Thorough Inline Review
 
 You author a single consolidated GitHub review for a GitHub PR: a concise headline
-in the review body (gate-status table inside a Review diagnostics accordion), plus
+in the review body (gate-status table inside a Review details accordion), plus
 short, grounded, confidence-gated inline comments.
 The review is posted directly as a visible comment — no pending draft flow.
 
@@ -323,7 +323,7 @@ because its partner `MEMORIES_USED_COUNT` is `|APPLIED_MEMORIES|`, built at Step
 memories alone, and the two are rendered as a single `read · used` pair that must describe one
 population. Loaded `reviewer-lessons` are reported separately by the `<L> reviewer-lessons matched`
 announce line below.
-Both counters feed the Step 4 `Review diagnostics`
+Both counters feed the Step 4 `Review details`
 **Memories** line; the collapsed title headlines the **used** count (`MEMORIES_USED_COUNT`,
 computed at Step 2.2) — see *Review body format*.
 Announce the concrete resolved scope so the influence is visible at a glance, e.g.: `Memory scope: repo::<owner>/<repo> + global — <L> reviewer-lessons matched.`
@@ -1006,11 +1006,13 @@ Confirm the response contains `state: "COMMENTED"`.
 
 ### Review body format
 
-The `<sup>` footer line varies by run mode:
+The `<sup>` footer line varies by run mode. It renders **inside** the `Review details`
+accordion — the first line of the accordion body, immediately after the `<summary>` and before the
+gate table — not at the top level of the review body:
 - `full` mode: `<sup>Reviewed for commit \`HEAD_SHA\`.</sup>`
 - `incremental` or `incremental-quick`: `<sup>Incremental review for commit \`HEAD_SHA\` (delta since \`PRIOR_SHA_SHORT\`).</sup>`
 
-The diagnostics `<details>` block has the same structure on PASS, WARN, and FAIL, but each verdict
+The `Review details` `<details>` block has the same structure on PASS, WARN, and FAIL, but each verdict
 template embeds its **own** gate-table variant — PASS renders every gate ✅, WARN renders ✅/⚠️, and
 FAIL renders ✅/⚠️/❌. Use the table from the template matching the chosen verdict; a PASS (all-✅)
 table must never be rendered on a WARN or FAIL body. Fill in the actual values.
@@ -1028,14 +1030,14 @@ Pick the body by verdict, exactly as in Step 3 (see *Gate states*): **PASS** (al
 PARTIAL_REVIEW_BANNER
 Reviewed your changes — no issues found.
 
-<sup>FOOTER_LINE</sup>
-
 OPTIMALITY_SECTION
 
 ADDITIONAL_FINDINGS_SECTION
 
 <details>
-<summary>Review diagnosticsMEMORIES_USED_SUFFIX</summary>
+<summary>Review detailsMEMORIES_USED_SUFFIX</summary>
+
+<sup>FOOTER_LINE</sup>
 
 | Gate | Status | Details |
 |---|---|---|
@@ -1073,14 +1075,14 @@ MEMORIES_SECTION
 PARTIAL_REVIEW_BANNER
 Reviewed your changes — no blocking issues, **<WARN_GATE_COUNT> warning(s)**: <WARN_REASONS>.
 
-<sup>FOOTER_LINE</sup>
-
 OPTIMALITY_SECTION
 
 ADDITIONAL_FINDINGS_SECTION
 
 <details>
-<summary>Review diagnosticsMEMORIES_USED_SUFFIX</summary>
+<summary>Review detailsMEMORIES_USED_SUFFIX</summary>
+
+<sup>FOOTER_LINE</sup>
 
 | Gate | Status | Details |
 |---|---|---|
@@ -1118,14 +1120,14 @@ MEMORIES_SECTION
 PARTIAL_REVIEW_BANNER
 Reviewed your changes — **<SEVERITY_TALLY>** need attention before human review. Blocking: <FAIL_REASONS>.
 
-<sup>FOOTER_LINE</sup>
-
 OPTIMALITY_SECTION
 
 ADDITIONAL_FINDINGS_SECTION
 
 <details>
-<summary>Review diagnosticsMEMORIES_USED_SUFFIX</summary>
+<summary>Review detailsMEMORIES_USED_SUFFIX</summary>
+
+<sup>FOOTER_LINE</sup>
 
 | Gate | Status | Details |
 |---|---|---|
@@ -1253,7 +1255,7 @@ One line per deferred finding: path:line, prefix, the one-line body, and the con
 Sort by prefix priority, then descending confidence. This section is the reason a placement cap
 is allowed to exist — never drop a cleared finding instead of listing it here.
 
-`MEMORIES_SECTION` is the persistent memory block inside `Review diagnostics` (replacing the old
+`MEMORIES_SECTION` is the persistent memory block inside `Review details` (replacing the old
 applied-only list). It **always renders** — never omit the slot. `LOREKIT_CONNECTED` selects which
 of the two shapes below it takes, so a reader always sees either both counts or an explicit
 `not connected`, not only when something fired.
@@ -1284,14 +1286,14 @@ Build each `<url>` from the memory's retained `scope` + `key`, per
 `https://lorekit.io`), else a plain-text `` `<scope> · <key>` `` identifier — never a
 fabricated URL.
 
-`MEMORIES_USED_SUFFIX` is the tag appended to the `Review diagnostics` `<summary>` title so the
+`MEMORIES_USED_SUFFIX` is the tag appended to the `Review details` `<summary>` title so the
 collapsed label headlines how many memories **influenced** the review:
 - **Connected** — substitute ` (<MEMORIES_USED_COUNT> memories used)` — e.g.
-  `Review diagnostics (2 memories used)`. Use the singular `memory` at exactly 1; keep
+  `Review details (2 memories used)`. Use the singular `memory` at exactly 1; keep
   `(0 memories used)` when nothing fired.
-- **Not connected** — substitute nothing; the title stays the bare `Review diagnostics`.
+- **Not connected** — substitute nothing; the title stays the bare `Review details`.
 
-The gate-status table now lives **inside** the `Review diagnostics` `<details>` accordion (near
+The gate-status table now lives **inside** the `Review details` `<details>` accordion (near
 its top, immediately after the `<summary>` line and before `**Run mode**`), not at the top level
 of the review body.
 

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -251,7 +251,7 @@ The bullet count MUST equal the `used` count — the number of memories that fir
 downgrades + promotes). A mismatch means an applied memory was dropped from the list instead of
 linked. When nothing fired, render only the header line (`… · 0 used`). Which report surface renders
 this block is the consuming agent's contract — `pr-reviewer` renders it inside the posted review
-body's `Review diagnostics` block (Step 4), where the collapsed title also headlines the `used`
+body's `Review details` block (Step 4), where the collapsed title also headlines the `used`
 count.
 
 ---

--- a/agents/shared/rules/standards-conformance.md
+++ b/agents/shared/rules/standards-conformance.md
@@ -229,7 +229,7 @@ A silent run and a skipped run are different outcomes; without the block the rea
 them apart.
 A run that discovered governing docs and emitted 0 findings is healthy — most diffs conform.
 
-The `Review diagnostics` `<details>` block in Step 4 carries a standards diagnostics line on all
+The `Review details` `<details>` block in Step 4 carries a standards diagnostics line on all
 three bodies (PASS, WARN, FAIL):
 
 ```text

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -552,7 +552,7 @@ function checksInSync(plan, checks) {
       /narrative|aspirational/i.test(sc) &&
       (/path:line/i.test(sc) || /grounding/i.test(sc)));
 
-    // G17e: pr-reviewer.md has a standards diagnostics line in the Review diagnostics block
+    // G17e: pr-reviewer.md has a standards diagnostics line in the Review details block
     // AND the standards-specific precedence statement.
     // A bare /precedence|conflict/ sweep is tautological here: the base file already matches it
     // three times (Step 0.7's lesson-collision sentence, Gate 4's merge-conflict markers, and the
@@ -627,7 +627,7 @@ function checksInSync(plan, checks) {
   }
 
   // G19: the pr-reviewer posted review body uses a concise headline at the top level and the
-  // gate-status table lives only inside the Review diagnostics accordion.
+  // gate-status table lives only inside the Review details accordion.
   // Reads the REAL shipped agents/pr-reviewer.md — never re-encode expected strings as
   // a self-comparison (aw-lessons::mock-that-reimplements-the-thing-under-test).
   // Mirrors the G18 literal-sentence + positional-slice idiom.
@@ -645,8 +645,8 @@ function checksInSync(plan, checks) {
       prReviewer.includes("Blocking: <FAIL_REASONS>."));
 
     // G19d: in every Step-4 template block, every '| Gate | Status' line appears AFTER
-    // a '<summary>Review diagnostics' anchor — proving the table is inside the accordion,
-    // never between the <!-- PR_REVIEWER_REPORT --> marker and <sup>FOOTER_LINE</sup>.
+    // a '<summary>Review details' anchor — proving the table is inside the accordion,
+    // never at the top level between the <!-- PR_REVIEWER_REPORT --> marker and the accordion.
     // Slices only the Step-4 region (after '### Review body format', before
     // '### INLINE_COMMENTS_JSON format') to avoid false-matching the Step-3 terminal
     // tables at lines 818/844/870.
@@ -662,17 +662,17 @@ function checksInSync(plan, checks) {
       const blocks     = step4.split("<!-- PR_REVIEWER_REPORT -->").slice(1)
         .filter((b) => b.includes("Reviewed your changes"));
       // For each block: if a gate table row is present it must appear AFTER the
-      // '<summary>Review diagnostics' line (i.e. inside the accordion).
+      // '<summary>Review details' line (i.e. inside the accordion).
       let allTablesInsideAccordion = blocks.length >= 3;
       for (const b of blocks) {
         const gatePos = b.indexOf("| Gate | Status");
-        const diagPos = b.indexOf("<summary>Review diagnostics");
+        const diagPos = b.indexOf("<summary>Review details");
         // Gate table present but accordion comes after (or is absent) → table is at top level.
         if (gatePos !== -1 && (diagPos === -1 || gatePos < diagPos)) {
           allTablesInsideAccordion = false;
         }
       }
-      s.check("G19d pr-reviewer.md Step-4 gate tables all appear inside the Review diagnostics accordion (not at top level)",
+      s.check("G19d pr-reviewer.md Step-4 gate tables all appear inside the Review details accordion (not at top level)",
         allTablesInsideAccordion);
 
       // G19e: the review-body footer no longer carries the redundant CI-status sentence.
@@ -687,6 +687,24 @@ function checksInSync(plan, checks) {
       s.check("G19f pr-reviewer.md Step-4 gate table is 3-column with a static description on ✅",
         step4.includes("| Gate | Status | Details |") &&
         step4.includes("The multi-lens review found no blocking issues."));
+
+      // G19g: the '<sup>FOOTER_LINE</sup>' commit line renders INSIDE the accordion in every
+      // Step-4 template block — after the '<summary>Review details' line and before the gate
+      // table — never at the top level. Guards the requested move of the commit line into the
+      // Review details block. Per block: FOOTER_LINE must sit between the summary and the table.
+      let allFootersInsideAccordion = blocks.length >= 3;
+      for (const b of blocks) {
+        const diagPos   = b.indexOf("<summary>Review details");
+        const footerPos  = b.indexOf("<sup>FOOTER_LINE</sup>");
+        const gatePos   = b.indexOf("| Gate | Status");
+        // Footer must be present, after the accordion summary, and before the gate table.
+        if (footerPos === -1 || diagPos === -1 ||
+            footerPos < diagPos || (gatePos !== -1 && footerPos > gatePos)) {
+          allFootersInsideAccordion = false;
+        }
+      }
+      s.check("G19g pr-reviewer.md Step-4 commit footer (FOOTER_LINE) renders inside the Review details accordion",
+        allFootersInsideAccordion);
     }
   }
 }


### PR DESCRIPTION
Two presentation tweaks to the pr-reviewer agent's posted GitHub review body:

1. Rename the "Review diagnostics" accordion to "Review details" — the block
   holds the gate table, run mode, memories, quality tallies, integrations,
   optimality/standards summaries and skipped files, which reads more as
   details than diagnostics. Renamed across the frontmatter description, the
   intro, all three verdict templates (PASS/WARN/FAIL), and the supporting
   prose, plus the shared rules that reference it (standards-conformance.md,
   comment-relevance-memory.md) and the L1 eval anchor/comments.

2. Move the "Reviewed for commit <SHA>" footer (FOOTER_LINE) off the top level
   and into the accordion — first line of the accordion body, right after the
   <summary> and before the gate table — so the top level is just the headline.

Eval: renamed the G19d anchor to "<summary>Review details" and added G19g
locking the footer's new in-accordion position. 172/172 L1 checks pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PZrPdFZY4GD8ToChz3Yq84