### PR TITLE
feat(ci): add the reviewer-comment-relevance reusable workflow

### DIFF
--- a/.github/workflows/reviewer-comment-relevance.yml
+++ b/.github/workflows/reviewer-comment-relevance.yml
@@ -1,0 +1,124 @@
+# Reusable workflow: record a PR comment's resolution outcome into LoreKit.
+#
+# This is the write half of the reviewer's relevance memory. The `reviewer` and `pr-reviewer`
+# agents read the resulting records at the start of every run to suppress finding shapes this
+# repo has repeatedly declined, and to reinforce the ones that reliably get fixed. Without it
+# the agents re-raise the same dismissed nitpick on every PR forever, because nothing ever
+# told them it was dismissed.
+#
+# Two modes, both driven from GitHub webhooks by the caller:
+#   thread-resolved  A reviewer resolved one thread  -> relevant/fixed or not-relevant/wont-fix.
+#   pr-merged        A PR merged                     -> sweep still-open threads as ignored-at-merge.
+#
+# Behaviour: read-only on GitHub. It never posts, edits, resolves, or deletes anything on the PR;
+# its only side effect is a LoreKit write. scripts/record-comment-relevance.mjs always exits 0 —
+# a missing LOREKIT_API_KEY, an unreachable API, or an unexpected crash degrades to a no-op rather
+# than reddening a caller's PR, which matters because the caller fires on `pull_request: closed`
+# and a failure there would annotate an already-merged PR nobody is watching.
+#
+# Callers: copy plugins/pr-relevance-memory/templates/pr-relevance-caller.yml into your repo.
+
+name: Reviewer comment relevance
+
+on:
+  workflow_call:
+    inputs:
+      mode:
+        description: >
+          Which signal to record: `thread-resolved` for a single resolved thread, or `pr-merged`
+          to sweep the threads still open when a PR merged. An unrecognised value is a logged
+          no-op, not a failure.
+        required: true
+        type: string
+      pr_number:
+        description: The pull request number the signal belongs to.
+        required: true
+        type: string
+      # The comment_* inputs describe the FIRST comment of a resolved thread. They are unset in
+      # `pr-merged` mode, which rediscovers every thread from the API instead — so none may be
+      # required. All are typed `string` rather than `number`: a file-level review comment has a
+      # null `line`, and a null reaching a `number` input is a workflow error rather than the
+      # empty value the recorder already knows how to handle.
+      comment_id:
+        description: Numeric ID of the thread's first comment.
+        required: false
+        type: string
+        default: ""
+      comment_path:
+        description: Path of the file the comment was left on.
+        required: false
+        type: string
+        default: ""
+      comment_line:
+        description: Line the comment was left on. Empty for a file-level comment.
+        required: false
+        type: string
+        default: ""
+      comment_body:
+        description: >
+          Body of the first comment, used to derive the relevance fingerprint. Untrusted input —
+          see the note on the recorder step.
+        required: false
+        type: string
+        default: ""
+      comment_created_at:
+        description: ISO 8601 timestamp of the first comment, used as the fix-commit cutoff.
+        required: false
+        type: string
+        default: ""
+    secrets:
+      lorekit_api_key:
+        description: >
+          LoreKit API key for the memory write. Optional by design: with it unset the recorder
+          logs that it is unconfigured and skips the write, so a repo can install the caller
+          before provisioning the key.
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  record:
+    name: Record relevance signal
+    runs-on: ubuntu-latest
+    # The recorder walks a PR's commits and fetches each one's files to find a fix. On a long PR
+    # that is a lot of serial API calls, and this job holds no lock worth waiting on.
+    timeout-minutes: 10
+    steps:
+      - name: Check out the recorder
+        uses: actions/checkout@v4
+        with:
+          # A reusable workflow runs against the CALLER's checkout, so the script has to be
+          # fetched explicitly. `ref: main` matches reviewer-report-shape.yml — note it means a
+          # caller pinning `@v1` still gets main's recorder.
+          repository: mthines/agent-skills
+          ref: main
+          sparse-checkout: scripts/record-comment-relevance.mjs
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Record the signal
+        env:
+          # Every value is passed through the environment and never interpolated into the script
+          # body: a review comment is attacker-controlled text, and `${{ }}` inside a `run` block
+          # would splice it into the shell. Same rule as reviewer-report-shape.yml.
+          #
+          # `github.token` here is the CALLER's token, scoped by the caller's `permissions:` — so
+          # the recorder reads the caller's PRs, not this repository's.
+          GITHUB_TOKEN: ${{ github.token }}
+          LOREKIT_API_KEY: ${{ secrets.lorekit_api_key }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          FIRST_COMMENT_ID: ${{ inputs.comment_id }}
+          FIRST_COMMENT_PATH: ${{ inputs.comment_path }}
+          FIRST_COMMENT_LINE: ${{ inputs.comment_line }}
+          FIRST_COMMENT_BODY: ${{ inputs.comment_body }}
+          FIRST_COMMENT_CREATED_AT: ${{ inputs.comment_created_at }}
+          MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+          node scripts/record-comment-relevance.mjs --mode="$MODE"


### PR DESCRIPTION
## Summary

The `pr-relevance-memory` plugin shipped three of its four pieces — the caller template, the recorder (`scripts/record-comment-relevance.mjs`), and the rule doc — but not the reusable workflow both of the others name. This adds it.

The consequence of its absence isn't cosmetic. A `uses:` that can't resolve doesn't get skipped: GitHub **fails the run**. Any repo that followed the plugin README got a red annotation on every merge and every resolved thread, and the write half of the reviewer's relevance memory has never run anywhere. Nothing has been feeding `reviewer-comment-relevance::*`, so the reviewer agents have had no signal to learn this-repo-declines-that-finding from.

## Contract

Checked against both sides rather than assumed:

- **Inputs match the caller template field for field.** Only `mode` and `pr_number` are required — `pr-merged` passes just those two and rediscovers threads from the API, so none of the `comment_*` inputs may be required.
- **`comment_*` are typed `string`, not `number`.** A file-level review comment has a null `line`; a null reaching a `number` input is a workflow error, where an empty string is a value the recorder already handles.
- **Env var names are the ones the recorder actually reads** (`GH_REPO`, `PR_NUMBER`, `FIRST_COMMENT_*`). Its docstring additionally lists `THREAD_ID` and `FIRST_COMMENT_AUTHOR` — no code path reads either and the caller never supplies them, so they are deliberately not wired.

## Conventions

Follows `reviewer-report-shape.yml`, the sibling reusable workflow, throughout:

- **Sparse-checkout of this repo.** A reusable workflow runs against the *caller's* checkout, so the script has to be fetched explicitly — easy to miss, and the failure mode is a confusing "file not found" in someone else's repo.
- **`setup-node` 22.**
- **Untrusted text through `env:`, never `${{ }}` in a `run` block.** `comment_body` is attacker-controlled; interpolating it would splice it into the shell.

## Verification

- The workflow parses; inputs/secrets match the caller template field for field.
- The recorder was exercised through the exact invocation this workflow makes: unknown mode, both missing-env guards, and a fully-populated `thread-resolved` run with `gh` unavailable and no API key. All four exit 0 — the last still derives a fingerprint (`nitpick:nit-path-stale`) and reports the write as skipped, which is the graceful-no-op the caller depends on and the reason a failure here can't redden an already-merged PR.

## Known limitation

`ref: main` on the checkout mirrors `reviewer-report-shape.yml`, so a caller pinning `@v1` still gets `main`'s recorder. Called out in a comment in the file. Fixing it (deriving the ref from `github.job_workflow_ref`) would be a change to both reusable workflows, not just this one, so it isn't bundled here.

## Companion

The caller for `lorekit` is mthines/lorekit#552. **This PR must merge first** — merging that one against a `uses:` that can't yet resolve is precisely the red-run failure described above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqTahFjhFvX5WbecaTBBTe)_