### PR TITLE
feat(pr-reviewer): validate the POSTED report shape from outside the agent

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,6 +28,18 @@
         "url": "https://github.com/mthines/agent-skills",
         "path": "plugins/pr-relevance-memory"
       }
+    },
+    {
+      "name": "pr-reviewer-shape-guard",
+      "description": "GitHub Actions reusable workflow that validates a POSTED pr-reviewer report body against the report shape contract, from outside the agent — the only guard that sees what actually reached a PR. Install the caller template (templates/report-shape-caller.yml); no secrets required.",
+      "version": "1.0.0",
+      "author": { "name": "mthines" },
+      "license": "MIT",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/mthines/agent-skills",
+        "path": "plugins/pr-reviewer-shape-guard"
+      }
     }
   ]
 }

--- a/.github/workflows/reviewer-report-shape-self.yml
+++ b/.github/workflows/reviewer-report-shape-self.yml
@@ -1,0 +1,45 @@
+# pr-reviewer report shape guard — this repo's own caller.
+#
+# Generated from plugins/pr-reviewer-shape-guard/templates/report-shape-caller.yml, with the
+# `uses:` pointed at the local path instead of @main so a change to the reusable workflow is
+# exercised by the PR that makes it, rather than only after merge.
+#
+# Copy this file to:
+#   YOUR_REPO/.github/workflows/reviewer-report-shape.yml
+#
+# No secrets required. That is the entire setup.
+#
+# What this does:
+#   Every time pr-reviewer posts a review or a comment, this checks the POSTED body against the
+#   report shape contract — marker present, `Review details` accordion present and collapsed,
+#   nothing the accordion owns rendered above it, no advisory verdict, no link caged in a code
+#   span, and every declared count equal to the list it counts.
+#
+#   On a violation it leaves ONE sticky notice on the PR naming exactly what is malformed. It never
+#   edits or deletes the report itself.
+#
+# Why you want it: every other guard on this contract runs inside the agent's own control flow, so a
+# run that hand-writes the body is unobserved. This is the only check that sees what was published.
+#
+# See: https://github.com/mthines/agent-skills/blob/main/plugins/pr-reviewer-shape-guard/README.md
+
+name: Reviewer report shape
+
+on:
+  pull_request_review:
+    types: [submitted, edited]
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  shape:
+    # issue_comment fires on plain issues too; PR-only, and skip humans' own comments cheaply.
+    if: github.event_name == 'pull_request_review' || github.event.issue.pull_request
+    uses: ./.github/workflows/reviewer-report-shape.yml
+    with:
+      # Leave empty to check every body that looks like a pr-reviewer report. Set it to your
+      # reviewer's login(s) to narrow — but note a drifting run may post under an unexpected
+      # identity, which is exactly the case you want caught.
+      reviewer-logins: ""
+      # Set true only if you want a malformed report to fail a required check.
+      fail-the-check: false

--- a/.github/workflows/reviewer-report-shape.yml
+++ b/.github/workflows/reviewer-report-shape.yml
@@ -1,0 +1,145 @@
+# Reusable workflow: validate a POSTED pr-reviewer body against the shape contract.
+#
+# This is the only check on this contract that runs outside the agent. L1 validates the repository,
+# render-report.mjs fails closed only when it is invoked, and the Step 4a pre-write assertions are
+# prose in the file a drifting run has already skipped. A run that hand-writes the body is invisible
+# to all three — observed on mthines/lorekit#503, where the same definition produced the correct
+# shape three times and a flat, marker-less body on the fourth run 24 minutes later.
+#
+# Behaviour: read-only on the reviewer's own objects. It never edits or deletes a report. On a
+# violation it posts (or rewrites) ONE sticky notice comment, so a repeatedly-drifting run leaves one
+# comment rather than a thread per run. On the next conforming post it rewrites that notice to say so
+# rather than deleting it, keeping the record that drift happened.
+#
+# Callers: copy plugins/pr-reviewer-shape-guard/templates/report-shape-caller.yml into your repo.
+
+name: Reviewer report shape
+
+on:
+  workflow_call:
+    inputs:
+      reviewer-logins:
+        description: >
+          Comma-separated logins whose posts are checked. Leave empty to check every body that
+          looks like a pr-reviewer report — which is the safer default, because a drifting run may
+          post under an unexpected identity.
+        required: false
+        type: string
+        default: ""
+      fail-the-check:
+        description: >
+          When true the job exits non-zero on a violation, so the guard can gate a branch. Default
+          false: the notice comment is the signal, and a malformed report should not block a PR whose
+          code may be fine.
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the validator
+        uses: actions/checkout@v4
+        with:
+          repository: mthines/agent-skills
+          ref: main
+          sparse-checkout: scripts/validate-report-shape.mjs
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Resolve the posted body
+        id: body
+        env:
+          # Written via the environment, never interpolated into the script: a review body is
+          # attacker-controlled text and `${{ }}` inside a run block would splice it into shell.
+          EVENT_NAME: ${{ github.event_name }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          ALLOWED: ${{ inputs.reviewer-logins }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request_review" ]; then
+            printf '%s' "$REVIEW_BODY" > body.txt; AUTHOR="$REVIEW_AUTHOR"
+          else
+            printf '%s' "$COMMENT_BODY" > body.txt; AUTHOR="$COMMENT_AUTHOR"
+          fi
+          echo "author=$AUTHOR" >> "$GITHUB_OUTPUT"
+          if [ -n "${ALLOWED:-}" ] && ! printf '%s' ",$ALLOWED," | grep -qF ",$AUTHOR,"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "author $AUTHOR not in reviewer-logins — skipping"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate the shape
+        if: steps.body.outputs.skip == 'false'
+        id: validate
+        run: |
+          set +e
+          node scripts/validate-report-shape.mjs body.txt > verdict.json 2> summary.txt
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          set -e
+          cat summary.txt
+          {
+            echo "### Reviewer report shape"
+            echo
+            sed 's/^/    /' summary.txt
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report the verdict on the PR
+        if: steps.body.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          AUTHOR: ${{ steps.body.outputs.author }}
+          EXIT: ${{ steps.validate.outputs.exit }}
+        run: |
+          set -euo pipefail
+          MARKER="<!-- PR_REVIEWER_SHAPE_GUARD -->"
+          KIND=$(node -e 'process.stdout.write(require("./verdict.json").kind)')
+          [ "$KIND" = "not-a-reviewer-body" ] && { echo "not a reviewer body — nothing to report"; exit 0; }
+
+          EXISTING=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq "[.[] | select((.body // \"\") | contains(\"$MARKER\"))] | last // empty" \
+            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(String(JSON.parse(s).id))}catch{process.stdout.write("")}})')
+
+          if [ "$EXIT" = "0" ]; then
+            [ -z "$EXISTING" ] && { echo "conforms, no prior notice — nothing to post"; exit 0; }
+            { echo "$MARKER"; echo "✅ The latest \`pr-reviewer\` body from \`$AUTHOR\` conforms to the report shape contract ($KIND)."; } > note.md
+          else
+            { echo "$MARKER"
+              echo "⚠️ **The last \`pr-reviewer\` body from \`$AUTHOR\` does not match the report shape contract.**"
+              echo
+              echo "Classified \`$KIND\`. The report was not produced by \`render-report.mjs\`, or was edited after it was:"
+              echo
+              node -e 'for (const v of require("./verdict.json").violations) console.log(`- \`${v.code}\` — ${v.detail}`)'
+              echo
+              echo "This does not mean the review's findings are wrong — only that the body is malformed,"
+              echo "so consumers that parse it (\`implement-suggestion\`, the reviewer's own carry-forward)"
+              echo "will read it incompletely. Contract:"
+              echo "[\`agents/pr-reviewer.md § REPORT_BODY format\`](https://github.com/mthines/agent-skills/blob/main/agents/pr-reviewer.md)."
+            } > note.md
+          fi
+
+          if [ -n "$EXISTING" ]; then
+            gh api -X PATCH "repos/$GH_REPO/issues/comments/$EXISTING" -F body=@note.md >/dev/null
+            echo "updated notice $EXISTING"
+          else
+            gh api -X POST "repos/$GH_REPO/issues/$PR_NUMBER/comments" -F body=@note.md >/dev/null
+            echo "posted notice"
+          fi
+
+      - name: Fail the check when asked
+        if: steps.body.outputs.skip == 'false' && inputs.fail-the-check && steps.validate.outputs.exit != '0'
+        run: exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,9 @@ Validate with `claude plugin validate plugins/agent-tasks-hooks`.
 `pr-reviewer` body against the report shape contract, from outside the agent.
 Logic lives in `scripts/validate-report-shape.mjs`; the reusable workflow is
 `.github/workflows/reviewer-report-shape.yml`, and this repo consumes it via
-`.github/workflows/reviewer-report-shape-self.yml` (local `uses:` so a change is exercised by its own PR).
+`.github/workflows/reviewer-report-shape-self.yml` (local `uses:`, which always resolves from the default
+branch — `pull_request_review` and `issue_comment` workflows never run a PR's copy, so a change to the
+reusable workflow is exercised here only after merge; pre-merge coverage comes from L1 `G26`).
 Any repo adds the caller from `templates/report-shape-caller.yml` — no secrets.
 Fires on `pull_request_review` and `issue_comment`, posts one sticky notice per PR on a violation,
 and never edits or deletes the report itself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,23 @@ The extension rejects events with a known `schemaVersion` that is not `1`; missi
 Sentinel file at `${CLAUDE_PLUGIN_DATA}/sentinel` controls activation.
 Validate with `claude plugin validate plugins/agent-tasks-hooks`.
 
+### Plugin: pr-reviewer-shape-guard
+
+`plugins/pr-reviewer-shape-guard/` — GitHub Actions reusable workflow that validates a **posted**
+`pr-reviewer` body against the report shape contract, from outside the agent.
+Logic lives in `scripts/validate-report-shape.mjs`; the reusable workflow is
+`.github/workflows/reviewer-report-shape.yml`, and this repo consumes it via
+`.github/workflows/reviewer-report-shape-self.yml` (local `uses:` so a change is exercised by its own PR).
+Any repo adds the caller from `templates/report-shape-caller.yml` — no secrets.
+Fires on `pull_request_review` and `issue_comment`, posts one sticky notice per PR on a violation,
+and never edits or deletes the report itself.
+**Why it is the only guard that matters for drift:** L1, the renderer's fail-closed behaviour, the
+Step 4a pre-write assertions and the ingest round-trip all run inside the agent's control flow or
+against fixtures, so a run that hand-writes the body is invisible to every one of them — observed on
+`mthines/lorekit#503`, where one definition produced the correct shape three times and a flat,
+marker-less body on the fourth run 24 minutes later. Guarded by L1 `G26`, which executes the
+validator against real posted bodies kept in `scripts/eval/fixtures/posted-bodies/`.
+
 ### Plugin: pr-relevance-memory
 
 `plugins/pr-relevance-memory/` — GitHub Actions reusable workflow distribution plugin.

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ That is the entire integration.
 skills/                   44 skills, each with SKILL.md (some with rules/, references/, templates/, scripts/)
   testing/test-auto-fix/    stack-agnostic test healer — bootstrap, classify, confidence-gate, regression-detect
 agents/                   5 agents (pr-reviewer, linear-ticket-investigator, rca-investigator, bug-fix-verifier, feature-pr-verifier)
-plugins/                  1 Claude Code plugin (agent-tasks-hooks)
+plugins/                  3 Claude Code plugins (agent-tasks-hooks, pr-relevance-memory, pr-reviewer-shape-guard)
 packages/                 VS Code extension (vscode-agent-tasks)
 .claude-plugin/           marketplace.json — plugin distribution manifest
 scripts/                  Local symlink sync (scripts/sync-symlinks.sh)

--- a/plugins/pr-reviewer-shape-guard/.claude-plugin/plugin.json
+++ b/plugins/pr-reviewer-shape-guard/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "pr-reviewer-shape-guard",
+  "version": "1.0.0",
+  "description": "GitHub Actions reusable workflow that validates a POSTED pr-reviewer report body against the report shape contract, from outside the agent",
+  "author": { "name": "mthines" },
+  "repository": "https://github.com/mthines/agent-skills",
+  "license": "MIT",
+  "keywords": ["reviewer", "pr-review", "report-shape", "github-actions", "validation"]
+}

--- a/plugins/pr-reviewer-shape-guard/README.md
+++ b/plugins/pr-reviewer-shape-guard/README.md
@@ -1,0 +1,71 @@
+# pr-reviewer report shape guard
+
+A GitHub Actions reusable workflow that validates a **posted** `pr-reviewer` body against the report
+shape contract, from outside the agent.
+
+## Why this exists
+
+The report shape has four layers of enforcement, and until this one they all ran somewhere the agent
+controls:
+
+| Guard | Where it runs | Sees a posted report? |
+| --- | --- | --- |
+| L1 `G25` (439 checks) | CI, against `agent-skills` | **No** — it validates the repository |
+| `render-report.mjs` fail-closed | inside the run | Only if the run invokes it |
+| Step 4a pre-write assertions | inside the run | Only if the run reaches them |
+| ingest round-trip | CI, against fixtures | **No** — committed fixtures, not live output |
+
+So a run that simply hand-writes the body is invisible to every one of them. That is not theoretical.
+On `mthines/lorekit#503` the same agent definition produced the correct shape three times and then a
+flat, marker-less body on the fourth run 24 minutes later:
+
+| Time (UTC) | Review | Shape |
+| --- | --- | --- |
+| 17:44 | `4964076700` | accordion, counts, links correct |
+| 17:56 | `4964171425` | correct |
+| 18:07 | `4964277130` | correct |
+| 18:31 | `4964475125` | **flat** — no marker, no accordion, gate table at top level |
+
+This workflow is the first check that looks at what was actually published.
+
+## What it checks
+
+Run `node scripts/validate-report-shape.mjs <file>` locally to see the same verdict.
+
+| Code | Meaning |
+| --- | --- |
+| `missing-report-marker` | The body carries report sections but no `<!-- PR_REVIEWER_REPORT -->` |
+| `report-marked-as-pointer` | A full report carries the pointer marker, so a later run recovers it as a pointer and reads the report as absent |
+| `no-review-details-accordion` | No `<details>` immediately followed by `<summary>Review details` — the report renders expanded |
+| `accordion-pre-expanded` | A `<details>` carries `open` |
+| `accordion-owned-line-at-top-level` | A gate table, run mode, memories, quality or footer line renders above the accordion |
+| `verdict-in-posted-body` | The Step 3 advisory verdict is terminal-only |
+| `link-caged-in-code-span` | A markdown link wrapped in backticks renders as dead monospace text |
+| `count-disagrees-with-list` | `**Open bot threads (N)**` does not equal the bullets under it |
+| `summary-count-disagrees` | The `<summary>` counter disagrees with the list |
+| `pointer-too-long` / `pointer-carries-sections` | A pointer body grew into a report |
+
+A body that is not a `pr-reviewer` report or pointer is ignored, so ordinary PR comments never
+trigger it.
+
+## Installation
+
+1. Copy `templates/report-shape-caller.yml` to `YOUR_REPO/.github/workflows/reviewer-report-shape.yml`.
+2. That's it — no secrets.
+
+The validation logic stays in `mthines/agent-skills` and tracks `@main`, so pin a tag instead if you
+want to control upgrades.
+
+## What it does on a violation
+
+It posts **one** sticky notice comment per PR (marked `<!-- PR_REVIEWER_SHAPE_GUARD -->`), rewritten
+in place on later runs, so a repeatedly-drifting reviewer leaves one comment rather than a thread per
+run. When a later post conforms it rewrites the notice to say so rather than deleting it, keeping the
+record that drift happened.
+
+It is **read-only on the reviewer's objects**: it never edits or deletes a report, because a
+malformed body is still evidence of what the run did, and rewriting it would hide the failure this
+guard exists to surface.
+
+By default a violation does not fail the check — a malformed report body does not mean the review's
+findings are wrong. Set `fail-the-check: true` in the caller to gate a branch on it.

--- a/plugins/pr-reviewer-shape-guard/templates/report-shape-caller.yml
+++ b/plugins/pr-reviewer-shape-guard/templates/report-shape-caller.yml
@@ -1,0 +1,41 @@
+# pr-reviewer report shape guard — caller workflow
+#
+# Copy this file to:
+#   YOUR_REPO/.github/workflows/reviewer-report-shape.yml
+#
+# No secrets required. That is the entire setup.
+#
+# What this does:
+#   Every time pr-reviewer posts a review or a comment, this checks the POSTED body against the
+#   report shape contract — marker present, `Review details` accordion present and collapsed,
+#   nothing the accordion owns rendered above it, no advisory verdict, no link caged in a code
+#   span, and every declared count equal to the list it counts.
+#
+#   On a violation it leaves ONE sticky notice on the PR naming exactly what is malformed. It never
+#   edits or deletes the report itself.
+#
+# Why you want it: every other guard on this contract runs inside the agent's own control flow, so a
+# run that hand-writes the body is unobserved. This is the only check that sees what was published.
+#
+# See: https://github.com/mthines/agent-skills/blob/main/plugins/pr-reviewer-shape-guard/README.md
+
+name: Reviewer report shape
+
+on:
+  pull_request_review:
+    types: [submitted, edited]
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  shape:
+    # issue_comment fires on plain issues too; PR-only, and skip humans' own comments cheaply.
+    if: github.event_name == 'pull_request_review' || github.event.issue.pull_request
+    uses: mthines/agent-skills/.github/workflows/reviewer-report-shape.yml@main
+    with:
+      # Leave empty to check every body that looks like a pr-reviewer report. Set it to your
+      # reviewer's login(s) to narrow — but note a drifting run may post under an unexpected
+      # identity, which is exactly the case you want caught.
+      reviewer-logins: ""
+      # Set true only if you want a malformed report to fail a required check.
+      fail-the-check: false

--- a/plugins/pr-reviewer-shape-guard/templates/report-shape-caller.yml
+++ b/plugins/pr-reviewer-shape-guard/templates/report-shape-caller.yml
@@ -27,6 +27,13 @@ on:
   issue_comment:
     types: [created, edited]
 
+# Required. A called workflow can only ever narrow the caller's token, never widen it, so on a repo
+# whose default GITHUB_TOKEN is read-only the reusable workflow's `pull-requests: write` request
+# fails the run. Declaring it here is what keeps this a one-file install.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   shape:
     # issue_comment fires on plain issues too; PR-only, and skip humans' own comments cheaply.

--- a/scripts/eval/fixtures/posted-bodies/README.md
+++ b/scripts/eval/fixtures/posted-bodies/README.md
@@ -1,0 +1,15 @@
+# Posted-body fixtures
+
+Real `pr-reviewer` bodies as published, kept so the out-of-band validator
+(`scripts/validate-report-shape.mjs`) is tested against production output rather than only against
+output we generated ourselves.
+
+| File | Origin | Expected verdict |
+| --- | --- | --- |
+| `lorekit-503-flat.md` | `mthines/lorekit#503` review `4964475125` (2026-08-18 18:31 UTC) | violations — no marker, no accordion, gate table and diagnostics at top level |
+| `lorekit-503-report-as-pointer.md` | shape of reviews `4964076700` / `4964171425` / `4964277130` | violations — a full report body stamped `<!-- PR_REVIEWER_POINTER -->` |
+
+Both are abridged to the structure under test; the prose is not load-bearing. They exist because a
+validator written only against self-generated fixtures tends to encode the shape we *expect* to see
+rather than the shape that actually shipped — the flat body omitted `**Run mode**`, which broke the
+first classifier I wrote.

--- a/scripts/eval/fixtures/posted-bodies/lorekit-503-flat.md
+++ b/scripts/eval/fixtures/posted-bodies/lorekit-503-flat.md
@@ -1,0 +1,16 @@
+Reviewed your changes — no blocking issues, **2 warnings**: 6 open bot threads; 4 non-blocking findings.
+
+<sup>Reviewed for commit `3cb860d` (full review; head unchanged since the previous round).</sup>
+
+| Gate | Status | Details |
+| --- | --- | --- |
+| Description vs. code | ✅ | The description matches what the diff does, gaps included. |
+| Prior bot feedback | ⚠️ | 6 unresolved threads — all decorated `(non-blocking)`, so the gate warns. |
+
+**CI** — `Preview Deploy` is still pending; draft PR, so not treated as blocking.
+
+**Open threads (6)** — 3 carry a rationale on-thread.
+
+**Memories** — 51 indexed; 2 relevance memories applied.
+
+**Skipped files** — `pnpm-lock.yaml`

--- a/scripts/eval/fixtures/posted-bodies/lorekit-503-report-as-pointer.md
+++ b/scripts/eval/fixtures/posted-bodies/lorekit-503-report-as-pointer.md
@@ -1,0 +1,55 @@
+<!-- PR_REVIEWER_POINTER -->
+Reviewed your changes — no blocking issues, **3 warnings**.
+
+<details>
+<summary>Additional findings (2) — cleared review, not inlined</summary>
+
+- `packages/web/src/lib/queries/explorer-stats.ts:16` — nitpick: the header table still says GET /memories/activity (confidence 84)
+- `packages/web/src/lib/filters.ts:713` — question: no production call site remains for filtersToFacetParams (confidence 78)
+
+</details>
+
+<details>
+<summary>Review details — 2 open bot threads</summary>
+
+<sup>Incremental review for commit `2c2bd19` (delta since `70cf147`).</sup>
+
+| Gate | Status | Details |
+|---|---|---|
+| Description vs. code | ✅ | The description matches what the diff does. |
+| Prior bot feedback | ⚠️ | 2 unresolved bot thread(s) — see the thread list below |
+| Documentation | ✅ | The change is documented well enough to follow. |
+| Self-review signals | ✅ | No debug logs, leftover TODOs, or unreviewed stubs. |
+| Code review | ⚠️ | 3 non-blocking findings — see inline comments. |
+
+**Open bot threads (2)** <sup>4 resolved since `70cf147`</sup>
+
+- [`packages/web/src/lib/filters.ts:23`](https://github.com/o/r/pull/1#discussion_r1) — the docblock still names filtersToQueryParams
+- [`packages/schemas/src/memory.ts:735`](https://github.com/o/r/pull/1#discussion_r2) — the advertised bound is 5x what the hop survives
+
+**CI** — `Integration smoke (local Supabase)` is red on one case — `POST /memories/list` expected 200, got 500.
+
+**Verified** — `node scripts/sync-edge-schemas.mjs --check` in sync (15 files).
+
+**Run mode** — incremental · 256 lines in delta · 27 files touched
+
+**Memories** — 62 indexed · 1 used
+
+- [`pre-flight-logic:token-membership-tests-mis-ordered`](https://lorekit.io/lore?scope=%22repo%3A%3Ao%2Fr%22) — promoted, seen 2x
+
+
+**Quality** — produced 7 → posted inline 3 · cleared 3 · carried forward 0 · deferred 2 · below-bar 0
+
+- dropped: relevance 0 · dedupe 1 · grounding 0 · confidence 2 · shape 0
+
+**Integrations** — not activated
+
+**Optimality (2.4c)** — ran · 3 judged · 3 optimal · 0 proposal(s) · 0 inline pointer(s) · 0 withheld
+
+**Standards (2.4d)** — ran · 1 doc · 0 finding(s)
+
+**Skipped files** — none
+
+<sup>Reviewed by the [`pr-reviewer`](https://github.com/mthines/agent-skills/blob/main/agents/pr-reviewer.md) agent — open it to read how these gates and findings are produced.</sup>
+
+</details>

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -1579,6 +1579,114 @@ function checksInSync(plan, checks) {
     /PRIOR_REPORT_AUTHOR=[\s\S]{0,200}STICKY[\s\S]{0,80}LEGACY_REVIEW[\s\S]{0,80}POINTER_REVIEW/
       .test(prReviewer));
 
+  // ── G26: the out-of-band shape validator. Behavioural — these EXECUTE the validator, against
+  // both our own fixtures and REAL bodies as published. Everything else guarding the report shape
+  // runs inside the agent's control flow; a run that hand-writes the body is invisible to all of
+  // it, so this is the only check that observes what actually reached a PR.
+  {
+    const VALIDATOR = join(REPO_ROOT, "scripts/validate-report-shape.mjs");
+    const POSTED = join(REPO_ROOT, "scripts/eval/fixtures/posted-bodies");
+    const run = (input) => {
+      const r = spawnSync("node", [VALIDATOR], { input, encoding: "utf8" });
+      let verdict = null;
+      try { verdict = JSON.parse(r.stdout); } catch { /* reported below */ }
+      return { status: r.status, verdict, err: (r.stderr || "").trim() };
+    };
+    s.check("G26 the validator exists", existsSync(VALIDATOR));
+
+    // (a) Real production bodies must be rejected, with the specific codes that name the defect.
+    const REAL = [
+      ["lorekit-503-flat.md", ["missing-report-marker", "no-review-details-accordion",
+        "accordion-owned-line-at-top-level"]],
+      ["lorekit-503-report-as-pointer.md", ["report-marked-as-pointer"]],
+    ];
+    for (const [file, expectedCodes] of REAL) {
+      const p = join(POSTED, file);
+      if (!existsSync(p)) { s.check(`G26 posted fixture ${file} present`, false); continue; }
+      const r = run(readFileSync(p, "utf8"));
+      s.check(`G26 ${file} is rejected`, r.status === 1, `exit ${r.status}: ${r.err.slice(0, 80)}`);
+      const got = new Set((r.verdict?.violations || []).map((v) => v.code));
+      for (const code of expectedCodes) {
+        s.check(`G26 ${file} reports ${code}`, got.has(code), `got: ${[...got].join(", ")}`);
+      }
+    }
+
+    // (b) Every rendered snapshot must PASS. If the renderer's own output fails the external
+    // validator, the two disagree about the contract and one of them is wrong.
+    for (const name of ["pass", "warn", "fail"]) {
+      const p = join(REPO_ROOT, `scripts/eval/fixtures/report-body/${name}.expected.md`);
+      if (!existsSync(p)) continue;
+      const r = run(readFileSync(p, "utf8"));
+      s.check(`G26 the rendered ${name} snapshot passes the external validator`, r.status === 0,
+        `exit ${r.status}: ${r.err.slice(0, 120)}`);
+    }
+
+    // (b2) The gate table alone must classify a body as a report. The real flat body omitted
+    // `**Run mode**`, which broke a classifier that required two diagnostic labels; the abridged
+    // fixture still carries two others, so this synthesises the minimal case that makes the
+    // gate-table signal load-bearing. Column spacing varies between runs, so test both.
+    for (const [why, sep] of [["tight pipes", "|---|---|---|"], ["padded pipes", "| --- | --- | --- |"]]) {
+      const minimal = "Reviewed your changes — no blocking issues.\n\n"
+        + `| Gate | Status | Details |\n${sep}\n| Code review | ✅ | fine |\n`;
+      const r = run(minimal);
+      s.check(`G26 the gate table alone classifies a body as a report (${why})`,
+        r.status === 1 && r.verdict?.kind === "report-unmarked",
+        `kind ${r.verdict?.kind}, exit ${r.status}`);
+    }
+
+    // (c) Non-reviewer bodies are ignored, so the guard never fires on ordinary PR chatter.
+    for (const [why, body] of [
+      ["a plain human comment", "LGTM, nice work on the caching layer."],
+      ["a body with one incidental bold label", "**Note** — rebased onto main."],
+    ]) {
+      const r = run(body);
+      s.check(`G26 the validator ignores ${why}`, r.status === 0 && r.verdict?.kind === "not-a-reviewer-body",
+        `kind ${r.verdict?.kind}, exit ${r.status}`);
+    }
+
+    // (d) A genuine one-line pointer conforms — the guard must discriminate report from pointer.
+    {
+      const r = run('<!-- PR_REVIEWER_POINTER -->\nReviewed `abc1234` — 3 finding(s) inline.\n\n'
+        + '<!-- PR_REVIEWER_LEDGER {"v":1,"runs":[]} -->\n');
+      s.check("G26 a genuine one-line pointer conforms", r.status === 0 && r.verdict?.kind === "pointer",
+        `kind ${r.verdict?.kind}, exit ${r.status}`);
+    }
+
+    // (e) Each remaining defect class, synthesised.
+    const good = readFileSync(join(REPO_ROOT, "scripts/eval/fixtures/report-body/warn.expected.md"), "utf8");
+    const CASES = [
+      ["a pre-expanded accordion", good.replace("<details>\n<summary>Review details", "<details open>\n<summary>Review details"), "accordion-pre-expanded"],
+      ["a **Verdict** line", `${good}\n**Verdict**: PASS\n`, "verdict-in-posted-body"],
+      // Cage the WHOLE link, both delimiters — the production defect was
+      // ``['key'](url)``, and a leading pair alone cages nothing.
+      ["a caged markdown link",
+        good.replace(/^- (\[[^\]]*\]\([^)]*\))/m, "- ``$1``"), "link-caged-in-code-span"],
+      ["a count disagreeing with its list", good.replace("**Open bot threads (2)**", "**Open bot threads (5)**"), "count-disagrees-with-list"],
+    ];
+    for (const [why, body, code] of CASES) {
+      const r = run(body);
+      s.check(`G26 the validator flags ${why}`, r.status === 1, `exit ${r.status}`);
+      s.check(`G26 ${why} reports ${code}`,
+        (r.verdict?.violations || []).some((v) => v.code === code),
+        (r.verdict?.violations || []).map((v) => v.code).join(", "));
+    }
+
+    // (f) The workflow and its caller template must reference the validator and each other, or the
+    // guard is unreachable from a consuming repo.
+    const wf = readFileSync(join(REPO_ROOT, ".github/workflows/reviewer-report-shape.yml"), "utf8");
+    s.check("G26 the reusable workflow runs the validator",
+      wf.includes("scripts/validate-report-shape.mjs") && wf.includes("workflow_call"));
+    s.check("G26 the workflow reads bodies via env, never string-interpolated into shell",
+      /REVIEW_BODY: \$\{\{ github\.event\.review\.body \}\}/.test(wf) &&
+      !/run:[\s\S]{0,400}\$\{\{ github\.event\.review\.body \}\}/.test(wf));
+    s.check("G26 the workflow posts one sticky notice, keyed by a marker",
+      wf.includes("PR_REVIEWER_SHAPE_GUARD") && wf.includes("-X PATCH"));
+    const caller = readFileSync(join(REPO_ROOT,
+      "plugins/pr-reviewer-shape-guard/templates/report-shape-caller.yml"), "utf8");
+    s.check("G26 the caller template targets the reusable workflow",
+      caller.includes("mthines/agent-skills/.github/workflows/reviewer-report-shape.yml@main"));
+  }
+
   // G24c: the three Gate-3 failure modes are registered in the diagnostic surface, so a
   // regression has a named bucket instead of silently becoming "expected behaviour".
   for (const fm of ["F-nonblocking-thread-fails-gate-3", "F-gate-3-severity-reinvented",

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -1649,6 +1649,17 @@ function checksInSync(plan, checks) {
         `exit ${r.status}, codes: ${(r.verdict?.violations || []).map((v) => v.code).join(", ")}`);
     }
 
+    // (b5) The pointer budget must match the agent's own pre-flight, which strips the ledger and
+    // nothing else. Stripping the marker too made the external guard looser than the internal one.
+    {
+      const marker = "<!-- PR_REVIEWER_POINTER -->";
+      const prose = "x".repeat(600 - marker.length + 5);
+      const r = run(`${marker}\n${prose}\n`);
+      s.check("G26 the pointer budget counts the marker, as the agent's pre-flight does",
+        r.status === 1 && (r.verdict?.violations || []).some((v) => v.code === "pointer-too-long"),
+        `exit ${r.status}, codes: ${(r.verdict?.violations || []).map((v) => v.code).join(", ")}`);
+    }
+
     // (c) Non-reviewer bodies are ignored, so the guard never fires on ordinary PR chatter.
     for (const [why, body] of [
       ["a plain human comment", "LGTM, nice work on the caching layer."],

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -1710,18 +1710,33 @@ function checksInSync(plan, checks) {
 
     // (f) The workflow and its caller template must reference the validator and each other, or the
     // guard is unreachable from a consuming repo.
-    const wf = readFileSync(join(REPO_ROOT, ".github/workflows/reviewer-report-shape.yml"), "utf8");
-    s.check("G26 the reusable workflow runs the validator",
-      wf.includes("scripts/validate-report-shape.mjs") && wf.includes("workflow_call"));
-    s.check("G26 the workflow reads bodies via env, never string-interpolated into shell",
-      /REVIEW_BODY: \$\{\{ github\.event\.review\.body \}\}/.test(wf) &&
-      !/run:[\s\S]{0,400}\$\{\{ github\.event\.review\.body \}\}/.test(wf));
-    s.check("G26 the workflow posts one sticky notice, keyed by a marker",
-      wf.includes("PR_REVIEWER_SHAPE_GUARD") && wf.includes("-X PATCH"));
-    const caller = readFileSync(join(REPO_ROOT,
-      "plugins/pr-reviewer-shape-guard/templates/report-shape-caller.yml"), "utf8");
-    s.check("G26 the caller template targets the reusable workflow",
-      caller.includes("mthines/agent-skills/.github/workflows/reviewer-report-shape.yml@main"));
+    // Every read here is guarded: an unguarded readFileSync throws and takes down all of L1, so a
+    // deleted workflow would be reported as a total run failure instead of one named missing file.
+    const readGuarded = (rel) => {
+      const p = join(REPO_ROOT, rel);
+      const present = existsSync(p);
+      s.check(`G26 ${rel} present`, present);
+      return present ? readFileSync(p, "utf8") : "";
+    };
+    const wf = readGuarded(".github/workflows/reviewer-report-shape.yml");
+    if (wf) {
+      s.check("G26 the reusable workflow runs the validator",
+        wf.includes("scripts/validate-report-shape.mjs") && wf.includes("workflow_call"));
+      s.check("G26 the workflow reads bodies via env, never string-interpolated into shell",
+        /REVIEW_BODY: \$\{\{ github\.event\.review\.body \}\}/.test(wf) &&
+        !/run:[\s\S]{0,400}\$\{\{ github\.event\.review\.body \}\}/.test(wf));
+      s.check("G26 the workflow posts one sticky notice, keyed by a marker",
+        wf.includes("PR_REVIEWER_SHAPE_GUARD") && wf.includes("-X PATCH"));
+    }
+    const caller = readGuarded("plugins/pr-reviewer-shape-guard/templates/report-shape-caller.yml");
+    if (caller) {
+      s.check("G26 the caller template targets the reusable workflow",
+        caller.includes("mthines/agent-skills/.github/workflows/reviewer-report-shape.yml@main"));
+      // The caller must grant at least what the reusable workflow requests, or the run fails on a
+      // repo whose default token is read-only.
+      s.check("G26 the caller template declares the permissions the reusable workflow needs",
+        /permissions:\s*\n\s*contents: read\s*\n\s*pull-requests: write/.test(caller));
+    }
   }
 
   // G24c: the three Gate-3 failure modes are registered in the diagnostic surface, so a

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -1660,6 +1660,24 @@ function checksInSync(plan, checks) {
         `exit ${r.status}, codes: ${(r.verdict?.violations || []).map((v) => v.code).join(", ")}`);
     }
 
+    // (b6) The guard's own notice must not trip the guard. The workflow renders every violation
+    // `detail` into its sticky notice, so a detail quoting a marker verbatim made that notice
+    // classify as a malformed report when re-validated — the guard failing itself.
+    {
+      const flat = "Reviewed your changes.\n\n| Gate | Status | Details |\n|---|---|---|\n| Code review | OK | x |\n";
+      const r = run(flat);
+      const details = (r.verdict?.violations || []).map((v) => v.detail).join("\n");
+      const notice = ["<!-- PR_REVIEWER_SHAPE_GUARD -->",
+        "\u26a0\ufe0f **The last `pr-reviewer` body does not match the report shape contract.**", "",
+        ...(r.verdict?.violations || []).map((v) => `- \`${v.code}\` \u2014 ${v.detail}`), ""].join("\n");
+      const back = run(notice);
+      s.check("G26 no violation detail emits a marker verbatim",
+        !/<!--\s*PR_REVIEWER_(REPORT|POINTER)\s*-->/.test(details), details.slice(0, 120));
+      s.check("G26 the guard's own notice is not itself a reviewer body",
+        back.status === 0 && back.verdict?.kind === "not-a-reviewer-body",
+        `kind ${back.verdict?.kind}, exit ${back.status}`);
+    }
+
     // (c) Non-reviewer bodies are ignored, so the guard never fires on ordinary PR chatter.
     for (const [why, body] of [
       ["a plain human comment", "LGTM, nice work on the caching layer."],

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -1636,6 +1636,19 @@ function checksInSync(plan, checks) {
         `kind ${r.verdict?.kind}, exit ${r.status}`);
     }
 
+    // (b4) The gate table above the accordion must be caught with the SAME spacing tolerance the
+    // classifier uses. A literal `| Gate | Status | Details |` let a padded header classify as a
+    // report and then escape the flattening check.
+    for (const [why, hdr] of [["tight", "| Gate | Status | Details |"], ["padded", "|  Gate  |  Status  |  Details  |"]]) {
+      const flat = `Reviewed your changes.\n\n${hdr}\n|---|---|---|\n| Code review | OK | fine |\n\n`
+        + "<details>\n<summary>Review details</summary>\n\n**Run mode** \u2014 full\n\n</details>\n";
+      const r = run(flat);
+      s.check(`G26 a ${why}-spaced gate table above the accordion is flagged`,
+        r.status === 1 &&
+        (r.verdict?.violations || []).some((v) => v.code === "accordion-owned-line-at-top-level"),
+        `exit ${r.status}, codes: ${(r.verdict?.violations || []).map((v) => v.code).join(", ")}`);
+    }
+
     // (c) Non-reviewer bodies are ignored, so the guard never fires on ordinary PR chatter.
     for (const [why, body] of [
       ["a plain human comment", "LGTM, nice work on the caching layer."],

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -1662,6 +1662,12 @@ function checksInSync(plan, checks) {
       ["a caged markdown link",
         good.replace(/^- (\[[^\]]*\]\([^)]*\))/m, "- ``$1``"), "link-caged-in-code-span"],
       ["a count disagreeing with its list", good.replace("**Open bot threads (2)**", "**Open bot threads (5)**"), "count-disagrees-with-list"],
+      // The head slice must anchor on the `Review details` accordion, not on the first <details>.
+      // A flat body preceded by an unrelated fold sliced the head to nothing and reported clean.
+      ["a flat body preceded by an unrelated <details> fold",
+        "Reviewed your changes.\n\n<details>\n<summary>Additional findings</summary>\n\n- a\n\n</details>\n\n"
+        + "| Gate | Status | Details |\n|---|---|---|\n| Code review | \u2705 | fine |\n\n**Run mode** \u2014 full\n",
+        "accordion-owned-line-at-top-level"],
     ];
     for (const [why, body, code] of CASES) {
       const r = run(body);

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -1693,6 +1693,10 @@ function checksInSync(plan, checks) {
       ["a caged markdown link",
         good.replace(/^- (\[[^\]]*\]\([^)]*\))/m, "- ``$1``"), "link-caged-in-code-span"],
       ["a count disagreeing with its list", good.replace("**Open bot threads (2)**", "**Open bot threads (5)**"), "count-disagrees-with-list"],
+      // The captured drift body wrote `**Open threads (6)**`; requiring the canonical `bot` wording
+      // let a hand-written heading's wrong count through the very check meant to catch it.
+      ["a drift-worded count disagreeing with its list",
+        good.replace("**Open bot threads (2)**", "**Open threads (5)**"), "count-disagrees-with-list"],
       // The head slice must anchor on the `Review details` accordion, not on the first <details>.
       // A flat body preceded by an unrelated fold sliced the head to nothing and reported clean.
       ["a flat body preceded by an unrelated <details> fold",

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -1744,9 +1744,17 @@ function checksInSync(plan, checks) {
     if (wf) {
       s.check("G26 the reusable workflow runs the validator",
         wf.includes("scripts/validate-report-shape.mjs") && wf.includes("workflow_call"));
-      s.check("G26 the workflow reads bodies via env, never string-interpolated into shell",
-        /REVIEW_BODY: \$\{\{ github\.event\.review\.body \}\}/.test(wf) &&
-        !/run:[\s\S]{0,400}\$\{\{ github\.event\.review\.body \}\}/.test(wf));
+      // BOTH body inputs, not just the review one: `github.event.comment.body` is equally
+      // attacker-controlled, and asserting only the review body left half the claim unguarded.
+      for (const [label, expr] of [
+        ["REVIEW_BODY", "github.event.review.body"],
+        ["COMMENT_BODY", "github.event.comment.body"],
+      ]) {
+        const bound = new RegExp(`${label}: \\$\\{\\{ ${expr.replace(/\./g, "\\.")} \\}\\}`);
+        const spliced = new RegExp(`run:[\\s\\S]{0,400}\\$\\{\\{ ${expr.replace(/\./g, "\\.")} \\}\\}`);
+        s.check(`G26 the workflow binds ${label} via env, never interpolated into shell`,
+          bound.test(wf) && !spliced.test(wf));
+      }
       s.check("G26 the workflow posts one sticky notice, keyed by a marker",
         wf.includes("PR_REVIEWER_SHAPE_GUARD") && wf.includes("-X PATCH"));
     }

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -1655,8 +1655,13 @@ function checksInSync(plan, checks) {
     }
 
     // (e) Each remaining defect class, synthesised.
-    const good = readFileSync(join(REPO_ROOT, "scripts/eval/fixtures/report-body/warn.expected.md"), "utf8");
-    const CASES = [
+    // Guarded like case (b): an unguarded readFileSync throws and aborts ALL of L1, turning one
+    // missing fixture into a total run failure with no per-check attribution.
+    const goodPath = join(REPO_ROOT, "scripts/eval/fixtures/report-body/warn.expected.md");
+    const goodPresent = existsSync(goodPath);
+    s.check("G26 report-body snapshot warn.expected.md present (the synthesis base)", goodPresent);
+    const good = goodPresent ? readFileSync(goodPath, "utf8") : "";
+    const CASES = goodPresent ? [
       ["a pre-expanded accordion", good.replace("<details>\n<summary>Review details", "<details open>\n<summary>Review details"), "accordion-pre-expanded"],
       ["a **Verdict** line", `${good}\n**Verdict**: PASS\n`, "verdict-in-posted-body"],
       // Cage the WHOLE link, both delimiters — the production defect was
@@ -1670,7 +1675,7 @@ function checksInSync(plan, checks) {
         "Reviewed your changes.\n\n<details>\n<summary>Additional findings</summary>\n\n- a\n\n</details>\n\n"
         + "| Gate | Status | Details |\n|---|---|---|\n| Code review | \u2705 | fine |\n\n**Run mode** \u2014 full\n",
         "accordion-owned-line-at-top-level"],
-    ];
+    ] : [];
     for (const [why, body, code] of CASES) {
       const r = run(body);
       s.check(`G26 the validator flags ${why}`, r.status === 1, `exit ${r.status}`);

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -1613,9 +1613,11 @@ function checksInSync(plan, checks) {
 
     // (b) Every rendered snapshot must PASS. If the renderer's own output fails the external
     // validator, the two disagree about the contract and one of them is wrong.
+    // A missing snapshot must FAIL, exactly as an absent posted fixture does in case (a). A bare
+    // `continue` here ran zero checks, so deleting all three snapshots would have passed by vacuity.
     for (const name of ["pass", "warn", "fail"]) {
       const p = join(REPO_ROOT, `scripts/eval/fixtures/report-body/${name}.expected.md`);
-      if (!existsSync(p)) continue;
+      if (!existsSync(p)) { s.check(`G26 report-body snapshot ${name}.expected.md present`, false); continue; }
       const r = run(readFileSync(p, "utf8"));
       s.check(`G26 the rendered ${name} snapshot passes the external validator`, r.status === 0,
         `exit ${r.status}: ${r.err.slice(0, 120)}`);

--- a/scripts/validate-report-shape.mjs
+++ b/scripts/validate-report-shape.mjs
@@ -107,11 +107,15 @@ export function validate(body) {
   }
 
   if (kind === "report-unmarked") {
-    add("missing-report-marker", `body carries report sections but no ${REPORT_MARKER}`);
+    // Describe the marker, never emit it verbatim. The workflow renders these details into its
+    // notice comment, and a notice quoting `<!-- PR_REVIEWER_REPORT -->` classifies as a report
+    // itself — so the guard's own output failed the guard when re-validated.
+    add("missing-report-marker", "body carries report sections but no PR_REVIEWER_REPORT marker comment");
   }
   if (kind === "report-mismarked-as-pointer") {
-    add("report-marked-as-pointer", `a full report body carries ${POINTER_MARKER}, so a later run's`
-      + ` prior-run detection will recover it as a pointer and read the report as absent`);
+    add("report-marked-as-pointer", "a full report body carries the PR_REVIEWER_POINTER marker"
+      + " comment, so a later run's prior-run detection will recover it as a pointer and read the"
+      + " report as absent");
   }
 
   // ── the accordion ────────────────────────────────────────────────────────────────────────────

--- a/scripts/validate-report-shape.mjs
+++ b/scripts/validate-report-shape.mjs
@@ -32,8 +32,11 @@ const LEDGER_RE = /<!-- PR_REVIEWER_LEDGER [\s\S]*?-->/;
 
 // Lines the `Review details` accordion owns. Any of these above the first `<details>` means the
 // report was flattened — the exact regression seen in production.
+// The gate table is NOT in this list: its column spacing varies between runs, so a literal misses
+// `|  Gate  | Status | Details |`. It is matched with GATE_TABLE_RE below, the same regex the
+// classifier uses — otherwise a body could classify as a report on the regex and then escape this
+// check on the literal.
 const ACCORDION_OWNED = [
-  "| Gate | Status | Details |",
   "**Run mode**",
   "**Memories**",
   "**Quality**",
@@ -129,6 +132,9 @@ export function validate(body) {
     if (head.includes(owned)) {
       add("accordion-owned-line-at-top-level", `\`${owned}\` renders above the accordion`);
     }
+  }
+  if (GATE_TABLE_RE.test(head)) {
+    add("accordion-owned-line-at-top-level", "`| Gate | Status | Details |` renders above the accordion");
   }
 
   // ── the advisory verdict is terminal-only ────────────────────────────────────────────────────

--- a/scripts/validate-report-shape.mjs
+++ b/scripts/validate-report-shape.mjs
@@ -117,9 +117,14 @@ export function validate(body) {
     add("accordion-pre-expanded", "a <details> block carries `open`, so it renders expanded");
   }
 
-  // ── nothing the accordion owns may sit above the first <details> ──────────────────────────────
-  const firstDetails = body.indexOf("<details>");
-  const head = firstDetails === -1 ? body : body.slice(0, firstDetails);
+  // ── nothing the accordion owns may sit above the `Review details` accordion ───────────────────
+  // Anchor on the accordion itself, never on `body.indexOf("<details>")`. A report may legitimately
+  // carry an earlier, unrelated <details> block (an `Additional findings` fold, for one), and
+  // slicing at that one truncates the head before the flattened lines, so the flat body this check
+  // exists to catch would sail through. When there is no accordion the whole body is the head.
+  const head = accordionAt === -1
+    ? body
+    : lines.slice(0, accordionAt).join("\n");
   for (const owned of ACCORDION_OWNED) {
     if (head.includes(owned)) {
       add("accordion-owned-line-at-top-level", `\`${owned}\` renders above the accordion`);

--- a/scripts/validate-report-shape.mjs
+++ b/scripts/validate-report-shape.mjs
@@ -90,7 +90,11 @@ export function validate(body) {
 
   if (kind === "pointer") {
     // A pointer must stay a pointer: prose only, plus an optional ledger.
-    const prose = body.replace(LEDGER_RE, "").replace(POINTER_MARKER, "").trim();
+    // Strip the LEDGER only — not the marker. The agent's own Step 4b pre-flight measures the same
+    // 600-char budget against the body with just the ledger block removed, so also stripping the
+    // 27-char POINTER_MARKER here made this budget looser than the one it is meant to validate, and
+    // a body the agent rejects could pass the external guard.
+    const prose = body.replace(LEDGER_RE, "").trim();
     if (prose.length > 600) {
       add("pointer-too-long", `${prose.length} chars of prose (budget 600) — a pointer is one line`);
     }

--- a/scripts/validate-report-shape.mjs
+++ b/scripts/validate-report-shape.mjs
@@ -44,6 +44,10 @@ const ACCORDION_OWNED = [
   "**Optimality (2.4c)**",
   "**Standards (2.4d)**",
   "**Skipped files**",
+  // `bot` is optional: the one captured drift body wrote `**Open threads (6)**`, so requiring the
+  // canonical wording let a hand-written heading — the exact class this file exists to catch —
+  // through both this list and the count check below.
+  "**Open threads (",
   "**Open bot threads (",
   "<sup>Reviewed for commit",
   "<sup>Incremental review for commit",
@@ -151,16 +155,16 @@ export function validate(body) {
   if (caged) add("link-caged-in-code-span", `${caged[0].slice(0, 80)}`);
 
   // ── a declared count must equal the bullets rendered under it ──────────────────────────────────
-  const declared = body.match(/\*\*Open bot threads \((\d+)\)\*\*/);
+  const declared = body.match(/\*\*Open (?:bot )?threads \((\d+)\)\*\*/);
   if (declared) {
     const after = body.slice(body.indexOf(declared[0]) + declared[0].length);
     const block = after.split(/\n\s*\n/).find((p) => p.trim().startsWith("- ")) || "";
     const bullets = block.split("\n").filter((l) => l.trim().startsWith("- ")).length;
     if (Number(declared[1]) !== bullets) {
       add("count-disagrees-with-list",
-        `**Open bot threads (${declared[1]})** but ${bullets} bullet(s) rendered`);
+        `**Open threads (${declared[1]})** but ${bullets} bullet(s) rendered`);
     }
-    const suffix = body.match(/<summary>Review details — (\d+) open bot thread/);
+    const suffix = body.match(/<summary>Review details — (\d+) open (?:bot )?thread/);
     if (suffix && Number(suffix[1]) !== Number(declared[1])) {
       add("summary-count-disagrees", `summary says ${suffix[1]}, list says ${declared[1]}`);
     }

--- a/scripts/validate-report-shape.mjs
+++ b/scripts/validate-report-shape.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * validate-report-shape.mjs
+ *
+ * Validates a POSTED pr-reviewer body against the shape contract, from outside the agent.
+ *
+ * Why this exists — and why it cannot live in the agent. Every other guard on this contract runs
+ * somewhere the agent controls:
+ *
+ *   L1 / G25 (439 checks)      runs in CI against the repository, and never sees a posted report
+ *   render-report.mjs          fails closed, but only if the run invokes it
+ *   Step 4a pre-write asserts  prose in the same file a drifting run has already skipped
+ *   the ingest round trip      runs against committed fixtures, not live output
+ *
+ * So a run that simply hand-writes the body is unobserved by all of them. That is not theoretical:
+ * on mthines/lorekit#503 the same definition produced the correct shape three times and a flat,
+ * marker-less body on the fourth run 24 minutes later. This script is the first check that looks
+ * at what was actually published.
+ *
+ * Input:  the body text on stdin, or a file path as argv[2].
+ * Output: a JSON verdict on stdout ({ok, kind, violations[]}) plus a human summary on stderr.
+ * Exit:   0 = conforms or not a pr-reviewer body; 1 = violations found; 2 = usage error.
+ *
+ * It never edits or deletes anything. Reporting is the caller's job (see the workflow).
+ */
+
+import { readFileSync } from "node:fs";
+
+const REPORT_MARKER = "<!-- PR_REVIEWER_REPORT -->";
+const POINTER_MARKER = "<!-- PR_REVIEWER_POINTER -->";
+const LEDGER_RE = /<!-- PR_REVIEWER_LEDGER [\s\S]*?-->/;
+
+// Lines the `Review details` accordion owns. Any of these above the first `<details>` means the
+// report was flattened — the exact regression seen in production.
+const ACCORDION_OWNED = [
+  "| Gate | Status | Details |",
+  "**Run mode**",
+  "**Memories**",
+  "**Quality**",
+  "**Integrations**",
+  "**Optimality (2.4c)**",
+  "**Standards (2.4d)**",
+  "**Skipped files**",
+  "**Open bot threads (",
+  "<sup>Reviewed for commit",
+  "<sup>Incremental review for commit",
+  "<sup>No code changes since",
+  "<sup>Reviewed by the",
+];
+
+// Signals that a body is a full report even WITHOUT the marker. A drifting run drops the marker
+// first, so marker-presence cannot decide whether the contract applies — that is precisely the
+// body this script exists to catch.
+//
+// The gate-table header is decisive on its own: no other object in this pipeline emits a
+// `| Gate | Status | Details |` header, and the real flat body carried the table while omitting
+// `**Run mode**`, so a two-of-N rule over the diagnostic lines missed it. Column spacing varies
+// between runs (`| --- |` vs `|---|`), so match the header cells, not a fixed string.
+const GATE_TABLE_RE = /^\|\s*Gate\s*\|\s*Status\s*\|\s*Details\s*\|/m;
+const REPORT_SIGNALS = [
+  "**Run mode**",
+  "**Standards (2.4d)**",
+  "**Optimality (2.4c)**",
+  "**Memories**",
+  "**Skipped files**",
+  "**Integrations**",
+];
+
+function classify(body) {
+  const hasReportMarker = body.includes(REPORT_MARKER);
+  const hasPointerMarker = body.includes(POINTER_MARKER);
+  const signals = REPORT_SIGNALS.filter((s) => body.includes(s)).length;
+  const isReport = GATE_TABLE_RE.test(body) || signals >= 2;
+  // A pointer is one line plus an optional ledger; a report carries sections.
+  if (hasReportMarker) return "report";
+  if (isReport) return hasPointerMarker ? "report-mismarked-as-pointer" : "report-unmarked";
+  if (hasPointerMarker) return "pointer";
+  return "not-a-reviewer-body";
+}
+
+export function validate(body) {
+  const kind = classify(body);
+  const violations = [];
+  const add = (code, detail) => violations.push({ code, detail });
+
+  if (kind === "not-a-reviewer-body") return { ok: true, kind, violations };
+
+  if (kind === "pointer") {
+    // A pointer must stay a pointer: prose only, plus an optional ledger.
+    const prose = body.replace(LEDGER_RE, "").replace(POINTER_MARKER, "").trim();
+    if (prose.length > 600) {
+      add("pointer-too-long", `${prose.length} chars of prose (budget 600) — a pointer is one line`);
+    }
+    if (prose.includes("<details>")) add("pointer-carries-sections", "a pointer has no <details> blocks");
+    return { ok: violations.length === 0, kind, violations };
+  }
+
+  if (kind === "report-unmarked") {
+    add("missing-report-marker", `body carries report sections but no ${REPORT_MARKER}`);
+  }
+  if (kind === "report-mismarked-as-pointer") {
+    add("report-marked-as-pointer", `a full report body carries ${POINTER_MARKER}, so a later run's`
+      + ` prior-run detection will recover it as a pointer and read the report as absent`);
+  }
+
+  // ── the accordion ────────────────────────────────────────────────────────────────────────────
+  // Adjacency, checked line-wise. A `<details>` followed by `<summary>Review details` is the only
+  // thing that counts; the presence of some other <details> block is not evidence.
+  const lines = body.split("\n");
+  const accordionAt = lines.findIndex((l, i) =>
+    l.trim() === "<details>" && (lines[i + 1] || "").startsWith("<summary>Review details"));
+  if (accordionAt === -1) {
+    add("no-review-details-accordion",
+      "no `<details>` immediately followed by `<summary>Review details` — the report renders expanded");
+  }
+  if (/<details\s+open/.test(body)) {
+    add("accordion-pre-expanded", "a <details> block carries `open`, so it renders expanded");
+  }
+
+  // ── nothing the accordion owns may sit above the first <details> ──────────────────────────────
+  const firstDetails = body.indexOf("<details>");
+  const head = firstDetails === -1 ? body : body.slice(0, firstDetails);
+  for (const owned of ACCORDION_OWNED) {
+    if (head.includes(owned)) {
+      add("accordion-owned-line-at-top-level", `\`${owned}\` renders above the accordion`);
+    }
+  }
+
+  // ── the advisory verdict is terminal-only ────────────────────────────────────────────────────
+  if (body.includes("**Verdict**")) {
+    add("verdict-in-posted-body", "the Step 3 advisory verdict is terminal-only");
+  }
+
+  // ── a link caged in a code span renders as dead monospace text ────────────────────────────────
+  const caged = body.match(/``?\s*\[[^\]]*\]\([^)]*\)\s*``?/g);
+  if (caged) add("link-caged-in-code-span", `${caged[0].slice(0, 80)}`);
+
+  // ── a declared count must equal the bullets rendered under it ──────────────────────────────────
+  const declared = body.match(/\*\*Open bot threads \((\d+)\)\*\*/);
+  if (declared) {
+    const after = body.slice(body.indexOf(declared[0]) + declared[0].length);
+    const block = after.split(/\n\s*\n/).find((p) => p.trim().startsWith("- ")) || "";
+    const bullets = block.split("\n").filter((l) => l.trim().startsWith("- ")).length;
+    if (Number(declared[1]) !== bullets) {
+      add("count-disagrees-with-list",
+        `**Open bot threads (${declared[1]})** but ${bullets} bullet(s) rendered`);
+    }
+    const suffix = body.match(/<summary>Review details — (\d+) open bot thread/);
+    if (suffix && Number(suffix[1]) !== Number(declared[1])) {
+      add("summary-count-disagrees", `summary says ${suffix[1]}, list says ${declared[1]}`);
+    }
+  }
+
+  return { ok: violations.length === 0, kind, violations };
+}
+
+function main() {
+  const arg = process.argv[2];
+  let body;
+  try {
+    body = arg ? readFileSync(arg, "utf8") : readFileSync(0, "utf8");
+  } catch (e) {
+    process.stderr.write(`validate-report-shape: cannot read input: ${e.message}\n`);
+    process.exit(2);
+  }
+  const result = validate(body);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (result.kind === "not-a-reviewer-body") {
+    process.stderr.write("not a pr-reviewer body — nothing to check\n");
+  } else if (result.ok) {
+    process.stderr.write(`${result.kind}: conforms\n`);
+  } else {
+    process.stderr.write(`${result.kind}: ${result.violations.length} violation(s)\n`);
+    for (const v of result.violations) process.stderr.write(`  - ${v.code}: ${v.detail}\n`);
+  }
+  process.exit(result.ok ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();


### PR DESCRIPTION
## Summary

`lorekit#503` showed the remaining failure is **not** that the spec is unfollowable — #121 and #122 fixed that. It's that following it is **optional**. One definition, one PR, one head:

| Time (UTC) | Review | Shape |
|---|---|---|
| 17:44 | `4964076700` | correct — accordion, derived counts, real links |
| 17:56 | `4964171425` | correct |
| 18:07 | `4964277130` | correct |
| **18:31** | `4964475125` | **flat** — no marker, no accordion, gate table at top level |

Both merges predate all four runs by ~32 hours, so this is neither staleness nor a spec defect. It's non-determinism — **3 of 4**, up from 0 of 7 before this work — and nothing catches the one that drifts.

## Why nothing caught it

Every guard built so far runs where the agent decides:

| Guard | Where it runs | Sees a posted report? |
|---|---|---|
| L1 / `G25` (439 checks) | CI, against the repo | **No** — it validates the repository |
| `render-report.mjs` fail-closed | inside the run | only when it is invoked |
| Step 4a pre-write assertions | inside the run | only when the run reaches them |
| ingest round-trip | CI, against fixtures | **No** — committed fixtures, not live output |

The flat body has neither marker nor accordion, so pre-write assertions 1 and 2 would *both* have aborted — had they run. **Four PRs made the correct path easier and better-guarded, and never added a check that sees reality.** This adds one.

## Changes

**`scripts/validate-report-shape.mjs`** — takes a posted body, emits a structured verdict:

| Code | Catches |
|---|---|
| `missing-report-marker` | report sections with no `<!-- PR_REVIEWER_REPORT -->` |
| `report-marked-as-pointer` | a full report stamped `<!-- PR_REVIEWER_POINTER -->`, so a later run recovers it as a pointer and reads the report as absent |
| `no-review-details-accordion` | the flat regression |
| `accordion-pre-expanded` | a `<details>` carrying `open` |
| `accordion-owned-line-at-top-level` | gate table / run mode / memories / footer above the accordion |
| `verdict-in-posted-body` | the terminal-only advisory verdict |
| `link-caged-in-code-span` | the dead-link defect from #121 |
| `count-disagrees-with-list` · `summary-count-disagrees` | a declared count ≠ the bullets under it |
| `pointer-too-long` · `pointer-carries-sections` | a pointer grown into a report |

A body that is neither report nor pointer is ignored, so ordinary PR comments never trigger it.

**`.github/workflows/reviewer-report-shape.yml`** — reusable workflow on `pull_request_review` + `issue_comment`. Posts **one sticky notice** per PR, rewritten in place, so a repeatedly-drifting reviewer leaves one comment rather than a thread per run. **Read-only on the reviewer's objects**: it never edits or deletes a report, because a malformed body is evidence of what the run did and rewriting it would hide the failure this exists to surface. A violation does not fail the check by default — a malformed body doesn't mean the findings are wrong; `fail-the-check: true` opts into gating.

Bodies reach the script **through the environment, never interpolated into a `run:` block** — a review body is attacker-controlled text, and `${{ }}` inside `run:` would splice it into shell. L1 asserts this.

**`plugins/pr-reviewer-shape-guard/`** — caller template + README, following the `pr-relevance-memory` distribution pattern. No secrets; one file to copy.

**This repo is its own first consumer**, via a local `uses:`. Note that this does *not* exercise a PR’s copy: `pull_request_review` and `issue_comment` workflows — and every local `uses: ./…` they resolve — always run from the default branch, so a change to the reusable workflow takes effect here only after merge. Pre-merge coverage of the validator comes from L1 `G26`.

## Two things the classifier had to learn from real output

Both are why the fixtures live in `scripts/eval/fixtures/posted-bodies/` as **real published bodies**, not only ones I generated:

1. The flat body **omitted `**Run mode**`**, so my first classifier — requiring two diagnostic labels — missed it entirely and returned `not-a-reviewer-body`. The gate-table header is decisive on its own.
2. Column spacing varies between runs (`|---|` vs `| --- |`), so the header is matched by cells, not as a fixed string.

## Verification

`node scripts/eval/l1.mjs` → **537/537** at head (523/523 when this PR was opened; review fixes added fourteen checks).

**G26** executes the validator against the real posted bodies, asserts all three rendered snapshots **pass** it (if the renderer's own output failed the external validator, the two disagree about the contract and one is wrong), checks the ignore cases, and covers every defect class.

Mutation-tested red on every check. **One mutation initially stayed green:** the abridged flat fixture carries two other diagnostic labels, so it never exercised the gate-table-only path that I'd added specifically for it — fixed by adding the minimal synthesised case that does. Worth noting because it's the same trap as before: a fixture that's easier to detect than the real thing.

## Still open (needs a push credential with the `workflows` permission)

Six reviewer findings are validated but cannot land here — the applying identity’s token is refused on any commit touching `.github/workflows/**`:

- The self-caller header still repeats the corrected `uses:` claim (fixed in `CLAUDE.md` and above).
- `EVENT_NAME` is resolved and never passed to the validator, so a report posted to a review body still verdicts `conforms` — **the “makes the rate visible” claim below is therefore not yet met**.
- `ref: main` still overrides whatever ref a caller pins.
- The sticky-notice lookup uses `gh api --paginate` with `--jq`, which emits one object per page, so past 100 comments `JSON.parse` throws and a second notice is posted every run.
- An exit-2 validator crash leaves `verdict.json` empty, so the reporting step throws regardless of `fail-the-check: false`, and exit 2 is reported as a shape violation.
- The self-caller omits the `permissions:` block the distributed template now declares as required.

## What this does not fix

All four runs posted to **review bodies**, not the sticky — 0/4. That's the host question #121 deferred, and it's now the larger correctness problem, since duplicate reports are back by default. This guard will at least make the rate visible instead of us sampling PRs by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GF2dk4e8op1QkUmSNJU2he

---
_Generated by [Claude Code](https://claude.ai/code/session_01GF2dk4e8op1QkUmSNJU2he)_



