### PR TITLE
fix(outcome-learning): signal (c) needs corroboration, not just a region touch

### DIFF
--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -36,7 +36,7 @@ The three resolution outcomes that carry signal:
 
 | Outcome | Signal | How to detect |
 | --- | --- | --- |
-| **Fixed** — author pushed a commit that addresses the comment | Comment was relevant; reinforce the detection class | Author commit touches `(path, line ± 10)` after comment posted; or `implement-suggestion` applied the comment (`verdict: applied`) |
+| **Fixed** — author pushed a commit that addresses the comment | Comment was relevant; reinforce the detection class | `implement-suggestion` applied the comment (`verdict: applied`); or an author commit touches `(path, line ± 10)` after the comment **and** the thread is resolved or the author acknowledged it. A region touch with the thread still open is **indeterminate** — record nothing (`outcome-learning.md § Signal (c) requires corroboration`). |
 | **Won't fix** — author explicitly declines the comment | Comment was not relevant for this codebase; consider suppressing | Author replies "won't fix", "by design", "intentional", "not going to change", "nwf", "n/a"; or 👎 reaction from the author |
 | **Ignored at merge** — PR merges with the comment unresolved, no acknowledgement | Weak not-relevant signal; accumulate before suppressing | PR state transitions to `MERGED`; thread still open; no fix commit; no explicit decline |
 
@@ -445,10 +445,23 @@ The script fetches the thread's replies and checks for:
 3. A commit after the comment that touches `(path, line ± 10)` → `relevant / fixed`
 4. Thread resolved with none of the above → `relevant / fixed` (human accepted)
 
+Checks 3 and 4 are sound **in this mode** because the trigger is the resolution event itself, so the
+thread is resolved by construction — the corroboration `outcome-learning.md § Signal (c) requires
+corroboration` demands is present. The same region-touch test is **not** sound on the post-merge
+fallback path, which has no such guarantee.
+
 **`pull_request: closed` (merged)** (mode `pr-merged`) —
 Fires when a PR merges.
-Sweeps all review threads, skips any that had a fix commit or a won't-fix reply
-(already captured by the first trigger), records the rest as `weak-not-relevant / ignored-at-merge`.
+Sweeps all review threads and records `weak-not-relevant / ignored-at-merge` for the ones that
+merged unresolved with no fix and no decline.
+
+Two exclusions, and they are different:
+- A thread that was **resolved** before merge was already captured by the first trigger — skip it,
+  it has a record.
+- A thread that merged **unresolved but with a commit touching its region** was *not* captured (the
+  first trigger never fired for it) and is **indeterminate** — skip it with **no record at all**.
+  Do not write `ignored-at-merge` for it: the region was edited, so "ignored" is a claim the
+  evidence does not support. See `outcome-learning.md § Signal (c) requires corroboration`.
 
 **What the reusable workflow does:**
 - Checks out `mthines/agent-skills` to get `scripts/record-comment-relevance.mjs`.
@@ -526,7 +539,7 @@ When the `outcome-learning.md` gh-api measurement step fires (post-merge via
 `/review-outcomes <pr>` or at the tail of `--watch`), also emit a
 comment-relevance memory for each measured comment:
 
-- Signal (c) — fix commit touches `(path, line ± 10)` → write `relevant / fixed`.
+- Signal (c) — fix commit touches `(path, line ± 10)` **and** the thread is resolved, `implement-suggestion` recorded `verdict: applied`, or the author acknowledged → write `relevant / fixed`. A bare region touch on an open thread is indeterminate: **write nothing** (`outcome-learning.md § Signal (c) requires corroboration`). This path is the one the in-run re-scan predicate routes downgraded threads into, so an uncorroborated write here would land exactly the record that guard prevents.
 - Signal (a) — 👎 reaction from the PR author → write `not-relevant / wont-fix`.
 - Signal (b) — author reply correcting the finding, no fix commit → write `not-relevant / wont-fix`.
 - PR merged with thread open, no fix, no decline → write `weak-not-relevant / ignored-at-merge`.

--- a/agents/shared/rules/comment-relevance-memory.md
+++ b/agents/shared/rules/comment-relevance-memory.md
@@ -445,23 +445,52 @@ The script fetches the thread's replies and checks for:
 3. A commit after the comment that touches `(path, line ± 10)` → `relevant / fixed`
 4. Thread resolved with none of the above → `relevant / fixed` (human accepted)
 
-Checks 3 and 4 are sound **in this mode** because the trigger is the resolution event itself, so the
-thread is resolved by construction — the corroboration `outcome-learning.md § Signal (c) requires
-corroboration` demands is present. The same region-touch test is **not** sound on the post-merge
-fallback path, which has no such guarantee.
+**Check 3** is sound in this mode, and only in this mode: the trigger is the resolution event, so the
+thread is resolved by construction and the corroboration
+``outcome-learning.md § Signal (c) requires corroboration`` demands is present. The same region-touch
+test is **not** sound on the post-merge fallback path, which has no such guarantee.
+
+**Check 4 is not signal (c) at all** and that argument does not reach it. There is no region touch,
+so resolution is the *sole* evidence rather than corroboration of anything. It is retained as
+pre-existing behaviour, but note what it infers over: `pr-reviewer` Step 2.9c resolves threads it
+classified `declined` as well as `fixed` / `acknowledged`, so a decline whose wording misses
+`WONT_FIX_RE` — a different matcher, free to drift from Step 2.9c's phrase list — resolves, fires
+this trigger, and records `relevant / fixed` for a finding the author rejected. Not introduced here
+and not fixed here; flagged so the next change to either matcher knows the two are coupled.
 
 **`pull_request: closed` (merged)** (mode `pr-merged`) —
 Fires when a PR merges.
-Sweeps all review threads and records `weak-not-relevant / ignored-at-merge` for the ones that
-merged unresolved with no fix and no decline.
+Sweeps the PR's review threads and records `weak-not-relevant / ignored-at-merge` for the ones it
+cannot account for otherwise.
 
-Two exclusions, and they are different:
-- A thread that was **resolved** before merge was already captured by the first trigger — skip it,
-  it has a record.
-- A thread that merged **unresolved but with a commit touching its region** was *not* captured (the
-  first trigger never fired for it) and is **indeterminate** — skip it with **no record at all**.
-  Do not write `ignored-at-merge` for it: the region was edited, so "ignored" is a claim the
-  evidence does not support. See `outcome-learning.md § Signal (c) requires corroboration`.
+**What `modePrMerged` actually skips** (`scripts/record-comment-relevance.mjs`), and it is only two
+things, both REST-derivable:
+
+- A thread with a **won't-fix reply** (`WONT_FIX_RE`) — the decline is the record.
+- A thread with a **commit touching its region** since the comment. This skip is now load-bearing in
+  a way it was not before: such a thread is **indeterminate**, not "already captured". The region
+  was edited, so `ignored-at-merge` is a claim the evidence does not support; and the first trigger
+  (`thread-resolved`) never fired for it unless it was also resolved. Skipping it writes nothing,
+  which is the correct outcome — see
+  ``outcome-learning.md § Signal (c) requires corroboration``.
+
+**Known gap — resolved-with-no-touch double-writes.** The sweep has **no resolved-state check**, and
+cannot get one from the endpoint it reads: the script fetches `/pulls/{n}/comments`, and GitHub does
+not expose thread resolution in the REST comments list (the script says so at its own skip block).
+So a thread that was **resolved with no region touch and no matching decline phrase** — precisely
+`thread-resolved` mode's check 4, the "human accepted" fallthrough — takes `relevant / fixed` from
+the first trigger and then `weak-not-relevant / ignored-at-merge` from this sweep, on the same
+fingerprint. Two opposite directional records for one thread; per § Contradiction handling they
+surface as a contradiction rather than resolving.
+
+This predates the corroboration rule and is **not** fixed here. Closing it needs the same GraphQL
+`reviewThreads` query `outcome-learning.md § Step 3b` adds — a change to the committed script, not
+to this document. It is recorded rather than papered over because the alternative is a doc that
+claims a protection the implementation does not provide.
+
+Until then the Action path is dormant: `.github/workflows/reviewer-comment-relevance.yml` is still
+uncommitted (see the availability note in [`memory-buckets.md`](./memory-buckets.md)), so this is a
+spec defect awaiting a fix, not a live source of contradictory records.
 
 **What the reusable workflow does:**
 - Checks out `mthines/agent-skills` to get `scripts/record-comment-relevance.mjs`.

--- a/agents/shared/rules/outcome-learning.md
+++ b/agents/shared/rules/outcome-learning.md
@@ -65,6 +65,12 @@ These become new **detection candidates** — patterns to watch for in future ru
 Use `gh api` (read-only).
 Run after merge, or on-demand.
 
+**This sequence is REST plus one GraphQL call.** Steps 1–5 are REST, but signal (c)'s primary
+corroboration is thread resolution, and `isResolved` is a GraphQL `reviewThreads` field that no REST
+endpoint exposes. Step 3b acquires it. Without that step an agent following this sequence literally
+cannot evaluate the corroboration signal (c) requires, so signal (c) would never fire — a far larger
+behaviour change than "requires corroboration", and a silent one.
+
 ### Step 1 — Resolve the comment list
 
 ```bash
@@ -96,6 +102,27 @@ gh api repos/$REPO/pulls/$PR_NUMBER/comments \
 
 If a reply exists from the PR author AND no fix commit touches the commented line (Step 4 returns empty) → signal (b): the finding was challenged without action.
 
+### Step 3b — Thread resolution state (needed by signal (c))
+
+The **same** query `prior-comment-awareness.md § fetch existing PR comment state` runs, including its
+`endCursor` pagination walk — do not re-derive it, and do not drop the walk (`reviewThreads` caps at
+100 and `--paginate` does not work for GraphQL):
+
+```bash
+OWNER="${REPO%%/*}"; REPO_NAME="${REPO##*/}"
+# Walk reviewThreads(first:100, after:$cursor) until hasNextPage is false, exactly as
+# prior-comment-awareness.md § Thread state does, and merge the pages.
+# Build COMMENT_TO_THREAD: Map<databaseId, {threadId, isResolved}>.
+```
+
+Build `COMMENT_TO_THREAD` from the result, the same map that rule builds.
+
+**If the walk cannot complete** (permissions, API error, unpaged remainder), treat every affected
+comment's resolution state as **unknown** — never as unresolved. An unknown state fails corroboration,
+so those comments become indeterminate and are not written, per § Signal (c) requires corroboration.
+Log `[outcome] thread state unavailable — <N> comment(s) indeterminate`. Guessing "unresolved" here
+would convert a tooling gap into a stream of false `ignored-at-merge` records.
+
 ### Step 4 — Signal (c): author pushed a fix touching the commented line
 
 ```bash
@@ -116,7 +143,7 @@ posted — **and** corroboration that the finding was actually addressed.
 
 A commit touching the region is evidence that the author *edited near the finding*, not that they
 *fixed it*. Treating the touch alone as `relevant / fixed` is the same vacuous inference
-`thread-resolution.md § \`fixed\` requires that this run re-scanned the region` removes from the
+``thread-resolution.md § `fixed` requires that this run re-scanned the region`` removes from the
 in-run path: clause 1 without clause 2.
 
 It matters more here than it looks, because the in-run fix **deliberately routes threads to this
@@ -129,7 +156,7 @@ Corroboration is any **one** of:
 
 | Corroborating signal | Why it is evidence |
 | --- | --- |
-| The thread is **resolved** (`isResolved == true`) | Someone — author, reviewer, or fixer — asserted it was dealt with. This is the authority `prior-comment-awareness.md § Thread state` already designates. |
+| The thread is **resolved** (`isResolved == true`), from `COMMENT_TO_THREAD` (Step 3b) | Someone — author, reviewer, or fixer — asserted it was dealt with. This is the authority `prior-comment-awareness.md § Thread state` already designates; Step 3b is where this path obtains it. |
 | `implement-suggestion` recorded `verdict: applied` for the fingerprint | A gated apply landed the change; the `review-outcomes` bus carries it. |
 | The author replied with an acknowledgement ("fixed", "done", "addressed") | The author's own words. |
 

--- a/agents/shared/rules/outcome-learning.md
+++ b/agents/shared/rules/outcome-learning.md
@@ -49,7 +49,7 @@ After a PR is merged (or on-demand via `/review-outcomes <pr>`), measure the fol
 | --- | --- | --- |
 | **(a) Dismissed / 👎-reacted** | Author found the comment unhelpful or wrong | `gh api .../reactions` returns 👎 from PR author |
 | **(b) Author reply correcting the finding** | Finding was wrong for a stated reason | Thread contains an author reply, no follow-up commit touching the line |
-| **(c) Author pushed a fix touching the commented line** | Finding was acted on | A commit after the review comment touches `(path, line ± 5)` |
+| **(c) Author pushed a fix touching the commented line** | Finding was acted on | A commit after the review comment touches `(path, line ± 5)` **and** the thread is resolved. A region touch alone is not this signal — see *Signal (c) requires corroboration*. |
 
 Signal (c) is the primary gh-api resolution signal — it is the Bugbot metric.
 Signals (a) and (b) are the noise signals — they teach the agent where it over-flags.
@@ -109,7 +109,43 @@ gh api repos/$REPO/commits/$SHA \
 # If the patch hunk includes line ± 5 → resolution confirmed
 ```
 
-Signal (c) requires at least one commit SHA that touches `(path, line ± 5)` after the comment was posted.
+Signal (c) requires at least one commit SHA that touches `(path, line ± 5)` after the comment was
+posted — **and** corroboration that the finding was actually addressed.
+
+#### Signal (c) requires corroboration
+
+A commit touching the region is evidence that the author *edited near the finding*, not that they
+*fixed it*. Treating the touch alone as `relevant / fixed` is the same vacuous inference
+`thread-resolution.md § \`fixed\` requires that this run re-scanned the region` removes from the
+in-run path: clause 1 without clause 2.
+
+It matters more here than it looks, because the in-run fix **deliberately routes threads to this
+path**. A candidate the re-scan predicate downgrades is left `unaddressed` and open, precisely so a
+human decides. If a bare region touch then writes `relevant / fixed` at merge, the false record the
+in-run guard prevented lands anyway, one step later — and the guard buys a thread that stays open
+but no protection for the durable signal it was written to protect.
+
+Corroboration is any **one** of:
+
+| Corroborating signal | Why it is evidence |
+| --- | --- |
+| The thread is **resolved** (`isResolved == true`) | Someone — author, reviewer, or fixer — asserted it was dealt with. This is the authority `prior-comment-awareness.md § Thread state` already designates. |
+| `implement-suggestion` recorded `verdict: applied` for the fingerprint | A gated apply landed the change; the `review-outcomes` bus carries it. |
+| The author replied with an acknowledgement ("fixed", "done", "addressed") | The author's own words. |
+
+**With a region touch but none of the three, write nothing.** Do not fall through to
+`weak-not-relevant / ignored-at-merge` either: an open thread whose region was edited is genuinely
+*indeterminate*, and guessing in either direction poisons the signal — `relevant / fixed` rewards a
+finding that may still be live, `weak-not-relevant` punishes one that may have been fixed. Log it as
+`[outcome] INDETERMINATE <path>:<line> — region touched, thread open, no acknowledgement` and move
+on. A signal bucket is allowed to have gaps; it is not allowed to have invented entries.
+
+This also corrects the `pr-merged` sweep's skip rule in
+[`comment-relevance-memory.md`](./comment-relevance-memory.md): it skips threads "that had a fix
+commit … (already captured by the first trigger)", but the first trigger is
+`pull_request_review_thread: resolved`, which never fired for a thread that was never resolved. Those
+threads are indeterminate, not captured — so the sweep must skip them **as indeterminate**, not as
+already-recorded.
 
 ### Step 5 — Human-missed detection candidates
 
@@ -201,7 +237,7 @@ Outcome signals add a parallel gate:
 | --- | --- |
 | ≥ 3 `applied` verdicts from `review-outcomes` (same fingerprint) | Promote to `reviewer-lessons` — this pattern reliably gets fixed |
 | ≥ 3 `rejected-at-validation` or `reverted-after-ci` verdicts (same fingerprint) | Promote as a **noise pattern** — consider adding to a `filters:` entry in `.github/review.yaml` |
-| ≥ 3 gh-api signal (c) resolution confirmations (fallback path) | Promote to `diagnose` slow tier — pattern reliably gets fixed |
+| ≥ 3 gh-api signal (c) resolution confirmations (fallback path) — each **corroborated** per *Signal (c) requires corroboration*; indeterminate touches never count | Promote to `diagnose` slow tier — pattern reliably gets fixed |
 | ≥ 3 dismissals via gh-api signal (a) (same pattern, fallback path) | Promote as a **noise pattern** — consider `filters:` suppression |
 | ≥ 2 human-catch candidates of the same class | Surface as a detection candidate to the user; suggest rubric expansion |
 

--- a/agents/shared/rules/thread-resolution.md
+++ b/agents/shared/rules/thread-resolution.md
@@ -120,7 +120,7 @@ so `fixed` fires there exactly as it should. Reading the predicate as "no findin
 ⇒ no `fixed`" would disable the primary resolve path on precisely the runs where
 it is most correct.
 
-Three paths fail the predicate, and it covers all three without enumerating them:
+Four paths fail the predicate, and it covers all four without enumerating them:
 
 | Path | Conjunct that fails | Effect |
 | --- | --- | --- |


### PR DESCRIPTION
Narrow follow-up to #114. One real fix plus one free count correction; the remaining fourteen non-blocking findings stay parked.

## Why this one and not the others

#114's in-run re-scan predicate stops a still-live finding being *resolved* as `fixed`. It does not stop the false *durable record* — it defers it.

Signal (c) on the post-merge path fires on *"a commit after the comment touches `(path, line ± 10)`"*, with no thread-state and no re-scan clause, at a **wider** tolerance than the ±5 the in-run guard uses. So the record #114 prevents during the run lands at merge instead.

That is not incidental — #114 deliberately routes threads into this path. A candidate the predicate downgrades is left `unaddressed` and open *precisely so a human decides*. If a bare region touch then writes `relevant / fixed` at merge, the guard buys a thread that stays open and no protection at all for the signal it was written to protect.

## The fix

A region touch means the author edited *near* the finding, not that they fixed it — clause 1 without clause 2, the same vacuous inference #114 removed in-run. Signal (c) now requires one corroborating signal:

| Corroboration | Why it is evidence |
|---|---|
| Thread is resolved (`isResolved`) | Someone asserted it was dealt with — the authority `prior-comment-awareness.md` already designates |
| `implement-suggestion` recorded `verdict: applied` | A gated apply landed the change |
| Author replied "fixed" / "done" / "addressed" | The author's own words |

**With a touch and none of the three, write nothing.** Not `relevant / fixed`, and not `weak-not-relevant / ignored-at-merge` either. An open thread whose region was edited is genuinely *indeterminate*, and guessing in either direction poisons the signal: `relevant/fixed` rewards a finding that may still be live, `weak-not-relevant` punishes one that may have been fixed. A signal bucket may have gaps; it may not have invented entries.

## Two consumers corrected with it

- **The GitHub Action's `thread-resolved` mode keeps its region-touch check.** There the trigger *is* the resolution event, so corroboration holds by construction. Worth stating explicitly, since the same test is unsound on the fallback path — that asymmetry is exactly what made this easy to miss.
- **The `pr-merged` sweep** skipped fix-commit threads as *"already captured by the first trigger"*. The first trigger is `thread-resolved`, which never fired for a thread that was never resolved — so those threads got no signal from either path. Now skipped explicitly as indeterminate rather than silently.

The promotion gate inherits it: only corroborated confirmations count toward the ≥ 3 that promotes a pattern to the `diagnose` tier. Uncorroborated touches previously could have promoted a pattern on evidence that never existed.

## Also

`thread-resolution.md` said "Three paths" over a four-row table, disagreeing with `pr-reviewer.md`'s correct count of four.

## Verification

`node scripts/eval/l1.mjs` — 230/230.

Same standing caveat: consistency fixes verified by reading. None of the sticky contract has executed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115XYPfknyPW79DQw55C7na

---
_Generated by [Claude Code](https://claude.ai/code/session_0115XYPfknyPW79DQw55C7na)_