### PR TITLE
fix(pr-reviewer): route Agent0 fix verification through the repo's own scripts, not raw tsc/eslint

### DIFF
--- a/agents/shared/rules/agent0-fix-links.md
+++ b/agents/shared/rules/agent0-fix-links.md
@@ -139,7 +139,7 @@ boilerplate ("You are fixing one code-review finding…", the `<finding>` wrappe
 subject without a fetch and reads the live comment only for the fix detail:
 
 ```text
-Fix the pr-reviewer finding at {path}:{line} on {owner}/{repo}#{n} — "{lead}" — read its inline review comment for the details. Lint and typecheck only the files you changed — never the whole repo — then commit to the same branch (no new PR).
+Fix the pr-reviewer finding at {path}:{line} on {owner}/{repo}#{n} — "{lead}" — read its inline review comment for the details. Verify using the repo's own lint/typecheck scripts — never a raw tsc/eslint call or a whole-repo pass — skip verification if none exist — then commit to the same branch (no new PR).
 ```
 
 `{lead}` is the finding's own first line as posted (the Conventional-Comments prefix plus its first
@@ -155,7 +155,7 @@ Agent0 at the same comment.
 findings:
 
 ```text
-Fix the {count} open pr-reviewer findings on {owner}/{repo}#{n}, at: {locations}. Read the inline review comments at those locations for the details (GET /repos/{owner}/{repo}/pulls/{n}/comments). Then sweep for any other unresolved thread by that same reviewer and fix it too. Ignore every other author. Lint and typecheck only the files you changed — never the whole repo — then commit to the same branch (no new PR).
+Fix the {count} open pr-reviewer findings on {owner}/{repo}#{n}, at: {locations}. Read the inline review comments at those locations for the details (GET /repos/{owner}/{repo}/pulls/{n}/comments). Then sweep for any other unresolved thread by that same reviewer and fix it too. Ignore every other author. Verify using the repo's own lint/typecheck scripts — never a raw tsc/eslint call or a whole-repo pass — skip verification if none exist — then commit to the same branch (no new PR).
 ```
 
 - `{locations}` — comma-separated `{path}:{line}`, **capped at 15** (the cap that keeps the worst-case
@@ -172,7 +172,7 @@ human is most likely to click "fix" on with no button to click. Use this templat
 findings-based one when `{locations}` would be empty but CI is not green:
 
 ```text
-Fix the failing CI checks on {owner}/{repo}#{n} — {failing_checks}. View the failing job's logs for the cause, then commit a fix scoped to the files this PR changed (no new PR) — never run a whole-repo lint/typecheck/test pass to verify, only what the failing check touches.
+Fix the failing CI checks on {owner}/{repo}#{n} — {failing_checks}. View the failing job's logs for the cause, then commit a fix scoped to the files this PR changed (no new PR). Verify using the repo's own lint/typecheck/test scripts, scoped to what the failing check touches — never a raw tsc/eslint/test-runner call or a whole-repo pass — skip verification if none exist.
 ```
 
 - `{failing_checks}` — the same failing check names already surfaced in the report's `CI_NOTE` slot
@@ -209,17 +209,27 @@ told Agent0 there was nothing to fix.
 Scoping **Fix all** to the reviewer's own findings is both product and safety: it never asks Agent0
 to act on another author's comment, so no untrusted text drives the auto-submitted run.
 
-**Scope the checks to the files touched.** All three prompts (Fix this, Fix all, Fix all — CI-only)
-keep a verification guardrail — the cheapest line that stops a broken auto-commit — but it must say
-*"lint and typecheck only the files you changed — never the whole repo"* (or, for the CI-only
-template with no `{path}:{line}` to anchor to, "scoped to the files this PR changed... never a
-whole-repo ... pass"), not "run the repo's checks". A repo-wide `tsc` + `eslint` is what the earlier
-wording invited, and the Agent0 runner does not have the headroom for it: on a large repo the
-whole-project pass crashes the run, so the fix never lands. It is also wasted work by construction —
-a fix-link change is one finding at one location. Keep this clause in any future rewording of any of
-the three templates; dropping the "never the whole repo" half is what re-opens the crash (found live
-in review of `mthines/agent-skills#151`, where the first draft of the CI-only template said "run the
-repo's checks locally first").
+**Verify with the repo's own scripts, never a raw tool call.** All three prompts (Fix this, Fix all,
+Fix all — CI-only) keep a verification guardrail — the cheapest line that stops a broken auto-commit
+— but it must send Agent0 to the repo's *own* lint/typecheck/test scripts (whatever its
+`package.json`/CLI already documents), never a raw `tsc`/`eslint`/test-runner invocation, and never a
+whole-repo pass. Scoping by file count alone is not enough: `tsc --noEmit --project <tsconfig>`
+type-checks the whole project graph regardless of which files changed, so even a single-package
+invocation still crashes the Agent0 runner on a large monorepo. Observed live: with the earlier
+wording ("lint and typecheck only the files you changed — never the whole repo"), a run scoped
+correctly to the changed package but then reached for a raw `npx tsc --noEmit --project tsconfig.json`
+on that package's own large graph, ran out of memory, retried with
+`NODE_OPTIONS=--max-old-space-size=4096`, and still had to kill and retry a second time — the file-count
+scoping was honored, but nothing told it to prefer the repo's documented (and presumably
+already-scoped or cached) lint/typecheck script over a hand-rolled invocation. The fix is two-part:
+route through whatever the repo already documents for a fast check, and make explicit that skipping
+verification entirely is preferable to inventing a raw invocation — CI still catches what a skipped
+local check would have. It is also wasted work by construction — a fix-link change is one finding at
+one location. Keep this clause in any future rewording of any of the three templates; dropping the
+"repo's own … scripts" / "never a raw … call" pair is what reopens the crash (the whole-repo half was
+already fixed once, in review of `mthines/agent-skills#151`, where the first draft of the CI-only
+template said "run the repo's checks locally first" — this second incident shows scoping by file
+count was not sufficient on its own).
 
 ## Button markup
 

--- a/agents/shared/rules/agent0-fix-links.md
+++ b/agents/shared/rules/agent0-fix-links.md
@@ -172,7 +172,7 @@ human is most likely to click "fix" on with no button to click. Use this templat
 findings-based one when `{locations}` would be empty but CI is not green:
 
 ```text
-Fix the failing CI checks on {owner}/{repo}#{n} — {failing_checks}. View the failing job's logs for the cause, then commit a fix scoped to the files this PR changed (no new PR). Verify using the repo's own lint/typecheck/test scripts, scoped to what the failing check touches — never a raw tsc/eslint/test-runner call or a whole-repo pass — skip verification if none exist.
+Fix the failing CI checks on {owner}/{repo}#{n} — {failing_checks}. View the failing job's logs for the cause. Verify using the repo's own lint/typecheck/test scripts, scoped to what the failing check touches — never a raw tsc/eslint/test-runner call or a whole-repo pass — skip verification if none exist. Then commit a fix scoped to the files this PR changed (no new PR).
 ```
 
 - `{failing_checks}` — the same failing check names already surfaced in the report's `CI_NOTE` slot

--- a/scripts/eval/l1.mjs
+++ b/scripts/eval/l1.mjs
@@ -2538,6 +2538,7 @@ const isPollBlock = (block) =>
   const templates = [...rule.matchAll(/```text\n([^`]*?)\n```/g)].map((m) => m[1]);
   const fixAll = templates.find((t) => t.includes("{locations}"));
   const fixThis = templates.find((t) => t.includes("{path}:{line}") && !t.includes("{locations}"));
+  const ciOnly = templates.find((t) => t.includes("{failing_checks}"));
 
   s.check("G32a the Fix-all template hands over the worklist by location ({locations} + {count})",
     !!fixAll && fixAll.includes("{count}"),
@@ -2585,12 +2586,20 @@ const isPollBlock = (block) =>
     !!fixAll && fixAll.indexOf("sweep") > fixAll.indexOf("{locations}"),
     "the sweep moved ahead of {locations} — that is the discovery hunt again, with extra steps");
 
-  // The Agent0 runner lacks the headroom for a whole-project tsc + eslint — a repo-wide check pass
-  // crashes the run, so the fix never lands. Both prompts must scope verification to touched files.
-  for (const [name, tpl] of [["Fix-all", fixAll], ["Fix-this", fixThis]]) {
-    s.check(`G32g the ${name} template scopes checks to the changed files, never the whole repo`,
-      !!tpl && /only the files you changed/.test(tpl) && /never the whole repo/.test(tpl),
-      `${name} lost the scoped-check clause — a repo-wide lint/typecheck crashes the Agent0 runner`);
+  // The Agent0 runner lacks the headroom for a raw tsc/eslint invocation — even one scoped to a
+  // single changed package still walks that package's whole project graph and crashes the run, so
+  // scoping by file count alone (the earlier wording) was not sufficient; observed live when a run
+  // honored "only the files you changed" but still reached for `npx tsc --noEmit --project
+  // tsconfig.json` on the changed package. All three templates must instead route to the repo's own
+  // lint/typecheck/test scripts and allow skipping verification outright rather than inventing a raw
+  // invocation.
+  for (const [name, tpl] of [["Fix-all", fixAll], ["Fix-this", fixThis], ["Fix-all — CI-only", ciOnly]]) {
+    s.check(`G32g the ${name} template verifies via the repo's own scripts, never a raw call or a whole-repo pass`,
+      !!tpl
+        && /repo's own lint\/typecheck/.test(tpl)
+        && /never a raw [\w/-]+ call or a whole-repo pass/.test(tpl)
+        && /skip verification if none exist/.test(tpl),
+      `${name} lost the scoped-verification clause — a raw tsc/eslint call, even scoped to the changed package, still crashes the Agent0 runner on a large repo`);
   }
 
   const maxUrl = Number(/^const MAX_URL = (\d+)/m.exec(readFileSync(LINK_MOD, "utf8"))?.[1]);


### PR DESCRIPTION
## Summary

The "Fix with Agent0" verification guardrail scoped by file count only ("lint and typecheck only the files you changed — never the whole repo"). That's not sufficient: `tsc --noEmit --project tsconfig.json` type-checks the whole project graph regardless of which files changed, so even a correctly-scoped invocation still crashes the Agent0 runner on a large monorepo.

Observed live: a run honored the file-count scoping, but then reached for a raw `npx tsc --noEmit --project tsconfig.json` on the changed package's own (large) graph, ran out of memory, retried with `NODE_OPTIONS=--max-old-space-size=4096`, and still had to kill and retry a second time — repeatedly. The repo's own `AGENTS.md` documented a `pnpm run lint` script for exactly this, but the run judged it "too slow" and rolled its own faster raw invocation instead, which is what actually crashed.

## Changes

- All three prompt templates (Fix this, Fix all, Fix all — CI-only) in `agents/shared/rules/agent0-fix-links.md` now tell Agent0 to verify via the repo's *own* lint/typecheck/test scripts (its documented `package.json`/CLI), never a raw `tsc`/`eslint`/test-runner call, and to **skip verification entirely** rather than invent a raw invocation if no such script exists — CI still catches what a skipped local check would have.
- Rewrote the explanatory prose to document the new rationale and the live crash observation.
- `scripts/eval/l1.mjs` — updated `G32g` to assert the new guardrail wording (repo's own scripts / never a raw call / skip-if-none-exist) instead of the old file-count-only phrasing, and extended it to also cover the CI-only template (previously untested by this check).

## Test plan

- [x] `node scripts/eval/l1.mjs` — 744/744 checks passing, including the Fix-all worst-case URL length check (still under the 2500-char design target with the longer clause)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVA6vNUkikfV3MWUiHqZZ6)_