### PR TITLE
feat(github-actions-author): add comment-trigger feedback rule

### DIFF
--- a/skills/delivery/github-actions-author/SKILL.md
+++ b/skills/delivery/github-actions-author/SKILL.md
@@ -114,9 +114,9 @@ Ask in **one** batched message:
    manual, or composite/reusable shared piece?
 2. **Trigger surface** — push, pull_request, schedule, workflow_dispatch,
    workflow_call, or a comment / slash command (`issue_comment`,
-   `pull_request_review_comment`)? Which branches? Which path globs (to
-   skip irrelevant runs)? Comment/manual triggers additionally require
-   reaction + status feedback — see
+   `pull_request_review_comment`, `pull_request_review`)? Which branches?
+   Which path globs (to skip irrelevant runs)? Comment-triggered runs
+   additionally require acknowledgement + outcome feedback — see
    [`rules/feedback.md`](./rules/feedback.md).
 3. **Stack** — Node (npm/yarn/pnpm/bun), Python (pip/uv/poetry), Go,
    Rust, Java/Gradle, Docker, mixed?
@@ -259,13 +259,14 @@ Drop-in starters in [`templates/`](./templates/):
    The log is the only thing `gh run view --log-failed` returns, and it is
    what agents act on. See
    [`rules/log-output-visibility.md`](./rules/log-output-visibility.md).
-10. **Comment/manual triggers must give feedback.** A workflow with no PR
-    status check (`issue_comment`, `pull_request_review_comment`, a
-    comment-driven `workflow_dispatch`) is invisible. Acknowledge with a
-    👀 reaction as the **first** step, then report the outcome on **both**
-    paths — a 🚀/👍 reaction on success, a 👎 reaction plus a comment
-    linking the run on failure. See
-    [`rules/feedback.md`](./rules/feedback.md).
+10. **Comment-triggered runs must give feedback.** A workflow with no PR
+    status check (`issue_comment`, `pull_request_review_comment`,
+    `pull_request_review`, or a `workflow_dispatch` a comment or bot fired)
+    is invisible. Acknowledge as the **first** step, then report the outcome
+    on **both** paths — a 🚀/👍 reaction on success, a 👎 reaction plus a
+    comment linking the run on failure. `pull_request_review` has no
+    reactable comment, so it uses a single sticky PR comment for both beats.
+    See [`rules/feedback.md`](./rules/feedback.md).
 
 ---
 

--- a/skills/delivery/github-actions-author/SKILL.md
+++ b/skills/delivery/github-actions-author/SKILL.md
@@ -5,9 +5,11 @@ description: >
   2026 best practices: caching with `hashFiles` + `restore-keys`,
   parallelization via matrix + artifacts, reusability (composite actions
   for steps, reusable workflows for jobs), security (SHA-pinned actions,
-  least-privilege `GITHUB_TOKEN`, concurrency), and trackable errors
+  least-privilege `GITHUB_TOKEN`, concurrency), trackable errors
   (named steps, step summaries, annotations, and stdout/stderr that always
-  reaches the run log so agents can act on failures). Two modes: `scaffold`
+  reaches the run log so agents can act on failures), and feedback for
+  comment/manual triggers (👀 acknowledgement reaction on start, 🚀/👎
+  outcome reaction plus a run-linked comment at the end). Two modes: `scaffold`
   (default) generates workflow YAML; `review` audits an existing
   workflow against the same rules. Use when creating CI/CD pipelines,
   optimizing slow workflows, deduping copy-pasted YAML across repos, or
@@ -19,7 +21,7 @@ argument-hint: '[scaffold|review] [<workflow-file>]'
 license: MIT
 metadata:
   author: mthines
-  version: '1.1.0'
+  version: '1.2.0'
   workflow_type: scaffolder
   tags:
     - github-actions
@@ -32,6 +34,8 @@ metadata:
     - security
     - oidc
     - logging
+    - feedback
+    - reactions
 ---
 
 # GitHub Actions Author
@@ -100,7 +104,7 @@ Five phases. Each has a gate; do not proceed until it passes.
 | 1     | Anatomy + triggers    | [`rules/workflow-anatomy.md`](./rules/workflow-anatomy.md), [`rules/triggers-and-concurrency.md`](./rules/triggers-and-concurrency.md) | `on:` block scoped (branches + paths), concurrency set.           |
 | 2     | Speed (cache + parallel) | [`rules/caching.md`](./rules/caching.md), [`rules/parallelization.md`](./rules/parallelization.md) | Cache key is `hashFiles`-based with `restore-keys`; independent jobs run in parallel. |
 | 3     | Reusability           | [`rules/reusability.md`](./rules/reusability.md)                              | Any block used > 1 place is extracted to a composite action or reusable workflow. |
-| 4     | Security + errors     | [`rules/security.md`](./rules/security.md), [`rules/observability.md`](./rules/observability.md), [`rules/log-output-visibility.md`](./rules/log-output-visibility.md) | Third-party actions SHA-pinned, `permissions:` minimal, every step named, failures surface a stack-trace path, **every command's stdout + stderr reaches the run log**. |
+| 4     | Security + errors     | [`rules/security.md`](./rules/security.md), [`rules/observability.md`](./rules/observability.md), [`rules/log-output-visibility.md`](./rules/log-output-visibility.md), [`rules/feedback.md`](./rules/feedback.md) | Third-party actions SHA-pinned, `permissions:` minimal, every step named, failures surface a stack-trace path, **every command's stdout + stderr reaches the run log**, and any comment/manual-triggered workflow acknowledges (👀) and reports its outcome (🚀/👎 + run link). |
 
 ### Phase 0 — Intent and shape
 
@@ -109,8 +113,11 @@ Ask in **one** batched message:
 1. **Workflow purpose** — one sentence. CI, deploy, release, scheduled,
    manual, or composite/reusable shared piece?
 2. **Trigger surface** — push, pull_request, schedule, workflow_dispatch,
-   or workflow_call? Which branches? Which path globs (to skip irrelevant
-   runs)?
+   workflow_call, or a comment / slash command (`issue_comment`,
+   `pull_request_review_comment`)? Which branches? Which path globs (to
+   skip irrelevant runs)? Comment/manual triggers additionally require
+   reaction + status feedback — see
+   [`rules/feedback.md`](./rules/feedback.md).
 3. **Stack** — Node (npm/yarn/pnpm/bun), Python (pip/uv/poetry), Go,
    Rust, Java/Gradle, Docker, mixed?
 4. **Shape** — single job, matrix (axes?), build-then-test (artifact
@@ -214,7 +221,7 @@ Load on demand — do not preload.
 | 1     | [`rules/workflow-anatomy.md`](./rules/workflow-anatomy.md), [`rules/triggers-and-concurrency.md`](./rules/triggers-and-concurrency.md) |
 | 2     | [`rules/caching.md`](./rules/caching.md), [`rules/parallelization.md`](./rules/parallelization.md)                          |
 | 3     | [`rules/reusability.md`](./rules/reusability.md)                                                                            |
-| 4     | [`rules/security.md`](./rules/security.md), [`rules/observability.md`](./rules/observability.md), [`rules/log-output-visibility.md`](./rules/log-output-visibility.md) |
+| 4     | [`rules/security.md`](./rules/security.md), [`rules/observability.md`](./rules/observability.md), [`rules/log-output-visibility.md`](./rules/log-output-visibility.md), [`rules/feedback.md`](./rules/feedback.md) |
 
 Drop-in starters in [`templates/`](./templates/):
 
@@ -252,6 +259,13 @@ Drop-in starters in [`templates/`](./templates/):
    The log is the only thing `gh run view --log-failed` returns, and it is
    what agents act on. See
    [`rules/log-output-visibility.md`](./rules/log-output-visibility.md).
+10. **Comment/manual triggers must give feedback.** A workflow with no PR
+    status check (`issue_comment`, `pull_request_review_comment`, a
+    comment-driven `workflow_dispatch`) is invisible. Acknowledge with a
+    👀 reaction as the **first** step, then report the outcome on **both**
+    paths — a 🚀/👍 reaction on success, a 👎 reaction plus a comment
+    linking the run on failure. See
+    [`rules/feedback.md`](./rules/feedback.md).
 
 ---
 
@@ -273,6 +287,10 @@ Drop-in starters in [`templates/`](./templates/):
 - Diagnostics uploaded as an artifact or written only to `$GITHUB_STEP_SUMMARY`.
 - `|| true` or `continue-on-error: true` with nothing echoed.
 - `tee` without `set -o pipefail` (green job, failed command).
+- Comment/slash-command workflow that never reacts to the triggering comment (user can't tell it ran).
+- Feedback only on success — a failed comment-triggered run left with no reaction or comment.
+- Failure reaction (👎) with no comment linking the run (user knows it broke, not where).
+- Reacting to a comment before gating the command by author / prefix (any user drives the bot).
 
 ---
 
@@ -309,6 +327,11 @@ A **scaffold** run is done when:
 - [ ] The log-visibility grep from
       [`rules/log-output-visibility.md`](./rules/log-output-visibility.md#verification)
       returns no unjustified hits.
+- [ ] If comment/manual-triggered (no PR status check), the workflow
+      acknowledges with a 👀 reaction as its first step and reports the
+      outcome on both paths — a 🚀/👍 reaction on success, a 👎 reaction
+      plus a run-linked comment on failure — with `issues: write` /
+      `pull-requests: write` granted and the command gated before it reacts.
 - [ ] If using OIDC, `id-token: write` is set at the job level only.
 - [ ] User received a one-paragraph summary of what was created and
       where to commit it.

--- a/skills/delivery/github-actions-author/SKILL.md
+++ b/skills/delivery/github-actions-author/SKILL.md
@@ -8,7 +8,7 @@ description: >
   least-privilege `GITHUB_TOKEN`, concurrency), trackable errors
   (named steps, step summaries, annotations, and stdout/stderr that always
   reaches the run log so agents can act on failures), and feedback for
-  comment/manual triggers (👀 acknowledgement reaction on start, 🚀/👎
+  comment-triggered runs (👀 acknowledgement reaction on start, 🚀/👎
   outcome reaction plus a run-linked comment at the end). Two modes: `scaffold`
   (default) generates workflow YAML; `review` audits an existing
   workflow against the same rules. Use when creating CI/CD pipelines,
@@ -104,7 +104,7 @@ Five phases. Each has a gate; do not proceed until it passes.
 | 1     | Anatomy + triggers    | [`rules/workflow-anatomy.md`](./rules/workflow-anatomy.md), [`rules/triggers-and-concurrency.md`](./rules/triggers-and-concurrency.md) | `on:` block scoped (branches + paths), concurrency set.           |
 | 2     | Speed (cache + parallel) | [`rules/caching.md`](./rules/caching.md), [`rules/parallelization.md`](./rules/parallelization.md) | Cache key is `hashFiles`-based with `restore-keys`; independent jobs run in parallel. |
 | 3     | Reusability           | [`rules/reusability.md`](./rules/reusability.md)                              | Any block used > 1 place is extracted to a composite action or reusable workflow. |
-| 4     | Security + errors     | [`rules/security.md`](./rules/security.md), [`rules/observability.md`](./rules/observability.md), [`rules/log-output-visibility.md`](./rules/log-output-visibility.md), [`rules/feedback.md`](./rules/feedback.md) | Third-party actions SHA-pinned, `permissions:` minimal, every step named, failures surface a stack-trace path, **every command's stdout + stderr reaches the run log**, and any comment/manual-triggered workflow acknowledges (👀) and reports its outcome (🚀/👎 + run link). |
+| 4     | Security + errors     | [`rules/security.md`](./rules/security.md), [`rules/observability.md`](./rules/observability.md), [`rules/log-output-visibility.md`](./rules/log-output-visibility.md), [`rules/feedback.md`](./rules/feedback.md) | Third-party actions SHA-pinned, `permissions:` minimal, every step named, failures surface a stack-trace path, **every command's stdout + stderr reaches the run log**, and any comment-triggered workflow — including a `workflow_dispatch` a comment or bot fired, but not one fired from the Actions UI — acknowledges (👀) and reports its outcome (🚀/👎 + run link). |
 
 ### Phase 0 — Intent and shape
 
@@ -327,11 +327,16 @@ A **scaffold** run is done when:
 - [ ] The log-visibility grep from
       [`rules/log-output-visibility.md`](./rules/log-output-visibility.md#verification)
       returns no unjustified hits.
-- [ ] If comment/manual-triggered (no PR status check), the workflow
-      acknowledges with a 👀 reaction as its first step and reports the
-      outcome on both paths — a 🚀/👍 reaction on success, a 👎 reaction
-      plus a run-linked comment on failure — with `issues: write` /
-      `pull-requests: write` granted and the command gated before it reacts.
+- [ ] If comment-triggered and producing no PR status check — `issue_comment`,
+      `pull_request_review_comment`, `pull_request_review`, or a
+      `workflow_dispatch` a comment or bot fired, per the trigger table in
+      [`rules/feedback.md`](./rules/feedback.md#when-this-rule-applies) — the
+      workflow acknowledges on the triggering comment with a 👀 reaction as
+      its first step and reports the outcome on both paths — a 🚀/👍 reaction
+      on success, a 👎 reaction plus a run-linked comment on failure — with
+      `issues: write` / `pull-requests: write` granted and the command gated
+      before it reacts. A `workflow_dispatch` fired from the Actions UI has no
+      triggering comment and is out of scope.
 - [ ] If using OIDC, `id-token: write` is set at the job level only.
 - [ ] User received a one-paragraph summary of what was created and
       where to commit it.

--- a/skills/delivery/github-actions-author/SKILL.md
+++ b/skills/delivery/github-actions-author/SKILL.md
@@ -331,11 +331,14 @@ A **scaffold** run is done when:
       `pull_request_review_comment`, `pull_request_review`, or a
       `workflow_dispatch` a comment or bot fired, per the trigger table in
       [`rules/feedback.md`](./rules/feedback.md#when-this-rule-applies) — the
-      workflow acknowledges on the triggering comment with a 👀 reaction as
-      its first step and reports the outcome on both paths — a 🚀/👍 reaction
-      on success, a 👎 reaction plus a run-linked comment on failure — with
-      `issues: write` / `pull-requests: write` granted and the command gated
-      before it reacts. A `workflow_dispatch` fired from the Actions UI has no
+      workflow acknowledges as its first step and reports the outcome on both
+      paths, with `issues: write` / `pull-requests: write` granted and the
+      command gated before it acknowledges. Where the trigger carries a
+      reactable comment that means a 👀 reaction first, then a 🚀/👍 reaction
+      on success and a 👎 reaction plus a run-linked comment on failure.
+      A `pull_request_review` trigger carries none — GitHub exposes no
+      reactions endpoint for a review — so it uses a single sticky PR comment
+      for both beats. A `workflow_dispatch` fired from the Actions UI has no
       triggering comment and is out of scope.
 - [ ] If using OIDC, `id-token: write` is set at the job level only.
 - [ ] User received a one-paragraph summary of what was created and

--- a/skills/delivery/github-actions-author/rules/feedback.md
+++ b/skills/delivery/github-actions-author/rules/feedback.md
@@ -1,0 +1,259 @@
+---
+title: Feedback — Reactions and Status for Comment-Triggered Workflows
+impact: HIGH
+tags:
+  - feedback
+  - reactions
+  - issue_comment
+  - slash-command
+  - observability
+  - acknowledgement
+---
+
+# Feedback
+
+A `push` or `pull_request` run announces itself: it shows up as a status
+check on the PR, so the user always knows it fired.
+A **comment-triggered** workflow does not.
+A user types `/deploy` (or `/rebase`, `/format`, `/preview`) and then
+stares at a comment with no indication that anything is happening — no
+status check, no spinner, nothing.
+If the run silently fails, they never find out.
+
+**Rule:** every workflow triggered by a human comment or manual action
+that produces no obvious PR status check **must** give feedback on the
+triggering comment — an acknowledgement when it starts, and an outcome
+when it ends.
+
+## When this rule applies
+
+| Trigger                                                    | Needs feedback? | Why                                                        |
+| ---------------------------------------------------------- | --------------- | ---------------------------------------------------------- |
+| `issue_comment` (slash command on an issue/PR)             | **Yes**         | No status check; user has no signal it ran.               |
+| `pull_request_review_comment` (slash command on a diff)    | **Yes**         | Same — invisible without feedback.                        |
+| `pull_request_review` (`submitted`) acting on a command    | **Yes**         | Same.                                                     |
+| `workflow_dispatch` fired from a comment/bot               | **Yes**         | The requester is watching the comment, not the Actions UI. |
+| `pull_request` / `push` CI                                 | No (optional)   | The status check **is** the feedback. Summaries are extra. |
+
+## The three-beat loop
+
+Every comment-triggered workflow follows the same shape.
+
+1. **Acknowledge — first step, before any real work.**
+   React to the triggering comment with 👀 (`eyes`) the moment the run
+   starts, so the user knows it was picked up.
+   This must be the **first** step after gating (below), not the last —
+   a reaction that only lands after a 4-minute build is useless.
+2. **Progress (optional).** For long runs, create **one** sticky status
+   comment and update it in place (never post a fresh comment per tick —
+   that is notification spam).
+3. **Report outcome — always, on both paths.**
+   On success, add a 🚀/🎉/👍 reaction.
+   On failure, add a 👎 reaction **and** post a comment with the reason
+   and a link to the run, so the user can act without hunting.
+
+## Reaction vocabulary
+
+The reactions REST API accepts exactly these `content` values:
+`+1`, `-1`, `laugh`, `confused`, `heart`, `hooray`, `rocket`, `eyes`.
+
+| Beat                     | `content`                    | Renders  | Meaning                        |
+| ------------------------ | ---------------------------- | -------- | ------------------------------ |
+| Acknowledge (picked up)  | `eyes`                       | 👀       | Received — run has started.     |
+| Success                  | `rocket` / `hooray` / `+1`   | 🚀 🎉 👍 | Completed OK.                   |
+| Failure                  | `-1` / `confused`            | 👎 😕    | Failed — see comment + run link. |
+
+Pick **one** success reaction and **one** failure reaction per repo and
+stay consistent, so contributors learn to read them at a glance.
+
+## Permissions
+
+Reacting and commenting need write scope on the discussion surface.
+Grant the minimum at the job level:
+
+```yaml
+permissions:
+  issues: write          # react to / comment on issue comments
+  pull-requests: write   # react to / comment on PR + review comments
+```
+
+Without these the reactions API returns `403` — a common silent breakage.
+
+## Implementation with `gh api`
+
+`gh` is preinstalled on GitHub-hosted runners and reads `GH_TOKEN`.
+The triggering comment id is `${{ github.event.comment.id }}`; the
+issue/PR number is `${{ github.event.issue.number }}`.
+
+### Gate the command first (security)
+
+Comment triggers fire for **anyone with read access**.
+Gate before you react, or any user can drive your bot — see
+[`security.md`](./security.md).
+
+```yaml
+jobs:
+  command:
+    # Only run for the intended command, on a PR, from a trusted author.
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/deploy') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+               github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      # ... acknowledge / work / report, below
+```
+
+### Acknowledge — the first step
+
+```yaml
+- name: Acknowledge command
+  env:
+    GH_TOKEN: ${{ github.token }}
+  run: |
+    set -euo pipefail
+    gh api --method POST \
+      "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+      -f content='eyes' 2>&1 | tee reaction-ack.log
+```
+
+### Do the work
+
+```yaml
+- name: Run the command
+  env:
+    GH_TOKEN: ${{ github.token }}
+  run: |
+    set -euo pipefail
+    ./scripts/deploy.sh 2>&1 | tee deploy.log
+```
+
+### Report the outcome — both paths, always
+
+```yaml
+- name: Report success
+  if: success()
+  env:
+    GH_TOKEN: ${{ github.token }}
+  run: |
+    set -euo pipefail
+    gh api --method POST \
+      "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+      -f content='rocket' 2>&1 | tee reaction-ok.log
+
+- name: Report failure
+  if: failure()
+  env:
+    GH_TOKEN: ${{ github.token }}
+    RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  run: |
+    set -euo pipefail
+    gh api --method POST \
+      "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+      -f content='-1' 2>&1 | tee reaction-fail.log
+    gh api --method POST \
+      "/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+      -f body="❌ \`/deploy\` failed — [view run]($RUN_URL)" 2>&1 | tee comment-fail.log
+```
+
+`if: success()` / `if: failure()` guarantee exactly one outcome step
+runs even after an earlier step aborts the job.
+The failure comment **must** carry the `RUN_URL`; a 👎 with no link
+tells the user it broke but not where to look.
+
+## Implementation with a maintained action
+
+`peter-evans/create-or-update-comment` handles reactions and sticky
+comments in one place. Use it when you also want a progress comment.
+
+```yaml
+- name: Acknowledge
+  uses: peter-evans/create-or-update-comment@<sha>   # v4.x
+  with:
+    comment-id: ${{ github.event.comment.id }}
+    reactions: eyes
+```
+
+SHA-pin it like any third-party action ([`security.md`](./security.md)).
+
+## Examples
+
+### Good — acknowledge first, outcome on both paths
+
+```yaml
+steps:
+  - name: Acknowledge command
+    env: { GH_TOKEN: ${{ github.token }} }
+    run: |
+      set -euo pipefail
+      gh api --method POST \
+        "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+        -f content='eyes' 2>&1 | tee reaction-ack.log
+
+  - name: Run command
+    env: { GH_TOKEN: ${{ github.token }} }
+    run: ./scripts/preview.sh 2>&1 | tee preview.log
+
+  - name: Report success
+    if: success()
+    env: { GH_TOKEN: ${{ github.token }} }
+    run: |
+      gh api --method POST \
+        "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+        -f content='rocket' 2>&1 | tee reaction-ok.log
+
+  - name: Report failure
+    if: failure()
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    run: |
+      gh api --method POST \
+        "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
+        -f content='-1' 2>&1 | tee reaction-fail.log
+      gh api --method POST \
+        "/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments" \
+        -f body="❌ Preview failed — [view run]($RUN_URL)" 2>&1 | tee comment-fail.log
+```
+
+### Bad — silent, or feedback only at the end
+
+```yaml
+steps:
+  - run: ./scripts/deploy.sh        # no ack, no reaction, no outcome
+```
+
+```yaml
+steps:
+  - run: ./scripts/deploy.sh
+  - if: success()                   # ack missing — user was blind the whole run
+    run: gh api ... -f content='rocket'
+  # no failure branch — a failed deploy leaves the comment with no signal
+```
+
+Why bad: the user has no idea the command was received, and a failure is
+completely invisible — no reaction, no comment, no link.
+
+## Common mistakes
+
+- **Feedback only at the end.** The user is blind during the run.
+  **Fix:** react 👀 as the **first** step.
+- **No failure branch.** Success is signalled, failure is silent.
+  **Fix:** an `if: failure()` step that reacts **and** links the run.
+- **Failure reaction with no run link.** User knows it broke, not where.
+  **Fix:** post a comment with `RUN_URL` alongside the 👎.
+- **Missing `issues: write` / `pull-requests: write`.** Reactions API
+  `403`. **Fix:** grant the scope at the job level.
+- **Reacting before gating the command.** Any read-access user drives the
+  bot. **Fix:** gate on `author_association` / command prefix **first**,
+  then react — see [`security.md`](./security.md).
+- **A fresh comment per progress tick.** Notification spam.
+  **Fix:** one sticky comment, updated in place
+  (`create-or-update-comment`).
+- **Assuming the comment is on a PR.** `issue_comment` also fires on
+  plain issues. **Fix:** gate on `github.event.issue.pull_request` when
+  the command only makes sense on a PR.

--- a/skills/delivery/github-actions-author/rules/feedback.md
+++ b/skills/delivery/github-actions-author/rules/feedback.md
@@ -20,10 +20,12 @@ stares at a comment with no indication that anything is happening — no
 status check, no spinner, nothing.
 If the run silently fails, they never find out.
 
-**Rule:** every workflow triggered by a human comment or manual action
-that produces no obvious PR status check **must** give feedback on the
-triggering comment — an acknowledgement when it starts, and an outcome
-when it ends.
+**Rule:** every workflow triggered by a comment — directly, or through a
+`workflow_dispatch` that a comment or a bot fired — and that produces no
+obvious PR status check **must** give feedback on the triggering comment:
+an acknowledgement when it starts, and an outcome when it ends.
+A `workflow_dispatch` fired from the Actions UI has no triggering comment,
+so it is out of scope.
 
 ## When this rule applies
 

--- a/skills/delivery/github-actions-author/rules/feedback.md
+++ b/skills/delivery/github-actions-author/rules/feedback.md
@@ -20,12 +20,16 @@ stares at a comment with no indication that anything is happening — no
 status check, no spinner, nothing.
 If the run silently fails, they never find out.
 
-**Rule:** every workflow triggered by a comment — directly, or through a
-`workflow_dispatch` that a comment or a bot fired — and that produces no
-obvious PR status check **must** give feedback on the triggering comment:
-an acknowledgement when it starts, and an outcome when it ends.
-A `workflow_dispatch` fired from the Actions UI has no triggering comment,
-so it is out of scope.
+**Rule:** every workflow triggered by a comment or a review — directly, or
+through a `workflow_dispatch` that a comment or a bot fired — and that
+produces no obvious PR status check **must** report back: an
+acknowledgement when it starts, and an outcome when it ends.
+Deliver both on the triggering comment whenever there is one.
+A `pull_request_review` trigger has none — GitHub exposes no reactions
+endpoint for a review — so it acknowledges and reports with a single
+sticky PR comment instead, updated in place (see the route table below).
+A `workflow_dispatch` fired from the Actions UI has no triggering comment
+at all, so it is out of scope.
 
 ## When this rule applies
 

--- a/skills/delivery/github-actions-author/rules/feedback.md
+++ b/skills/delivery/github-actions-author/rules/feedback.md
@@ -224,12 +224,15 @@ steps:
 
   - name: Run command
     env: { GH_TOKEN: ${{ github.token }} }
-    run: ./scripts/preview.sh 2>&1 | tee preview.log
+    run: |
+      set -euo pipefail
+      ./scripts/preview.sh 2>&1 | tee preview.log
 
   - name: Report success
     if: success()
     env: { GH_TOKEN: ${{ github.token }} }
     run: |
+      set -euo pipefail
       gh api --method POST \
         "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
         -f content='rocket' 2>&1 | tee reaction-ok.log
@@ -240,6 +243,7 @@ steps:
       GH_TOKEN: ${{ github.token }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     run: |
+      set -euo pipefail
       gh api --method POST \
         "/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" \
         -f content='-1' 2>&1 | tee reaction-fail.log

--- a/skills/delivery/github-actions-author/rules/feedback.md
+++ b/skills/delivery/github-actions-author/rules/feedback.md
@@ -82,8 +82,33 @@ Without these the reactions API returns `403` — a common silent breakage.
 ## Implementation with `gh api`
 
 `gh` is preinstalled on GitHub-hosted runners and reads `GH_TOKEN`.
-The triggering comment id is `${{ github.event.comment.id }}`; the
-issue/PR number is `${{ github.event.issue.number }}`.
+
+### Pick the reaction route from the trigger — the id namespaces are disjoint
+
+An `issue_comment` id and a `pull_request_review_comment` id live in
+**different namespaces**, and each 404s on the other's route.
+A pull request **review** has no reactions endpoint at all.
+Read the row for your trigger before you copy any snippet below.
+
+| Trigger                        | Comment id                                            | Reaction route                                                | PR / issue number                            |
+| ------------------------------ | ----------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------- |
+| `issue_comment`                | `${{ github.event.comment.id }}`                       | `/repos/{owner}/{repo}/issues/comments/{id}/reactions`          | `${{ github.event.issue.number }}`            |
+| `pull_request_review_comment`  | `${{ github.event.comment.id }}`                       | `/repos/{owner}/{repo}/pulls/comments/{id}/reactions`           | `${{ github.event.pull_request.number }}`     |
+| `pull_request_review`          | none — the payload carries `github.event.review.id`    | none — react to nothing; post the outcome as a PR comment on `/repos/{owner}/{repo}/issues/{pr}/comments` | `${{ github.event.pull_request.number }}` |
+| `workflow_dispatch` (comment/bot-fired) | none — the dispatching bot passes it, e.g. `${{ inputs.comment_id }}` | the route matching the id the caller passed (`issues` or `pulls`) | pass it as an input too, e.g. `${{ inputs.pr_number }}` |
+
+Confirm the row once with a read-only probe before you rely on it:
+
+```bash
+# Substitute a real id. Exactly one of these returns 200; the other returns 404.
+gh api "/repos/$OWNER/$REPO/issues/comments/$ID/reactions"
+gh api "/repos/$OWNER/$REPO/pulls/comments/$ID/reactions"
+```
+
+Every snippet below uses the `issue_comment` row.
+For `pull_request_review_comment`, swap `issues/comments` for
+`pulls/comments` and `github.event.issue.number` for
+`github.event.pull_request.number`.
 
 ### Gate the command first (security)
 
@@ -179,6 +204,9 @@ comments in one place. Use it when you also want a progress comment.
 ```
 
 SHA-pin it like any third-party action ([`security.md`](./security.md)).
+`comment-id` on this action addresses an **issue** comment only, so it
+cannot acknowledge a `pull_request_review_comment` — use the `gh api`
+`pulls/comments` route above for that trigger.
 
 ## Examples
 
@@ -254,6 +282,10 @@ completely invisible — no reaction, no comment, no link.
 - **A fresh comment per progress tick.** Notification spam.
   **Fix:** one sticky comment, updated in place
   (`create-or-update-comment`).
+- **Using `/issues/comments/{id}/reactions` for a review comment.** The id
+  404s — the two namespaces are disjoint, and a review has no reactions
+  endpoint at all. **Fix:** pick the route from the per-trigger table in
+  [Implementation with `gh api`](#implementation-with-gh-api).
 - **Assuming the comment is on a PR.** `issue_comment` also fires on
   plain issues. **Fix:** gate on `github.event.issue.pull_request` when
   the command only makes sense on a PR.

--- a/skills/delivery/github-actions-author/rules/triggers-and-concurrency.md
+++ b/skills/delivery/github-actions-author/rules/triggers-and-concurrency.md
@@ -89,6 +89,27 @@ on:
 Adds a "Run workflow" button to the Actions UI. Always add to deploy
 and release workflows for re-runs without pushing a tag.
 
+## Comment / slash-command triggers
+
+```yaml
+on:
+  issue_comment:
+    types: [created]
+```
+
+`issue_comment` fires on both issues and PRs; gate on
+`github.event.issue.pull_request` when the command only makes sense on a
+PR. These triggers fire for anyone with read access — gate on
+`author_association` and the command prefix before doing any work (see
+[`security.md`](./security.md)).
+
+Unlike `push` / `pull_request`, a comment-triggered run produces **no PR
+status check**, so it is invisible unless it reports back. Every
+comment/manual-triggered workflow **must** acknowledge the triggering
+comment with a 👀 reaction as its first step and report its outcome
+(🚀/👍 on success, 👎 + a run-linked comment on failure) — see
+[`feedback.md`](./feedback.md).
+
 ## Schedule
 
 ```yaml

--- a/skills/delivery/github-actions-author/rules/triggers-and-concurrency.md
+++ b/skills/delivery/github-actions-author/rules/triggers-and-concurrency.md
@@ -105,7 +105,9 @@ PR. These triggers fire for anyone with read access — gate on
 
 Unlike `push` / `pull_request`, a comment-triggered run produces **no PR
 status check**, so it is invisible unless it reports back. Every
-comment/manual-triggered workflow **must** acknowledge the triggering
+comment-triggered workflow — including a `workflow_dispatch` that a
+comment or a bot fired, but not one fired from the Actions UI, which has
+no triggering comment — **must** acknowledge the triggering
 comment with a 👀 reaction as its first step and report its outcome
 (🚀/👍 on success, 👎 + a run-linked comment on failure) — see
 [`feedback.md`](./feedback.md).


### PR DESCRIPTION
Comment-triggered workflows (issue_comment, pull_request_review_comment,
pull_request_review, and a comment-driven workflow_dispatch) produce no PR
status check, so they are invisible unless they report back. Add a dedicated
feedback rule and wire it through the skill:

- rules/feedback.md — the three-beat loop (acknowledge with a 👀 reaction as
  the first step, optional sticky progress comment, report the outcome on
  both paths: 🚀/👍 on success, 👎 + a run-linked comment on failure),
  reaction vocabulary, a per-trigger reaction-route table (a review-comment
  id resolves only on /pulls/comments/{id}/reactions, and a
  pull_request_review has no reactions endpoint at all, so it uses a sticky
  PR comment instead), required permissions, the gate-before-acknowledge
  security cross-ref, gh api + peter-evans implementations, and common
  mistakes.
- SKILL.md — Phase 4 gate + rule list, Phase 0 trigger-surface question,
  Required Reading table, Core Principle #10, anti-patterns, Definition of
  Done item, description/tags, version bump 1.1.0 → 1.2.0.
- triggers-and-concurrency.md — comment/slash-command trigger subsection
  pointing to the feedback rule.

A workflow_dispatch fired from the Actions UI has no triggering comment and
is explicitly out of scope throughout.

Note: two further review-feedback commits (b5ff497, ef5577e) were pushed to
this branch after the merge and are NOT part of merge commit 1965f65. They
add a full sticky-comment recipe for the review trigger (GET find by marker,
POST create, PATCH /issues/comments/{id} update) and make feedback.md's route
table the single owner of the acknowledgement mechanism so the prose sites
cannot drift from it. They need a follow-up pull request to land.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EN2mTeYkBLbaFJkbbbThkD
