### PR TITLE
Resolve the live review findings missed before #107 merged

### DIFF
--- a/skills/delivery/create-pr/SKILL.md
+++ b/skills/delivery/create-pr/SKILL.md
@@ -272,12 +272,14 @@ put observed_sha "$PR_HEAD"
 put observed_state pending     # overwritten by the row's own verdict below
 ```
 
+**Increment the relevant counter immediately after each attempt returns, before consulting this table.** Comparing an un-incremented counter (or one left unset by `touch`) runs one attempt more than the cap says — `attempts` at 0 with `< 4` yields five watches, not four.
+
 | Attempt outcome | Next step |
 | --------------- | --------- |
 | Exit 0 | CI green — `put observed_state green`, jump to Step 10 |
-| Registration poll exited 124 **and** `registration_attempts < 3` | Checks not registered yet — increment `registration_attempts`, poll again. **Does not touch `attempts`** |
+| Registration poll exited 124 **and** `registration_attempts < 3` | Checks not registered yet — poll again. **Does not touch `attempts`** |
 | Registration poll exited 124 **and** `registration_attempts == 3` | After ≈ 4½ minutes of polling, this repo genuinely doesn't run CI on PRs — jump to Step 10 |
-| Exit 124 and `attempts < 4` | Increment `attempts`, watch once more |
+| Exit 124 and `attempts < 4` | Watch once more |
 | Exit 124 and `attempts == 4` | **Stop.** Run `gh pr checks <pr-number>` once, report the still-pending checks, `put observed_state pending`, escalate — never watch again |
 | Exit 127, or stderr matching `command not found` / `could not resolve` / `authentication` | **Tooling failure, not a CI failure.** `timeout` is absent on stock macOS (use `gtimeout`); `gh` auth and network errors also exit non-zero. Report the command failure; do **not** fan out CI-log triage against a run that never failed |
 | Any other non-zero | A check genuinely failed — `put observed_state failing`, go to Step 8 |
@@ -319,7 +321,7 @@ Use the returned `category` to decide the path:
   ```bash
   gh run rerun <run-id> --failed
   ```
-  Then re-watch with `timeout 540 gh pr checks <pr-number> --watch` (tool `timeout: 600000`), **drawing from the same `.agent/ci-watch-<pr-number>.state` budget as Step 7** — a rerun does not reset `attempts`. At most one rerun per check, and if the budget is spent, report and escalate instead of watching again. A `ci-auto-fix` subagent that watches on your behalf spends from the same file.
+  Then re-watch with `timeout 540 gh pr checks <pr-number> --watch` (tool `timeout: 600000`), **drawing from the same `.agent/ci-watch-<pr-number>.state` budget as Step 7** — a rerun does not reset `attempts`. At most one rerun per check, and if the budget is spent, report and escalate instead of watching again. A `ci-auto-fix` subagent does **not** spend from this file — it watches a commit it just pushed, using its own local counter, and reports `attempts_used` back for you to reconcile (Step 9).
 
 ## Step 9: Apply Fixes
 
@@ -363,7 +365,7 @@ if [ "$NEW_HEAD" != "$(get observed_sha)" ]; then
 fi
 ```
 
-If the head did **not** move (no subagent pushed), debit `attempts` by the total `attempts_used` reported instead. Skipping this leaves the state file pointing at the pre-fix commit — fail-safe, since Phase 7 then re-watches rather than skipping, but the cross-boundary budget stops functioning.
+If the head did **not** move (no subagent pushed), **add** the reported total to `attempts` — the counter rises toward the cap of 4, so a subagent's watches are recorded by incrementing, never by subtracting. Skipping this leaves the state file pointing at the pre-fix commit — fail-safe, since Phase 7 then re-watches rather than skipping, but the cross-boundary budget stops functioning.
 
 **Judgment-required failures — keep in the main thread.** `/confidence` reviews *this* conversation's reasoning, so a subagent can't run it. With the triage summary already in hand:
 

--- a/skills/delivery/create-pr/SKILL.md
+++ b/skills/delivery/create-pr/SKILL.md
@@ -230,6 +230,8 @@ mkdir -p "$(dirname "$STATE")" && touch "$STATE"
 
 **Wire format: one `key=value` per line, no quoting, no nesting.** Both `create-pr` and Phase 7 read and write it with plain shell, so the format must be trivially parseable by each:
 
+**These two helpers are a snippet, not persistent state.** Fact 2 above applies to them as well: a function defined in one Bash call does not exist in the next. Paste both definitions into *every* call that uses them (or inline the `grep`/`printf` directly) — a later `put observed_sha` that assumes an earlier definition is a command-not-found, and the write silently never happens.
+
 ```bash
 get() { grep -E "^$1=" "$STATE" | tail -1 | cut -d= -f2-; }        # empty if unset
 # Write to a temp file and mv — mv is atomic within a filesystem, so a

--- a/skills/workflow/autonomous-workflow/CLAUDE.md
+++ b/skills/workflow/autonomous-workflow/CLAUDE.md
@@ -782,7 +782,7 @@ end-user-facing; this file is contributor-facing.
     Step 7 used `timeout 1800`, which exceeds Claude Code's 600 s Bash cap — the
     harness killed the call before `exit 124`, so the documented expiry handling
     was dead code and the agent saw only an opaque timeout. Step 7 now uses
-    `timeout 540` against an explicit PR-scoped `CI_WATCH_ATTEMPTS` budget
+    `timeout 540` against an explicit PR-scoped budget (the `attempts` key in `.agent/ci-watch-<pr>.state`)
     (4 attempts ≈ 36 min total, *more* real wait than the broken 1800), and the
     Step 8 flake path draws from the same counter instead of resetting it.
     `phase-7-ci-gate.md` Step 1 had **no** bound at all; it is now bounded by the

--- a/skills/workflow/autonomous-workflow/references/cloud-stalling-analysis.md
+++ b/skills/workflow/autonomous-workflow/references/cloud-stalling-analysis.md
@@ -213,7 +213,7 @@ That is why the same skill "works sometimes" — the failure lives in the delive
 > | --- | ------ | ---- |
 > | R1 capability probe | **Not implemented** | Premise falsified (must-fix #1); probe fails open (must-fix #3); steelman supersedes the `gh` half |
 > | R2 degradation matrix | **Not implemented** | Second source of truth (should-fix #8); superseded by the shim |
-> | R3 bounded waits | **Implemented**, revised | Single PR-scoped `CI_WATCH_ATTEMPTS` budget, not a fourth local counter (should-fix #5) |
+> | R3 bounded waits | **Implemented**, revised | Single PR-scoped budget (`attempts` in `.agent/ci-watch-<pr>.state`), not a fourth local counter (should-fix #5) |
 > | R4 CI-watch dedup | **Implemented**, halved | CI watch deduplicated; the two `review-loop` passes left alone — they are not duplication |
 > | R5 `aw` terminal contract | **Implemented** | Plus a mandatory `Degraded:` line |
 > | R6 compaction re-anchor | **Not implemented** | Never observed; covers ≤ ⅓ of runs (nice-to-have #11) |

--- a/skills/workflow/autonomous-workflow/rules/phase-7-ci-gate.md
+++ b/skills/workflow/autonomous-workflow/rules/phase-7-ci-gate.md
@@ -78,9 +78,9 @@ PR_HEAD=$(gh pr view <pr-number> --json headRefOid -q .headRefOid)
 
 | State file says | `observed_sha` vs `PR_HEAD` | Phase 7 Step 1 does |
 | --------------- | --------------------------- | ------------------- |
-| Terminal (`green` or triaged failure) | **equal** | **Skip the watch** — go to the outcome table below |
-| Terminal | **different** (branch moved since) | **Watch again**, resetting both counters to `0` — a new commit is a new wait. The recorded result describes a commit that is no longer head; reporting it would mark an unobserved commit green |
-| Pending, `attempts < 4`, SHA equal | — | Resume watching with the remaining attempts |
+| `observed_state` is `green` or `failing` (both terminal) | **equal** | **Skip the watch** — go to the outcome table below. `failing` means `create-pr` already triaged it; pick up at [Auto Fix](#auto-fix) rather than re-watching |
+| Terminal (`green` / `failing`) | **different** (branch moved since) | **Watch again**, resetting both counters to `0` — a new commit is a new wait. The recorded result describes a commit that is no longer head; reporting it would mark an unobserved commit green |
+| `observed_state` is `pending`, `attempts < 4`, SHA equal | — | Resume watching with the remaining attempts |
 | `attempts == 4`, SHA **equal** | — | **Do not watch again.** Run `gh pr checks <pr-number>` once, report pending checks, escalate |
 | `attempts == 4`, SHA **different** | — | Reset both counters to `0` and watch — the spent budget belonged to the previous commit |
 | State file exists but `observed_sha` is **empty** | undecidable | **Watch exactly once, then apply the normal rows.** An empty SHA means the writer did not follow the record-on-every-attempt rule (or predates it), so "different commit" cannot be distinguished from "budget already spent here". Do **not** reset the counters — resetting is how Phase 7 re-spends a budget `create-pr` already exhausted — but do **not** skip to escalation either: one bounded attempt, recorded properly, is a strictly better failure than never watching a branch that may have moved. After that attempt `observed_sha` is populated and every row above decides normally |
@@ -90,6 +90,7 @@ This is the fix for the one place Phases 6 and 7 genuinely duplicated work. The 
 
 | Outcome             | Next step                                                              |
 | ------------------- | ---------------------------------------------------------------------- |
+| Exit 127, or stderr matching `command not found` / `could not resolve` / `authentication` / `rate limit` | **Tooling failure, not a CI failure** — `timeout` is absent on stock macOS (use `gtimeout`). Report the command failure; do **not** route to Auto Fix. Mirrors [`create-pr` Step 7](../../../delivery/create-pr/SKILL.md) |
 | All checks succeed  | Go to Step 4 (report success), then optional cleanup                   |
 | One check fails     | Go to Auto Fix                                                         |
 | Multiple fail       | Go to Parallel CI Fixes                                                |
@@ -179,13 +180,13 @@ prompt: |
   CI_WATCH_STATE is informational only — never write to it.
 
   Return only:
-  - outcome: fixed | still-failing | gave-up
+  - outcome: green | still-failing | timed-out | gave-up   (ci-auto-fix's own vocabulary — do not translate it)
   - watched_sha: the PR head SHA your watch actually observed
   - attempts_used: how many watch attempts you spent
   - remaining_error: one short paragraph if still red, else empty
 ```
 
-**Reconcile when they return** — you are the single writer of the state file, using the same rule as [`create-pr` Step 9](../../../delivery/create-pr/SKILL.md): if the PR head moved, `put observed_sha` to the new head and reset both counters (a new commit is a new wait); if it did not, debit `attempts` by the reported total.
+**Reconcile when they return** — you are the single writer of the state file. Use the rule defined in [`create-pr` Step 9](../../../delivery/create-pr/SKILL.md), which is the owning surface; do not restate it differently here. In short: if the PR head moved, `put observed_sha` to the new head, reset `registration_attempts` to `0`, and set `attempts` to the reported `attempts_used` total (**not** `0` — those watches were spent on the new head); if it did not move, add the reported total to `attempts`. Either way `attempts` only ever rises toward the cap.
 
 Log to Progress Log:
 

--- a/skills/workflow/autonomous-workflow/templates/aw.agent.md
+++ b/skills/workflow/autonomous-workflow/templates/aw.agent.md
@@ -263,7 +263,8 @@ AW RUN COMPLETE
 - Needs you: [blockers or decisions, or "nothing"]
 ```
 
-Micro and Lite may collapse this to one line (`AW RUN COMPLETE — Micro, PR <url>, nothing needed`).
+Micro and Lite may collapse this to one line, but **`Degraded:` survives the collapse** — it is mandatory in every form:
+`AW RUN COMPLETE — Micro, PR <url>, degraded: none, nothing needed`.
 Full always emits the full block.
 
 Two rules that make it honest:


### PR DESCRIPTION
## Superseded by the revert of #107

`main` no longer contains #107 ([#110](https://github.com/mthines/agent-skills/pull/110) reverted it), so this PR's diff patches text that is no longer there. **Do not merge as-is.**

Leaving it open as the record of what the ten live findings were and how each was fixed — that content is the useful part and should feed the clean redo:

| Finding | Fix |
| --- | --- |
| `create-pr` Step 8 "spends from the same file" vs `ci-auto-fix`'s informational-only rule | Step 8 restated to the read-only / report-back contract |
| `phase-7` claiming "the same rule as Step 9" while stating a different one | `phase-7` defers to `create-pr` as the owning surface |
| `attempts` compared before increment → 5 watches, not 4 | Increment point made explicit |
| `registration_attempts` same off-by-one → 4 polls, not 3 | Same |
| "debit `attempts`" — wrong direction, the counter rises toward the cap | Now adds |
| `triaged failure` — a value nothing writes | Rows key on `green` / `failing` / `pending` |
| `outcome` enum mismatch with `ci-auto-fix` | Uses `ci-auto-fix`'s vocabulary verbatim |
| No exit-127 tooling row in `phase-7` | Mirrors `create-pr` Step 7 |
| `Degraded:` dropped from `aw`'s Micro/Lite one-liner | Example carries it |
| `CI_WATCH_ATTEMPTS` stale name | Removed |
| `get`/`put` don't survive a fresh Bash call | Labelled a per-call snippet |

The redo should keep the three fixes that addressed the reported symptom (explicit `timeout: 600000`, the honest `review-loop` skip, `aw`'s terminal block) and **drop the cross-skill watch budget**, which is where nearly every defect above originated.