### PR TITLE
fix(reviewer): forbid coordinate keys in comment-relevance memory

### DIFF
--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -147,6 +147,17 @@ magnitude in words (`four-gib-allocation-cap`, not `4294967296-byte-cap`), which
 is the better gist anyway. If you have encoded a coordinate, move it to the
 record's `examples` field.
 
+**Existing rows are not migrated.** Most rows written before this rule carry a
+bare gist with no `<category>:` segment (at the time of writing, 59 of 70 rows in
+`repo::mthines/agent-skills`). Re-keying them in place is deliberately **not**
+attempted: a bulk rewrite would have to re-derive `category` from comment bodies
+that are no longer fetched, and a wrong guess is worse than no row. Instead the
+old keys are left to lapse — they are never re-sighted under the new derivation,
+so their TTL expires them, while the correctly-keyed row for the same finding
+class accumulates from `seen_count: 1`. Expect a one-TTL window in which a
+finding class is represented by both an old and a new row; suppression simply
+takes longer to arm for those classes and nothing is lost.
+
 ---
 
 ## Relevance memory record schema

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -130,14 +130,22 @@ a claim.
 | - | -------------------- | ------- |
 | 1 | `/\bpr[-_#]?\d+/i` | `pr16855`, `pr-103` |
 | 2 | `/#\d+/` | `#16855` |
-| 3 | `/\d{6,}/` | comment ids, thread ids, run ids |
-| 4 | `/\b(?=[0-9a-f]{7,}\b)[0-9a-f]*[0-9][0-9a-f]*\b/i` | commit SHAs (hex run carrying a digit) |
+| 3 | `/\d{9,}/` | comment ids, thread ids, run ids |
+| 4 | `/\b(?=[0-9a-f]{7,40}\b)(?=[0-9a-f]*[a-f])(?=[0-9a-f]*[0-9])[0-9a-f]+\b/i` | commit SHAs (7–40 char hex run carrying **both** a letter and a digit) |
 | 5 | more than one `:` in the segment after the bucket prefix | `file:line` |
 
 No row fires on a digit that belongs to the claim: rows 1–2 require a `pr`/`#`
-prefix, row 3 needs a 6-digit run (an HTTP status, byte size, or timeout never
-reaches one), and row 4 needs a 7-character hex run containing a digit. If you
-have encoded a coordinate, move it to the record's `examples` field.
+prefix, row 4 needs a hex run carrying both a letter and a digit (requiring only a
+digit would re-match any 7-digit number, since digits are hex characters — that is
+why `1048576` is clean, and why a hypothetical all-numeric short SHA is accepted
+rather than widen the row back out), and row 3's bound
+is set at 9 because that is where GitHub's numeric ids start (comment, review,
+and run ids are 9–10 digits) and above where real claims land — `65535` (port),
+`86400` (seconds), `120000` (ms), and `1048576` (bytes) are all shorter. If a
+claim genuinely needs a 9-digit-or-longer number, do not encode it: spell the
+magnitude in words (`four-gib-allocation-cap`, not `4294967296-byte-cap`), which
+is the better gist anyway. If you have encoded a coordinate, move it to the
+record's `examples` field.
 
 ---
 

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -97,9 +97,28 @@ the same deterministic transform `scripts/record-comment-relevance.mjs`'s
 slug wobble; deriving mechanically makes the same comment yield the same key
 every time, so LoreKit's server-side dedup increments `seen_count` in place.
 
-**Self-check before every write:** if the key you are about to write matches
-`/(pr)?\d{3,}/` or contains more than one `:` in the segment after the bucket
-prefix, STOP — you have encoded a coordinate. Re-derive `<category>:<claim-gist>`.
+**Digits inside a gist are legitimate.** `fingerprint()` preserves them, so
+`issue:500-responses-not-retried` and `suggestion:4096-byte-buffer-configurable`
+are correct keys. Do not strip a number that is part of the claim — stripping it
+makes the agent's key diverge from the script's for the same comment, which is
+the exact split this rule exists to prevent. Only *coordinate shapes* are banned.
+
+**Self-check before every write:** STOP and re-derive `<category>:<claim-gist>` if
+the key you are about to write hits any row below — each matches a coordinate, not
+a claim.
+
+| # | Test against the key | Catches |
+| - | -------------------- | ------- |
+| 1 | `/\bpr[-_#]?\d+/i` | `pr16855`, `pr-103` |
+| 2 | `/#\d+/` | `#16855` |
+| 3 | `/\d{6,}/` | comment ids, thread ids, run ids |
+| 4 | `/\b(?=[0-9a-f]{7,}\b)[0-9a-f]*[0-9][0-9a-f]*\b/i` | commit SHAs (hex run carrying a digit) |
+| 5 | more than one `:` in the segment after the bucket prefix | `file:line` |
+
+No row fires on a digit that belongs to the claim: rows 1–2 require a `pr`/`#`
+prefix, row 3 needs a 6-digit run (an HTTP status, byte size, or timeout never
+reaches one), and row 4 needs a 7-character hex run containing a digit. If you
+have encoded a coordinate, move it to the record's `examples` field.
 
 ---
 

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -367,7 +367,7 @@ Sweeps all review threads, skips any that had a fix commit or a won't-fix reply
   ```bash
   npx @lorekit/cli memory write \
     --scope "repo::{owner}/{repo}" \
-    --key "reviewer-comment-relevance::{fingerprint}" \
+    --key "reviewer-comment-relevance::{category}:{claim-gist}" \
     --value '{"fingerprint":"...","relevance":"...","resolution_method":"...","reason":"...","seen_count":1,"status":"active","expires":"..."}' \
     --tags "loop::reviewer-comment-relevance,source::{resolution_method}" \
     --source-agent "github-actions/reviewer-comment-relevance"
@@ -418,7 +418,7 @@ memory.search { q: "<fingerprint slug>", scopes: ["repo::{owner}/{repo}", "globa
 # Write (UPDATE if exists, ADD otherwise).
 memory.write {
   scope: "repo::{owner}/{repo}",   # or "global" for universal patterns
-  key: "reviewer-comment-relevance::<fingerprint>",
+  key: "reviewer-comment-relevance::<category>:<claim-gist>",   # NO pr#/comment-id/sha — see § Key format
   value: "<record body as JSON or markdown>",
   tags: ["loop::reviewer-comment-relevance", "source::<resolution_method>"],
   source_agent: "implement-suggestion",

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -67,9 +67,39 @@ Where:
 - `claim-gist` = a 3–6 word stable slug describing the finding class (e.g.
   `null-check-guaranteed-upstream`, `map-vs-record-preference`).
 
-Keys MUST NOT encode `file:line` coordinates — those drift.
-They MUST encode the structural pattern so the signal accumulates across files
-and commits.
+The key MUST be **exactly two colon-separated segments after the bucket prefix**:
+`<category>:<claim-gist>`. Nothing else.
+
+Keys MUST NOT encode **any coordinate** — not `file:line`, and not a PR number,
+comment id, commit SHA, thread id, or run index. Every coordinate drifts or is
+unique-per-occurrence, which silently breaks the accumulation this whole loop
+depends on: a key that is unique per comment never reaches `seen_count ≥ 3`, so
+suppression never fires and the memory is inert. Coordinates belong in the
+record's `examples` field (see the schema below), never in the key.
+
+```text
+# ✅ RIGHT — a structural fingerprint that accumulates across files, commits, and PRs
+reviewer-comment-relevance::suggestion:clinerules-link-not-added
+reviewer-comment-relevance::issue:null-check-guaranteed-upstream
+
+# ❌ WRONG — encodes PR + comment-id coordinates; unique per occurrence, never accumulates.
+#    This is the observed drift that produced 2–3 duplicate rows per comment on
+#    dash0hq/dash0 and left the relevance loop non-functional there.
+reviewer-comment-relevance::pr16855-3758467267-clinerules-link-not-added
+reviewer-comment-relevance::pr16855-3758467267-clinerules-link-not-added-wontfix
+```
+
+**Derive the key mechanically, not from memory of the comment.** Compute
+`category` from the Conventional Comments prefix and `claim-gist` as a 3–6 word
+kebab slug of the substantive claim (strip code spans, URLs, and stop-words) —
+the same deterministic transform `scripts/record-comment-relevance.mjs`'s
+`fingerprint()` implements. Re-deriving descriptively per run is what makes the
+slug wobble; deriving mechanically makes the same comment yield the same key
+every time, so LoreKit's server-side dedup increments `seen_count` in place.
+
+**Self-check before every write:** if the key you are about to write matches
+`/(pr)?\d{3,}/` or contains more than one `:` in the segment after the bucket
+prefix, STOP — you have encoded a coordinate. Re-derive `<category>:<claim-gist>`.
 
 ---
 

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -64,8 +64,10 @@ reviewer-comment-relevance::<category>:<claim-gist>
 
 Where:
 - `category` = the Conventional Comments prefix (e.g. `suggestion`, `issue`, `nitpick`).
-- `claim-gist` = a 3–6 word stable slug describing the finding class (e.g.
-  `null-check-guaranteed-upstream`, `map-vs-record-preference`).
+- `claim-gist` = the first 6 surviving words of the comment body, in source order,
+  kebab-joined (e.g. `null-check-guaranteed-upstream`, `map-vs-record-preference`).
+  "Surviving" is defined by the algorithm below — it is a mechanical truncation,
+  not a summary you compose.
 
 The key MUST be **exactly two colon-separated segments after the bucket prefix**:
 `<category>:<claim-gist>`. Nothing else.
@@ -89,13 +91,30 @@ reviewer-comment-relevance::pr16855-3758467267-clinerules-link-not-added
 reviewer-comment-relevance::pr16855-3758467267-clinerules-link-not-added-wontfix
 ```
 
-**Derive the key mechanically, not from memory of the comment.** Compute
-`category` from the Conventional Comments prefix and `claim-gist` as a 3–6 word
-kebab slug of the substantive claim (strip code spans, URLs, and stop-words) —
-the same deterministic transform `scripts/record-comment-relevance.mjs`'s
-`fingerprint()` implements. Re-deriving descriptively per run is what makes the
-slug wobble; deriving mechanically makes the same comment yield the same key
-every time, so LoreKit's server-side dedup increments `seen_count` in place.
+**Derive the key mechanically, not from memory of the comment.**
+`fingerprint()` in [`scripts/record-comment-relevance.mjs`](../../../scripts/record-comment-relevance.mjs)
+is the **normative implementation** — the GitHub Actions write path runs it, so an
+agent that derives differently produces a second key for the same comment and the
+`seen_count` splits. Follow its steps exactly; do not paraphrase the comment.
+
+1. `category` — the Conventional Comments prefix at the start of the body
+   (`issue`, `suggestion`, `nitpick`, `nit`, `question`, `praise`, `chore`),
+   matched case-insensitively and followed by `:` or `(`. `nit` normalises to
+   `nitpick`. **No prefix ⇒ `suggestion`**, not "no category".
+2. `claim-gist` — from the body, in this order: drop fenced code blocks, then
+   inline code spans, then URLs; replace every non-alphanumeric character with a
+   space; lowercase; delete the stop-words (the script's list is normative — do
+   not re-invent it); collapse whitespace.
+3. Take the **first 6 surviving words in source order** and kebab-join them. This
+   is positional truncation, not selection of the 6 most meaningful words — the
+   leading `issue`/`suggestion` word survives the stop-list and will normally be
+   the first token, which is expected and matches the script.
+4. Nothing survives ⇒ `general-finding`.
+
+Re-deriving descriptively per run is what makes the slug wobble; running this
+transform makes the same comment yield the same key every time, so LoreKit's
+server-side dedup increments `seen_count` in place. When the body is long or
+ambiguous, execute `fingerprint()` rather than emulating it.
 
 **Digits inside a gist are legitimate.** `fingerprint()` preserves them, so
 `issue:500-responses-not-retried` and `suggestion:4096-byte-buffer-configurable`

--- a/agents/shared/rules/thread-resolution.md
+++ b/agents/shared/rules/thread-resolution.md
@@ -189,8 +189,8 @@ memory.write {
 }
 ```
 
-The `<fingerprint>` is `<category>:<claim-gist>` and **nothing else** — never a
-`pr{N}-{commentId}` or any other coordinate. Encoding coordinates makes the key
+The key's fingerprint segment is `<category>:<claim-gist>` and **nothing else** —
+never a `pr{N}-{commentId}` or any other coordinate. Encoding coordinates makes the key
 unique per occurrence, so `seen_count` never accumulates and the signal is inert
 (this is the drift that produced duplicate rows on `dash0hq/dash0`). Put the PR
 and comment id in the record's `examples` field. See the ✅/❌ examples and

--- a/agents/shared/rules/thread-resolution.md
+++ b/agents/shared/rules/thread-resolution.md
@@ -181,13 +181,20 @@ adds the trigger. Writes are append-only, non-blocking, and a silent no-op when
 ```
 memory.write {
   scope: "repo::{owner}/{repo}",            # or "global" for a universal pattern
-  key:   "reviewer-comment-relevance::<fingerprint>",
+  key:   "reviewer-comment-relevance::<category>:<claim-gist>",   # NO pr#/comment-id/sha — see below
   value: "<record body: relevance, resolution_method, reason, examples, seen_count, expires>",
   tags:  ["loop::reviewer-comment-relevance", "source::<resolution_method>"],
   source_agent: "pr-reviewer",
   trigger: "re-review-reconcile"
 }
 ```
+
+The `<fingerprint>` is `<category>:<claim-gist>` and **nothing else** — never a
+`pr{N}-{commentId}` or any other coordinate. Encoding coordinates makes the key
+unique per occurrence, so `seen_count` never accumulates and the signal is inert
+(this is the drift that produced duplicate rows on `dash0hq/dash0`). Put the PR
+and comment id in the record's `examples` field. See the ✅/❌ examples and
+self-check in [`comment-relevance-memory.md` § Key format](./comment-relevance-memory.md#key-format).
 
 The `loop::reviewer-comment-relevance` tag conveys the bucket's kind (`signal`)
 and host (`reviewer`): LoreKit records both from the tag automatically (migration

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -366,9 +366,12 @@ function checksInSync(plan, checks) {
     ["comment-relevance-memory.md", crm],
     ["thread-resolution.md", threadRes],
   ]) {
-    s.check(`G9d ${label} spells the relevance key as <category>:<claim-gist>, never a bare <fingerprint>`,
+    // Ban BOTH placeholder spellings: the markdown templates use `<fingerprint>` and the
+    // GitHub Actions CLI snippet uses `{fingerprint}`. Guarding only the angle form leaves
+    // the brace form free to regress the same defect.
+    s.check(`G9d ${label} spells the relevance key as <category>:<claim-gist>, never a bare fingerprint placeholder`,
       doc.includes("reviewer-comment-relevance::<category>:<claim-gist>") &&
-      !doc.includes("reviewer-comment-relevance::<fingerprint>"));
+      !/reviewer-comment-relevance::[<{]fingerprint[>}]/.test(doc));
   }
 
   // G10: review-config.md declares that absent .review.yaml defaults to profile: balanced,

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -356,6 +356,20 @@ function checksInSync(plan, checks) {
     !crm.includes("(pr)?\\d{3,}") && crm.includes("Digits inside a gist are legitimate"));
   s.check("G9d thread-resolution warns against coordinate keys in the pr-reviewer write path",
     /NO pr#\/comment-id\/sha/.test(threadRes) && threadRes.includes("<category>:<claim-gist>"));
+  // The ban must cover EVERY write path, not just pr-reviewer's. A bare `::<fingerprint>`
+  // placeholder left in any memory.write template is an open invitation to re-encode a
+  // coordinate, which is how the drift reached dash0hq/dash0 in the first place. Assert the
+  // expanded placeholder is present AND the bare one is gone, per writing agent.
+  const implSuggestion = read("skills/workflow/implement-suggestion/SKILL.md");
+  for (const [label, doc] of [
+    ["implement-suggestion/SKILL.md", implSuggestion],
+    ["comment-relevance-memory.md", crm],
+    ["thread-resolution.md", threadRes],
+  ]) {
+    s.check(`G9d ${label} spells the relevance key as <category>:<claim-gist>, never a bare <fingerprint>`,
+      doc.includes("reviewer-comment-relevance::<category>:<claim-gist>") &&
+      !doc.includes("reviewer-comment-relevance::<fingerprint>"));
+  }
 
   // G10: review-config.md declares that absent .review.yaml defaults to profile: balanced,
   // and that balanced = today's defaults (threshold 80, per-file caps 5/10).

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -331,6 +331,25 @@ function checksInSync(plan, checks) {
   s.check("G9c pr-reviewer.md wires 2.6b between 2.6 and 2.7",
     prReviewer.includes("2.6b") && prReviewer.includes("verification-receipt"));
 
+  // G9d: comment-relevance keys must be a pure `<category>:<claim-gist>` fingerprint —
+  // NEVER a coordinate (pr#/comment-id/sha/file:line). Coordinate keys are unique per
+  // occurrence, so seen_count never accumulates and the relevance loop goes inert; this
+  // is the observed drift that left ~40 duplicate rows on dash0hq/dash0. The rule and the
+  // pr-reviewer write path must both carry the broadened prohibition + the ❌ anti-pattern
+  // exemplar, so the agent cannot read "MUST NOT encode file:line" narrowly and think a
+  // pr{N}-{commentId} key is allowed. Lock the guidance in place (presence, not absence —
+  // the ❌ example intentionally contains a coordinate key).
+  const crm = read("agents/shared/rules/comment-relevance-memory.md");
+  const threadRes = read("agents/shared/rules/thread-resolution.md");
+  s.check("G9d comment-relevance-memory broadens the coordinate ban beyond file:line",
+    /PR number,\s+comment id/.test(crm) && /never in the key/.test(crm));
+  s.check("G9d comment-relevance-memory shows the pr{N}-{commentId} anti-pattern as ❌ WRONG",
+    /❌ WRONG/.test(crm) && /reviewer-comment-relevance::pr\d+-\d+/.test(crm));
+  s.check("G9d comment-relevance-memory carries the pre-write coordinate self-check",
+    crm.includes("Self-check before every write") && /encoded a coordinate/.test(crm));
+  s.check("G9d thread-resolution warns against coordinate keys in the pr-reviewer write path",
+    /NO pr#\/comment-id\/sha/.test(threadRes) && threadRes.includes("<category>:<claim-gist>"));
+
   // G10: review-config.md declares that absent .review.yaml defaults to profile: balanced,
   // and that balanced = today's defaults (threshold 80, per-file caps 5/10).
   // Back-compat: any behavior change without a config file is a guard failure.

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -347,6 +347,13 @@ function checksInSync(plan, checks) {
     /❌ WRONG/.test(crm) && /reviewer-comment-relevance::pr\d+-\d+/.test(crm));
   s.check("G9d comment-relevance-memory carries the pre-write coordinate self-check",
     crm.includes("Self-check before every write") && /encoded a coordinate/.test(crm));
+  // The self-check must key on coordinate SHAPES, not on any run of digits. `fingerprint()`
+  // in scripts/record-comment-relevance.mjs preserves digits, so a bare `\d{3,}` test fires
+  // on legitimate gists (`issue:500-responses-not-retried`) — the agent would strip the digits
+  // while the script keeps them, re-creating the agent/script key split this rule exists to
+  // close. Lock both halves: the over-broad test is gone, and the carve-out is stated.
+  s.check("G9d comment-relevance self-check does not fire on digits inside a claim gist",
+    !crm.includes("(pr)?\\d{3,}") && crm.includes("Digits inside a gist are legitimate"));
   s.check("G9d thread-resolution warns against coordinate keys in the pr-reviewer write path",
     /NO pr#\/comment-id\/sha/.test(threadRes) && threadRes.includes("<category>:<claim-gist>"));
 

--- a/skills/workflow/implement-suggestion/SKILL.md
+++ b/skills/workflow/implement-suggestion/SKILL.md
@@ -416,7 +416,10 @@ memory.write { scope: "<global | repo::{owner}/{repo}>", key: "review-outcomes::
 # Deduplicate first; UPDATE seen_count if exists, ADD otherwise.
 # Scope: almost always repo::{owner}/{repo}; global only for universal patterns.
 memory.search { q: "<fingerprint slug>", scopes: ["repo::{owner}/{repo}", "global"], limit: 5 }
-memory.write { scope: "repo::{owner}/{repo}", key: "reviewer-comment-relevance::<fingerprint>", value: "<relevance record>", tags: ["loop::reviewer-comment-relevance", "source::<resolution_method>"], source_agent: "implement-suggestion", trigger: "outcome-emit" }
+# The key is EXACTLY `<category>:<claim-gist>` — never a pr#, comment id, SHA, or file:line.
+# A coordinate key is unique per occurrence, so seen_count never accumulates and the signal
+# is inert. Put coordinates in the record's `examples` field. Self-check: comment-relevance-memory.md § Key format.
+memory.write { scope: "repo::{owner}/{repo}", key: "reviewer-comment-relevance::<category>:<claim-gist>", value: "<relevance record>", tags: ["loop::reviewer-comment-relevance", "source::<resolution_method>"], source_agent: "implement-suggestion", trigger: "outcome-emit" }
 ```
 
 LoreKit owns storage server-side and dedups on write.


### PR DESCRIPTION
## Why

The `reviewer-comment-relevance` bucket is meant to key on a structural `<category>:<claim-gist>` fingerprint so the signal **accumulates** across files, commits, and PRs. In practice the `pr-reviewer` write path drifted into per-comment **coordinate keys** (`pr{N}-{commentId}-{slug}`), which:

- created 2–3 duplicate rows per comment (the slug is re-derived each run), and
- **defeated accumulation entirely** — a key unique per comment never reaches `seen_count ≥ 3`, so suppression never fires and the memory goes inert.

Found while grooming `repo::dash0hq/dash0`: ~40 redundant rows across 36 comments, several carrying contradictory `fixed` vs `wont-fix` verdicts for the *same* comment. The old wording (*"keys MUST NOT encode `file:line`"*) was read too narrowly — the agent inferred a PR/comment-id coordinate was fine.

## What

- **`comment-relevance-memory.md`** — broaden the prohibition to **any** coordinate (PR#, comment-id, SHA, thread-id), add ✅/❌ examples of the exact observed anti-pattern, a mechanical-derivation instruction, and a pre-write self-check.
- **`thread-resolution.md`** — mirror the warning in the pr-reviewer write path with a cross-link.
- **`implement-suggestion/SKILL.md`** — expand the Phase 7 emit's key template to `<category>:<claim-gist>` so the ban covers every write path, not just `pr-reviewer`'s.
- **Derivation** — the rule now names `fingerprint()` normative and spells out its four steps (positional first-6 words, `suggestion` default when no prefix, `nit` → `nitpick`) instead of describing a summarisation the script does not perform.
- **Migration** — an explicit note that pre-existing bare-gist rows are left to lapse on TTL rather than bulk re-keyed.
- **`scripts/eval/l1.mjs`** — 8 new `G9d` guards locking the contract (5 static, plus one per writing agent asserting no bare `<fingerprint>` placeholder survives).

## Verification

`node scripts/eval/l1.mjs` → **178/178 checks passed**. Each new guard was proven red against the pre-fix content before being accepted (174/175 and 176/178 respectively). No behavior change to any script; `record-comment-relevance.mjs` already produced the correct fingerprint — this aligns the agent-side rules with it.

Review round 2 (4 threads, all resolved): tightened the self-check thresholds the first round introduced — row 3 raised to `\d{9,}` (a `120000` ms timeout and a `1048576` byte cap are ordinary claim content), and row 4 tightened to require a hex letter as well as a digit, which was matching any 7-digit number for the same reason. G9d now bans both the `<fingerprint>` and `{fingerprint}` placeholder spellings.

Review round 1 (3 threads, all resolved): narrowed the pre-write self-check so it keys on coordinate *shapes* rather than any 3+ digit run — `fingerprint()` preserves digits, so the old test tripped on legitimate gists like `issue:500-responses-not-retried` and would have made the agent strip digits the script keeps.

The 41 already-accumulated duplicate rows on `dash0hq/dash0` were archived out-of-band (reversible) during the groom; this PR stops the recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)