### PR TITLE
fix(pr-reviewer): scope Agent0 fix-prompt checks to the changed files

### DIFF
--- a/agents/pr-reviewer/scripts/build-agent0-link.mjs
+++ b/agents/pr-reviewer/scripts/build-agent0-link.mjs
@@ -21,7 +21,7 @@ const HOSTS = { production: "https://app.dash0.com", development: "https://app.d
 // requires the whole request line to fit ONE 8k buffer or it answers 414, and Apache's
 // LimitRequestLine defaults to 8190 — so 8000 sat exactly on the cliff rather than short of it.
 // 4000 keeps a 2x margin under that. The legacy "2048 everywhere" figure comes from IE's 2083 and
-// no longer binds a known modern host. Measured against it: fix-this ~400 chars, fix-all ~2170 at
+// no longer binds a known modern host. Measured against it: fix-this ~650 chars, fix-all ~2240 at
 // its 15-location cap with pathological paths (agent0-fix-links.md § Deep-link format).
 const MAX_URL = 4000;
 

--- a/agents/shared/rules/agent0-fix-links.md
+++ b/agents/shared/rules/agent0-fix-links.md
@@ -95,9 +95,9 @@ guard therefore sat exactly on that cliff — a 7999-char link passed and then 4
 Neither prompt embeds a finding *body*; both embed the finding **locations**, which are known at
 build time and are what turns a multi-call discovery hunt into one fetch (§ Prompt templates). The
 **Fix all** URL therefore scales with the finding count: measured worst case at the 15-location cap,
-with pathological 94-character paths, is ~2170 chars; a typical PR lands nearer 1500. **Fix this** is
-~400. If a template ever needs to grow past the 2500 target, cut the location cap — do not raise
-`MAX_URL`.
+with pathological 94-character paths, is ~2240 chars; a typical PR lands nearer 1600. **Fix this** is
+~650 with a full-length lead line. If a template ever needs to grow past the 2500 target, cut the
+location cap — do not raise `MAX_URL`.
 
 ## Prompt templates
 
@@ -116,7 +116,7 @@ boilerplate ("You are fixing one code-review finding…", the `<finding>` wrappe
 subject without a fetch and reads the live comment only for the fix detail:
 
 ```text
-Fix the pr-reviewer finding at {path}:{line} on {owner}/{repo}#{n} — "{lead}" — read its inline review comment for the details, then commit to the same branch (no new PR); run the repo's checks first.
+Fix the pr-reviewer finding at {path}:{line} on {owner}/{repo}#{n} — "{lead}" — read its inline review comment for the details. Lint and typecheck only the files you changed — never the whole repo — then commit to the same branch (no new PR).
 ```
 
 `{lead}` is the finding's own first line as posted (the Conventional-Comments prefix plus its first
@@ -132,7 +132,7 @@ Agent0 at the same comment.
 findings:
 
 ```text
-Fix the {count} open pr-reviewer findings on {owner}/{repo}#{n}, at: {locations}. Read the inline review comments at those locations for the details (GET /repos/{owner}/{repo}/pulls/{n}/comments). Ignore every other author. Run the repo's checks first, then commit to the same branch (no new PR).
+Fix the {count} open pr-reviewer findings on {owner}/{repo}#{n}, at: {locations}. Read the inline review comments at those locations for the details (GET /repos/{owner}/{repo}/pulls/{n}/comments). Ignore every other author. Lint and typecheck only the files you changed — never the whole repo — then commit to the same branch (no new PR).
 ```
 
 - `{locations}` — comma-separated `{path}:{line}`, **capped at 15** (the cap that keeps the worst-case
@@ -151,9 +151,15 @@ them. Observed on `mthines/lorekit#594`: four discovery calls before the first e
 told Agent0 there was nothing to fix.
 
 Scoping **Fix all** to the reviewer's own findings is both product and safety: it never asks Agent0
-to act on another author's comment, so no untrusted text drives the auto-submitted run. The one
-guardrail kept in both prompts is "run the repo's checks first" — the cheapest line that stops a
-broken auto-commit.
+to act on another author's comment, so no untrusted text drives the auto-submitted run.
+
+**Scope the checks to the files touched.** Both prompts keep a verification guardrail — the cheapest
+line that stops a broken auto-commit — but it must say *"lint and typecheck only the files you
+changed — never the whole repo"*, not "run the repo's checks". A repo-wide `tsc` + `eslint` is what
+the earlier wording invited, and the Agent0 runner does not have the headroom for it: on a large
+repo the whole-project pass crashes the run, so the fix never lands. It is also wasted work by
+construction — a fix-link change is one finding at one location. Keep this clause in any future
+rewording; dropping the "never the whole repo" half is what re-opens the crash.
 
 ## Button markup
 

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -2494,13 +2494,21 @@ const isPollBlock = (block) =>
   const TARGET = 2500;
   const worst = `Fix the 15 open pr-reviewer findings on mthines/lorekit#594, at: ${
     Array.from({ length: 15 }, (_, i) => `${"packages/service/src/features/nested/module".padEnd(86, "x")}-${i}.ts:${1200 + i}`).join(", ")
-  }. Read the inline review comments at those locations for the details (GET /repos/mthines/lorekit/pulls/594/comments). Ignore every other author. Run the repo's checks first, then commit to the same branch (no new PR).`;
+  }. Read the inline review comments at those locations for the details (GET /repos/mthines/lorekit/pulls/594/comments). Ignore every other author. Lint and typecheck only the files you changed — never the whole repo — then commit to the same branch (no new PR).`;
   const worstLen = buildLink(worst).length;
   s.check(`G32d a worst-case 15-location Fix-all URL stays under the ${TARGET}-char design target`,
     worstLen < TARGET, `worst-case URL is ${worstLen} chars — lower the location cap in agent0-fix-links.md, do not raise MAX_URL`);
 
   s.check("G32e the rule caps the Fix-all location list at 15",
     /capped at 15/.test(rule), "agent0-fix-links.md no longer states the 15-location cap G32d assumes");
+
+  // The Agent0 runner lacks the headroom for a whole-project tsc + eslint — a repo-wide check pass
+  // crashes the run, so the fix never lands. Both prompts must scope verification to touched files.
+  for (const [name, tpl] of [["Fix-all", fixAll], ["Fix-this", fixThis]]) {
+    s.check(`G32g the ${name} template scopes checks to the changed files, never the whole repo`,
+      !!tpl && /only the files you changed/.test(tpl) && /never the whole repo/.test(tpl),
+      `${name} lost the scoped-check clause — a repo-wide lint/typecheck crashes the Agent0 runner`);
+  }
 
   const maxUrl = Number(/^const MAX_URL = (\d+)/m.exec(readFileSync(LINK_MOD, "utf8"))?.[1]);
   s.check("G32f MAX_URL stays under the 8k request-line cliff it was moved off",


### PR DESCRIPTION
Follow-up to #144, which shipped the location-first Agent0 fix prompts. Both prompts ended with *"run the repo's checks first"*, and in practice that invites a whole-project `tsc` + `eslint`. The Agent0 runner does not have the headroom for it — on a large repo the repo-wide pass crashes the run, so the fix never lands.

It is also wasted work by construction. Both prompts now address findings at *known locations*; a fix-link run is surgical, so verifying the whole project buys nothing over verifying what it touched.

## What changed

Both templates now end with:

> …Lint and typecheck only the files you changed — never the whole repo — then commit to the same branch (no new PR).

The verification guardrail is kept, just scoped — an unverified auto-commit is the worse failure. The rule records *why* the clause is shaped this way, so a future reword doesn't tidy it back into "run the repo's checks".

**L1 `G32g`** asserts the clause in each template. Dropping the "never the whole repo" half is exactly what re-opens the crash, and a trailing clause is the kind of thing a prompt rewrite quietly loses. Confirmed it fails when the old wording is restored, so it isn't vacuous.

## Length budget

Re-measured rather than assumed, since #144 made the Fix-all URL variable-length:

| | before | after |
| --- | --- | --- |
| Fix-all worst case (15 locations, 94-char paths) | 2170 | **2241** |
| Fix-all typical | ~1500 | ~1596 |
| Fix-this (full-length lead line) | ~400 | ~641 |

Still under the 2500 design target and ~1.8× under the 4000 `MAX_URL` guard. The numbers in the rule and in `MAX_URL`'s own comment were updated to match rather than left stale.

`node scripts/eval/l1.mjs` — 702/702.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4cUHtWoSpa3t8FE2WaoYH)_