### PR TITLE
Give pr-reviewer's clean-PASS review a positive, rewarding tone

### DIFF
--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1209,7 +1209,7 @@ Pick the body by verdict, exactly as in Step 3 (see *Gate states*): **PASS** (al
 ```markdown
 <!-- PR_REVIEWER_REPORT -->
 PARTIAL_REVIEW_BANNER
-Reviewed your changes — no issues found.
+✅ Reviewed your changes — no issues found. Nice work!
 
 OPTIMALITY_SECTION
 
@@ -1251,14 +1251,20 @@ MEMORIES_SECTION
 </details>
 ```
 
+**Positive-close on the PASS headline.** The clean-PASS headline is deliberately warm — a leading
+`✅` and a short `Nice work!` close — so a clean review lands as a small reward for the author, not a
+flat verdict. This tone is reserved for the all-clear PASS (every gate ✅, nothing inline); WARN and
+FAIL headlines stay neutral. Keep the checkmark and the `Nice work!` close verbatim; do not add extra
+emoji or exclamation beyond them.
+
 **Advisory clause on the PASS headline.** A PASS can still carry a `LOW_CONFIDENCE_SECTION` (every
 gate ✅, yet near-miss `issue`/`suggestion` findings were deferred — advisory findings never affect
 a gate). So the bare `no issues found.` would read as contradicting the advisory `issue:` entries
 just below it. When `CADV > 0`, append ` <CADV> advisory finding(s) below the confidence bar (see
-Low-confidence findings).` to the PASS headline; the `Reviewed your changes — no issues found.` base
-is preserved (nothing blocking or inline survived), so the reader learns advisory findings exist
-without the headline overstating cleanliness. When `CADV == 0` the headline stays exactly
-`Reviewed your changes — no issues found.`
+Low-confidence findings).` after the `Nice work!` close; the `✅ Reviewed your changes — no issues
+found. Nice work!` base is preserved (nothing blocking or inline survived), so the reader learns
+advisory findings exist without the headline overstating cleanliness. When `CADV == 0` the headline
+stays exactly `✅ Reviewed your changes — no issues found. Nice work!`
 
 **On WARN** — soft warnings only (hard Gates 2/3/4/5 ✅, at least one of Description vs. code / Code review is ⚠️, none ❌):
 

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -1209,7 +1209,7 @@ Pick the body by verdict, exactly as in Step 3 (see *Gate states*): **PASS** (al
 ```markdown
 <!-- PR_REVIEWER_REPORT -->
 PARTIAL_REVIEW_BANNER
-✅ Reviewed your changes — no issues found. Nice work!
+✅ Reviewed your changes — no issues found.
 
 OPTIMALITY_SECTION
 
@@ -1251,20 +1251,20 @@ MEMORIES_SECTION
 </details>
 ```
 
-**Positive-close on the PASS headline.** The clean-PASS headline is deliberately warm — a leading
-`✅` and a short `Nice work!` close — so a clean review lands as a small reward for the author, not a
-flat verdict. This tone is reserved for the all-clear PASS (every gate ✅, nothing inline); WARN and
-FAIL headlines stay neutral. Keep the checkmark and the `Nice work!` close verbatim; do not add extra
-emoji or exclamation beyond them.
+**Affirming checkmark on the PASS headline.** The clean-PASS headline leads with a `✅` so a clean
+review reads as a subtle, confirming reward for the author rather than a flat verdict. The checkmark
+carries the affirmation; the wording stays factual — no praise phrase, no extra emoji or exclamation.
+This affirming lead is reserved for the all-clear PASS (every gate ✅, nothing inline); WARN and FAIL
+headlines stay neutral.
 
 **Advisory clause on the PASS headline.** A PASS can still carry a `LOW_CONFIDENCE_SECTION` (every
 gate ✅, yet near-miss `issue`/`suggestion` findings were deferred — advisory findings never affect
 a gate). So the bare `no issues found.` would read as contradicting the advisory `issue:` entries
 just below it. When `CADV > 0`, append ` <CADV> advisory finding(s) below the confidence bar (see
-Low-confidence findings).` after the `Nice work!` close; the `✅ Reviewed your changes — no issues
-found. Nice work!` base is preserved (nothing blocking or inline survived), so the reader learns
-advisory findings exist without the headline overstating cleanliness. When `CADV == 0` the headline
-stays exactly `✅ Reviewed your changes — no issues found. Nice work!`
+Low-confidence findings).` to the PASS headline; the `✅ Reviewed your changes — no issues found.`
+base is preserved (nothing blocking or inline survived), so the reader learns advisory findings exist
+without the headline overstating cleanliness. When `CADV == 0` the headline stays exactly
+`✅ Reviewed your changes — no issues found.`
 
 **On WARN** — soft warnings only (hard Gates 2/3/4/5 ✅, at least one of Description vs. code / Code review is ⚠️, none ❌):
 

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -677,8 +677,8 @@ function checksInSync(plan, checks) {
   {
     // G19a: the three concise headline sentences are present (PASS / WARN / FAIL).
     // These are literal anchors grepped from the rewritten Step 4 section.
-    s.check("G19a pr-reviewer.md has the PASS concise headline with a positive checkmark close",
-      prReviewer.includes("✅ Reviewed your changes — no issues found. Nice work!"));
+    s.check("G19a pr-reviewer.md has the PASS concise headline with an affirming checkmark lead",
+      prReviewer.includes("✅ Reviewed your changes — no issues found."));
 
     s.check("G19b pr-reviewer.md has the WARN concise headline led by WARN_GATE_COUNT and naming the warned gates",
       prReviewer.includes("Reviewed your changes — no blocking issues, **<WARN_GATE_COUNT> warning(s)**: <WARN_REASONS>."));

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -677,8 +677,8 @@ function checksInSync(plan, checks) {
   {
     // G19a: the three concise headline sentences are present (PASS / WARN / FAIL).
     // These are literal anchors grepped from the rewritten Step 4 section.
-    s.check("G19a pr-reviewer.md has the PASS concise headline",
-      prReviewer.includes("Reviewed your changes — no issues found."));
+    s.check("G19a pr-reviewer.md has the PASS concise headline with a positive checkmark close",
+      prReviewer.includes("✅ Reviewed your changes — no issues found. Nice work!"));
 
     s.check("G19b pr-reviewer.md has the WARN concise headline led by WARN_GATE_COUNT and naming the warned gates",
       prReviewer.includes("Reviewed your changes — no blocking issues, **<WARN_GATE_COUNT> warning(s)**: <WARN_REASONS>."));


### PR DESCRIPTION
The all-clear approval comment was a flat "Reviewed your changes — no
issues found." Mirror the warmth of external review bots (e.g. Cursor
Bugbot) so a clean review lands as a small reward for the author: lead
with a ✅ checkmark and close with "Nice work!".

- PASS headline now reads "✅ Reviewed your changes — no issues found.
  Nice work!"; WARN and FAIL headlines stay neutral (this tone is
  reserved for the all-clear PASS).
- Document the positive-close intent and keep the advisory-clause logic
  anchored on the preserved "no issues found." phrase, now appending the
  advisory sentence after the "Nice work!" close.
- Update L1 eval G19a to lock the checkmark + close, not just the anchor
  substring.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011vJ4QboXMYB7XbcG7FFuWQ