### PR TITLE
feat(pr-reviewer): sweep for the reviewer's other unresolved threads in Fix-all

### DIFF
--- a/agents/pr-reviewer/scripts/build-agent0-link.mjs
+++ b/agents/pr-reviewer/scripts/build-agent0-link.mjs
@@ -21,7 +21,7 @@ const HOSTS = { production: "https://app.dash0.com", development: "https://app.d
 // requires the whole request line to fit ONE 8k buffer or it answers 414, and Apache's
 // LimitRequestLine defaults to 8190 — so 8000 sat exactly on the cliff rather than short of it.
 // 4000 keeps a 2x margin under that. The legacy "2048 everywhere" figure comes from IE's 2083 and
-// no longer binds a known modern host. Measured against it: fix-this ~650 chars, fix-all ~2240 at
+// no longer binds a known modern host. Measured against it: fix-this ~650 chars, fix-all ~2350 at
 // its 15-location cap with pathological paths (agent0-fix-links.md § Deep-link format).
 const MAX_URL = 4000;
 

--- a/agents/shared/rules/agent0-fix-links.md
+++ b/agents/shared/rules/agent0-fix-links.md
@@ -95,8 +95,10 @@ guard therefore sat exactly on that cliff — a 7999-char link passed and then 4
 Neither prompt embeds a finding *body*; both embed the finding **locations**, which are known at
 build time and are what turns a multi-call discovery hunt into one fetch (§ Prompt templates). The
 **Fix all** URL therefore scales with the finding count: measured worst case at the 15-location cap,
-with pathological 94-character paths, is ~2240 chars; a typical PR lands nearer 1600. **Fix this** is
-~650 with a full-length lead line. If a template ever needs to grow past the 2500 target, cut the
+with pathological 94-character paths, is ~2350 chars; a typical PR lands nearer 1700, and a
+three-finding PR near 850. **Fix this** is ~650 with a full-length lead line. The figures are not
+guesses — L1 `G32d` fills the live template and measures it, so a clause added here is measured on
+the next run. If a template ever needs to grow past the 2500 target, cut the
 location cap — do not raise `MAX_URL`.
 
 ## Prompt templates
@@ -132,14 +134,26 @@ Agent0 at the same comment.
 findings:
 
 ```text
-Fix the {count} open pr-reviewer findings on {owner}/{repo}#{n}, at: {locations}. Read the inline review comments at those locations for the details (GET /repos/{owner}/{repo}/pulls/{n}/comments). Ignore every other author. Lint and typecheck only the files you changed — never the whole repo — then commit to the same branch (no new PR).
+Fix the {count} open pr-reviewer findings on {owner}/{repo}#{n}, at: {locations}. Read the inline review comments at those locations for the details (GET /repos/{owner}/{repo}/pulls/{n}/comments). Then sweep for any other unresolved thread by that same reviewer and fix it too. Ignore every other author. Lint and typecheck only the files you changed — never the whole repo — then commit to the same branch (no new PR).
 ```
 
 - `{locations}` — comma-separated `{path}:{line}`, **capped at 15** (the cap that keeps the worst-case
-  URL inside the 2500 target above). Past the cap, append ` (+{overflow} more — sweep the remaining
-  unresolved threads)` after the list rather than growing the URL; blocking findings are cap-exempt
-  inline, so the count can exceed 15.
+  URL inside the 2500 target above). Past the cap, append ` (+{overflow} more)` after the list rather
+  than growing the URL — the sweep clause already tells Agent0 to find them, so do not restate it
+  here. Blocking findings are cap-exempt inline, so the count can exceed 15.
 - `{count}` — the full open-finding count including any overflow, so Agent0 can tell when it is done.
+
+**The sweep goes after the list, never before it.** Handing over `{locations}` is what removes the
+discovery round trips; the sweep is a completeness net for what the list cannot carry — findings
+past the 15 cap, a thread opened between the render and the click, and anything a payload bug drops.
+Both halves are needed: the list alone can be incomplete, and the sweep alone is the four-call
+discovery hunt this template was rewritten to eliminate. Moving the sweep to the front re-creates
+that hunt with extra steps, so keep the order — known work first, sweep second.
+
+It is scoped by **author**, not by login: *"that same reviewer"* resolves against the authors of the
+comments at `{locations}`, which Agent0 has just read. Do not substitute a `{login}` placeholder —
+the reviewer's own login is not reliably resolvable at build time (`/user` 401s on some access
+paths), and a wrong or empty login would either widen the sweep to every author or void it entirely.
 
 **Do not send Agent0 to the report comment first.** The earlier template opened with *"open the
 pr-reviewer report comment (marker `PR_REVIEWER_REPORT`)"*, which cost a list-and-scan over every

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -2541,16 +2541,36 @@ const isPollBlock = (block) =>
   // Worst case the cap allows: 15 locations at 94-char paths. The design target is 2500 — the point
   // of the target is that MAX_URL (4000) stays a fail-closed guard rather than a routine ceiling,
   // since the real cliff behind it is the 8k request-line buffer of a default nginx/Apache.
+  // Filled from the LIVE template, never hand-copied: a transcribed copy silently stops measuring
+  // the real prompt the moment the template gains a clause, which is exactly when the measurement
+  // matters. Substitute the placeholders a real fill would.
   const TARGET = 2500;
-  const worst = `Fix the 15 open pr-reviewer findings on mthines/lorekit#594, at: ${
-    Array.from({ length: 15 }, (_, i) => `${"packages/service/src/features/nested/module".padEnd(86, "x")}-${i}.ts:${1200 + i}`).join(", ")
-  }. Read the inline review comments at those locations for the details (GET /repos/mthines/lorekit/pulls/594/comments). Ignore every other author. Lint and typecheck only the files you changed — never the whole repo — then commit to the same branch (no new PR).`;
+  const worstLocations = Array.from({ length: 15 },
+    (_, i) => `${"packages/service/src/features/nested/module".padEnd(86, "x")}-${i}.ts:${1200 + i}`).join(", ");
+  const worst = (fixAll ?? "")
+    .replaceAll("{owner}", "mthines").replaceAll("{repo}", "lorekit")
+    .replaceAll("{n}", "594").replaceAll("{count}", "15")
+    .replaceAll("{locations}", worstLocations);
+  s.check("G32d0 the worst-case fill leaves no unsubstituted placeholder",
+    worst !== "" && !/\{[a-z_]+\}/.test(worst),
+    `template gained a placeholder this fill does not substitute: ${/\{[a-z_]+\}/.exec(worst)?.[0] ?? "(no template)"}`);
   const worstLen = buildLink(worst).length;
   s.check(`G32d a worst-case 15-location Fix-all URL stays under the ${TARGET}-char design target`,
     worstLen < TARGET, `worst-case URL is ${worstLen} chars — lower the location cap in agent0-fix-links.md, do not raise MAX_URL`);
 
   s.check("G32e the rule caps the Fix-all location list at 15",
     /capped at 15/.test(rule), "agent0-fix-links.md no longer states the 15-location cap G32d assumes");
+
+  // The embedded worklist can be incomplete — findings past the 15 cap, a thread opened between the
+  // render and the click, a payload bug. The sweep is the completeness net, and it must come AFTER
+  // the locations: in front of them it is the four-call discovery hunt G32b exists to prevent.
+  s.check("G32h the Fix-all template sweeps for the same reviewer's other unresolved threads",
+    !!fixAll && /sweep for any other unresolved thread by that same reviewer/.test(fixAll),
+    "Fix-all lost the sweep clause — findings past the location cap, or opened after the render, go unfixed");
+
+  s.check("G32i the sweep follows the location list rather than preceding it",
+    !!fixAll && fixAll.indexOf("sweep") > fixAll.indexOf("{locations}"),
+    "the sweep moved ahead of {locations} — that is the discovery hunt again, with extra steps");
 
   // The Agent0 runner lacks the headroom for a whole-project tsc + eslint — a repo-wide check pass
   // crashes the run, so the fix never lands. Both prompts must scope verification to touched files.


### PR DESCRIPTION
The **Fix all** prompt hands Agent0 a finite list of `{path}:{line}` locations. That list can be incomplete — findings past the 15-location cap, a thread opened between the report render and the click, or anything a payload bug drops — and nothing told Agent0 to look beyond it, so those silently went unfixed.

## What changed

The read step now ends with:

> …Then sweep for any other unresolved thread by that same reviewer and fix it too.

**The list still comes first.** Handing over the locations is what removed the four discovery calls in #144; the sweep is a completeness net, not the entry point. Moved in front of the locations it *is* that discovery hunt again, with extra steps — so `G32i` asserts the order, not just the presence of the clause.

**Scoped by author, not by login.** *"that same reviewer"* resolves against the comments Agent0 has just read at those locations. A `{login}` placeholder would need a value that isn't reliably resolvable at build time (`/user` 401s on some access paths), and a wrong one either widens the sweep to every author or voids it entirely. `Ignore every other author` still bounds the run, so the safety property from #144 holds.

The overflow tail drops from `(+N more — sweep the remaining unresolved threads)` to `(+N more)`, since the sweep clause now says what to do about them.

## Fixture drift fix

`G32d`'s length fixture was a hand-copy of the template, and it had already drifted twice — it stops measuring the real prompt at exactly the moment a new clause makes the measurement matter. It now fills the **live** template, with `G32d0` failing on any placeholder the fill doesn't substitute.

| | before | after |
| --- | --- | --- |
| Worst case (15 locations, 94-char paths) | 2241 | **2352** |
| Typical (15 locations) | ~1596 | ~1707 |
| Small PR (3 findings) | — | ~849 |

Still under the 2500 design target and well under the 4000 `MAX_URL` guard.

## Verification

`node scripts/eval/l1.mjs` — 737/737. New: `G32d0`, `G32h`, `G32i`. Confirmed `G32i` fails when the sweep clause is moved ahead of `{locations}`, so it isn't vacuous.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4cUHtWoSpa3t8FE2WaoYH)_