### PR TITLE
feat(review-loop): run the committed preview-spec against the preview at exit

### DIFF
--- a/skills/delivery/create-pr/SKILL.md
+++ b/skills/delivery/create-pr/SKILL.md
@@ -107,6 +107,8 @@ Skill("preview-spec", "author <pr-url>")
 
 `preview-spec` owns the spec grammar, the marker contract, and its authoring memory loop; it edits the PR body in place, adding one `<!-- preview-spec:v1 -->` block. The block is exempt from the description length budget and is preserved verbatim by the Step 6.5 review-loop's description refresh — both rules live in the [description contract](./rules/description-contract.md#ui-verification-spec-optional). Continue to Step 6.5 regardless of whether a spec was authored.
 
+This step only **authors** the spec. The **run** is the review-loop's job: the default Step 6.5 invocation (`Skill("review-loop", "<pr-url> --no-ci")`) executes the block once against the live preview deployment at exit, report-only (its Step 1.6). `create-pr` deliberately does **not** pass `--no-preview-run` — that opt-out is for `autonomous-workflow`, whose Phase 7 rehearses the same specs itself. So a hand-driven UI PR gets both halves here: authored at 6.4, verified at 6.5.
+
 ## Step 6.5: Post-draft quality loop (delegated to `review-loop`)
 
 After the draft PR is open, run the bounded review-apply-simplify convergence loop.

--- a/skills/quality/review-loop/SKILL.md
+++ b/skills/quality/review-loop/SKILL.md
@@ -648,7 +648,7 @@ Open threads at exit: <count>
 CI at exit: <green | pending | red (<failing check names>) | error (<verbatim query failure>) | not run (--no-ci) | none on this repo>
   ci-auto-fix handoffs: <CI_HANDOFFS> of 2
 
-Preview spec: <green (<N> specs on <url>) | red (<N> failing on <url>) — review before undrafting | inconclusive (preview not deployed at exit) | not run (no preview-spec block) | skipped (--no-preview-run) | skipped (preview-spec not available)>
+Preview spec: <green (<N> specs on <url>) | red (<N> failing on <url>) — review before undrafting | inconclusive (preview not deployed at exit) | not run (no preview-spec block) | skipped (--no-preview-run) | skipped (--no-feedback) | skipped (preview-spec not available)>
 
 PR description: <refreshed | unchanged (no code applied) | skipped (--no-refresh)>
 Linear note: <posted <ticket> | no ticket linked | Linear MCP unavailable | skipped>

--- a/skills/quality/review-loop/SKILL.md
+++ b/skills/quality/review-loop/SKILL.md
@@ -12,8 +12,11 @@ description: >
   before undrafting. Also converges CI: after each iteration's push it reads the
   check state and delegates a red mechanical failure to ci-auto-fix, so
   convergence means zero open threads AND CI not red (--no-ci opts out; create-pr
-  and autonomous-workflow pass it because they own their own CI phase). With
-  --external-review the reviewer is out-of-process: sub-step A waits on the
+  and autonomous-workflow pass it because they own their own CI phase). On a UI PR
+  it also runs the committed preview-spec block against the live preview deployment
+  once at exit (report-only, never blocks convergence; --no-preview-run opts out —
+  autonomous-workflow passes it because its Phase 7 already rehearses the same
+  specs). With --external-review the reviewer is out-of-process: sub-step A waits on the
   shared review-activity poll for another agent's review instead of dispatching
   pr-reviewer, which also makes the loop usable where the Task tool is disabled.
   Caller contract: this is an orchestrator whose first sub-step is a delegation,
@@ -23,13 +26,13 @@ description: >
   Callers: autonomous-workflow Phase 6/7, create-pr (post-draft), and standalone
   via /review-changes. Invoke with /review-loop <PR-URL|#n> [--cap N]
   [--critical] [--external-review] [--interval S] [--no-ci] [--no-feedback]
-  [--no-refresh].
+  [--no-refresh] [--no-preview-run].
 disable-model-invocation: false
-argument-hint: '<PR-URL|#n> [--cap N] [--critical] [--external-review] [--interval S] [--no-ci] [--no-feedback] [--no-refresh]'
+argument-hint: '<PR-URL|#n> [--cap N] [--critical] [--external-review] [--interval S] [--no-ci] [--no-feedback] [--no-refresh] [--no-preview-run]'
 license: MIT
 metadata:
   author: mthines
-  version: '1.4.0'
+  version: '1.5.0'
   workflow_type: command
   tags:
     - review
@@ -182,6 +185,7 @@ Everything else is a flag.
 | `--external-review` | Replace sub-step A: wait for an **out-of-process** reviewer instead of dispatching `pr-reviewer`. See [Sub-step A — external-review mode](#sub-step-a--external-review-mode). |
 | `--interval S` | Poll interval in seconds for `--external-review`, default `300`, **clamped to `540`**. Ignored without `--external-review`. |
 | `--no-ci` | Skip sub-step D (the CI pass). Callers that own their own CI phase pass this — `create-pr` (Steps 7–9) and `autonomous-workflow` (Phase 7) both do. |
+| `--no-preview-run` | Skip [Step 1.6](#step-16-preview-spec-run-report-only-once-on-exit), the report-only preview-spec run at exit. `autonomous-workflow` passes this because its Phase 7 spec rehearsal already runs the same specs against the preview; `create-pr` does **not**, so a hand-driven UI PR gets its authored spec verified here. |
 
 **Incompatible combinations**, refused or downgraded at Step 0:
 
@@ -274,6 +278,13 @@ fi
 NO_CI=0
 if [[ " $ARGUMENTS " == *" --no-ci "* ]]; then
   NO_CI=1
+fi
+
+# --no-preview-run: skip Step 1.6, the report-only preview-spec run at exit.
+# autonomous-workflow passes this (its Phase 7 rehearses the same specs).
+NO_PREVIEW_RUN=0
+if [[ " $ARGUMENTS " == *" --no-preview-run "* ]]; then
+  NO_PREVIEW_RUN=1
 fi
 
 CAP=${cap_flag:-5}
@@ -535,6 +546,51 @@ The `simplify` mode applies Class M mechanical refactors and dispatches no pr-re
 All other `polish` modes trigger an internal agent pass, which would create a dispatch cycle.
 This is the anti-circularity guarantee.
 
+### Step 1.6: Preview-spec run (report-only, once, on exit)
+
+After the loop exits — however it exited (converged, no-progress, or cap) — run the
+PR's embedded preview-spec **once** against the live preview deployment. This is the
+run half of the `author` step `create-pr` performs at its Step 6.4: the spec was
+written into the PR body; here it is executed.
+
+Skip this step entirely when **any** of:
+
+- `NO_PREVIEW_RUN == 1` — the caller owns preview verification (`autonomous-workflow`
+  passes this; its Phase 7 rehearses the same specs).
+- `NO_FEEDBACK == 1` — report-only mode applied nothing, so there is nothing new to verify.
+- the loop returned a dispatch skip (missing `Task`, nested dispatch) — no run happened.
+
+Otherwise dispatch it **once**, regardless of iteration count:
+
+```text
+Skill("preview-spec", "run <PR-URL>")
+```
+
+`preview-spec run` owns the whole procedure: it reads the committed
+`<!-- preview-spec:v1 -->` block (the **only** source — never the gitignored
+`.agent/{branch}/specs.md`, so it works on this or any checkout), resolves the
+preview URL via the GitHub deployments API, dispatches `aw-tester --all`, and
+returns a verdict. This loop only records the outcome.
+
+**Report-only — this step never gates.** The verdict does **not** block convergence,
+does **not** reopen the loop, and does **not** undraft the PR — matching
+`autonomous-workflow`'s Phase 7 rehearsal, which also never auto-undrafts on the
+spec verdict. Convergence is already decided by threads-resolved + CI-settled before
+this step runs; the preview verdict is surfaced for the human undrafting the PR.
+
+Map its outcome into the report:
+
+| `preview-spec run` outcome | This loop records |
+| --- | --- |
+| `no spec` (no block — not a UI PR, or `author` never ran) | `not run (no preview-spec block)` — log and continue |
+| `inconclusive: preview not deployed` | `inconclusive (preview not deployed at exit)` — note `re-run /preview-spec run <PR-URL> once the preview is up`. Never a red |
+| `green` | `green (<N> specs on <preview-url>)` |
+| `red` | `red (<N> failing on <preview-url>) — review before undrafting`. Report-only; does not reopen the loop |
+| `preview-spec` not installed / `Skill()` refused | `skipped (preview-spec not available)` — log one line and continue; it is a non-load-bearing companion |
+
+Run it **at most once** per `review-loop` invocation — it is an exit signal, not a
+per-iteration check, and each run spends a full `aw-tester` Playwright dispatch.
+
 ### Step 2: Refresh the PR description and Linear note (on convergence)
 
 Skip this step entirely when `NO_REFRESH == 1`, when `NO_FEEDBACK == 1`, or when
@@ -592,6 +648,8 @@ Open threads at exit: <count>
 CI at exit: <green | pending | red (<failing check names>) | error (<verbatim query failure>) | not run (--no-ci) | none on this repo>
   ci-auto-fix handoffs: <CI_HANDOFFS> of 2
 
+Preview spec: <green (<N> specs on <url>) | red (<N> failing on <url>) — review before undrafting | inconclusive (preview not deployed at exit) | not run (no preview-spec block) | skipped (--no-preview-run) | skipped (preview-spec not available)>
+
 PR description: <refreshed | unchanged (no code applied) | skipped (--no-refresh)>
 Linear note: <posted <ticket> | no ticket linked | Linear MCP unavailable | skipped>
 
@@ -619,6 +677,7 @@ threads over a red build is not a review-ready PR.
 - **One `implement-suggestion` per iteration, no `--watch`.** The loop drives re-review; `--watch` waits for external bots and would conflict.
 - **Cap is a hard limit.** If threads are still open at the cap, surface them and stop. Do not extend the cap silently.
 - **Convergence requires CI settled, not just threads resolved.** Unless `--no-ci` is set, a red check blocks the clean-convergence exit. Reporting zero open threads over a red build is the CI-shaped version of green-washing.
+- **The preview-spec run is report-only and never part of convergence.** Step 1.6 runs after the loop has already decided convergence (threads-resolved + CI-settled); its verdict is surfaced for the human, never gates the loop, and never undrafts — matching `autonomous-workflow` Phase 7. It runs at most once per invocation, reads only the committed `preview-spec:v1` block (never `.agent/{branch}/specs.md`), and `autonomous-workflow` opts out via `--no-preview-run` because Phase 7 rehearses the same specs. A missing `preview-spec` is a silent skip, not a failure.
 - **Never fix CI in this context.** Sub-step D classifies and delegates to `ci-auto-fix`; it applies no fix itself, and every `ci-auto-fix` refusal (no `--no-verify`, no `continue-on-error`, no skipped suites, no weakened assertions) holds transitively.
 - **Never carry CI watch state — query it.** Sub-step D reads check state statelessly at the current remote head and writes nothing; it never records a verdict or a spent budget for another phase to inherit, and it never reintroduces a cross-phase watch-state file ([`diagnostic-surface.md`](../../workflow/autonomous-workflow/rules/diagnostic-surface.md) — *watch state is queried, never carried*). `CI_HANDOFFS` is counted inside this run only.
 - **A failed poll is never a quiet reviewer.** Under `--external-review`, `POLL_ERROR` aborts with `poll error`. Converting a broken probe into "the reviewer had nothing to say" reports a never-reviewed PR as converged.
@@ -637,5 +696,6 @@ threads over a red build is not a review-ready PR.
 | `autonomous-workflow` Phase 6/7 | Invokes `review-loop` in place of the retired `reviewer` agent dispatches. |
 | `review-changes` | Routes to `review-loop` as the primary convergence entry point. |
 | `ci-auto-fix` | Sub-step D: dispatched as a subagent on a red check, capped at 2 handoffs per run. Owns the fix; this loop only classifies and delegates. Skipped under `--no-ci`. |
+| `preview-spec run` | Step 1.6: dispatched once at exit on a UI PR to run the committed spec against the preview deployment. Report-only — never gates convergence or undrafts. Skipped under `--no-preview-run` (which `autonomous-workflow` passes, its Phase 7 owning the same rehearsal) or when the skill is absent. Pairs with `create-pr` Step 6.4, which authored the spec. |
 | `review-activity-poll` | Shared rule owning the `--external-review` wait — [`agents/shared/rules/review-activity-poll.md`](../../../agents/shared/rules/review-activity-poll.md), co-owned with `implement-suggestion --watch`. |
 | `implement-suggestion --watch` | **Sibling, never nested.** Both wait on an out-of-process reviewer via the shared poll; `--watch` is the thin one (apply + push + stop, and it reads CI only as a stop reason). This loop adds `--resolve-all`, simplify, CI delegation, and the description refresh. The hard rule *one `implement-suggestion` per iteration, no `--watch`* keeps them from stacking. |

--- a/skills/workflow/autonomous-workflow/SKILL.md
+++ b/skills/workflow/autonomous-workflow/SKILL.md
@@ -259,7 +259,7 @@ Three phases benefit from sub-agent fan-out:
 | 4     | Run tests → iterate (cap: 5 same area in Full Mode) → run `checks.yaml` checks (all must pass; definitions immutable; `unsatisfiable` escalates) → `confidence(analysis)` at cap → one-shot auto-replan or escalate to user |
 | 5     | `Skill("docs", "update --auto")` always — refreshes `CLAUDE.md`, `.claude/rules/`, `README.md`, `docs/`, `CHANGELOG.md` |
 | 6     | `Skill("aw-create-walkthrough")` → `Skill("create-pr")` (push → open draft PR → `review-loop` convergence → watch CI) |
-| 7     | Watch CI → `Skill("ci-auto-fix")` per failure (parallel) → after CI green `Skill("review-loop", "<pr-url> --critical --no-ci")` (self-relation; optional, skips if not installed) → `gw remove` after merge (optional) |
+| 7     | Watch CI → `Skill("ci-auto-fix")` per failure (parallel) → after CI green `Skill("review-loop", "<pr-url> --critical --no-ci --no-preview-run")` (self-relation; optional, skips if not installed) → `gw remove` after merge (optional) |
 
 ### Lite Mode
 
@@ -275,7 +275,7 @@ Skip artifacts and most companions. Phase 0, Phase 2, Phase 5 (`docs update`), a
 | 4     | Test, fix failures (3-iteration limit applies)  |
 | 5     | `Skill("docs", "update --auto")`       |
 | 6     | `Skill("create-pr")`                            |
-| 7     | Watch CI, `ci-auto-fix` if needed, then `Skill("review-loop", "<pr-url> --critical --no-ci")` (self-relation; skips if not installed) |
+| 7     | Watch CI, `ci-auto-fix` if needed, then `Skill("review-loop", "<pr-url> --critical --no-ci --no-preview-run")` (self-relation; skips if not installed) |
 
 ---
 

--- a/skills/workflow/autonomous-workflow/references/autonomous-workflow-complete.md
+++ b/skills/workflow/autonomous-workflow/references/autonomous-workflow-complete.md
@@ -870,7 +870,7 @@ $ pnpm lint
 ### Review Changes (Post-Draft Self-Review via review-loop)
 
 ```
-Skill("review-loop", "<pr-url> --critical --no-ci")
+Skill("review-loop", "<pr-url> --critical --no-ci --no-preview-run")
 → REVIEW_RELATION: self (pr-reviewer detects authorship automatically)
 → Iteration 1: analyzed 8 commits across 5 new files / 3 modified files
 → Coverage: 100% on new code, no regressions in existing tests

--- a/skills/workflow/autonomous-workflow/rules/overview.md
+++ b/skills/workflow/autonomous-workflow/rules/overview.md
@@ -128,7 +128,7 @@ Phase 5: Documentation
     | Skill("docs", "update --auto") always (self-improving docs loop across CLAUDE.md, README.md, docs/)
     | (docs complete)
 Phase 6: PR Creation
-    | Skill("review-loop", "<pr-url> --critical --no-ci") -> Skill("aw-create-walkthrough") -> Skill("create-pr")
+    | Skill("review-loop", "<pr-url> --critical --no-ci --no-preview-run") -> Skill("aw-create-walkthrough") -> Skill("create-pr")
     | (draft PR delivered, walkthrough.md written)
 Phase 7: CI Gate + Optional Cleanup
     | Watch CI -> Skill("ci-auto-fix") per failed check (parallel, cap 2)

--- a/skills/workflow/autonomous-workflow/rules/phase-7-ci-gate.md
+++ b/skills/workflow/autonomous-workflow/rules/phase-7-ci-gate.md
@@ -415,7 +415,7 @@ Then proceed to [Optional Post-Merge Cleanup](#optional-post-merge-cleanup).
 ### Step 2: Invoke `review-loop`
 
 ```
-Skill("review-loop", "<pr-url> --critical --no-ci")
+Skill("review-loop", "<pr-url> --critical --no-ci --no-preview-run")
 ```
 
 `pr-reviewer` detects self-authorship via `REVIEW_RELATION` in Step 0.5 automatically.
@@ -429,6 +429,12 @@ has its own CI sub-step that would dispatch `ci-auto-fix` on a red check. Lettin
 run would create a **second spender** of the per-PR handoff budget this phase owns —
 the exact defect the CI-watch contract exists to prevent. So this phase keeps the
 budget and does the re-check itself, immediately below.
+
+**`--no-preview-run` is required here for the same reason.** `review-loop` has its own
+report-only preview-spec run at exit (its Step 1.6). This phase's
+[Spec Rehearsal](#spec-rehearsal-optional-ui-tasks-only) already runs the same specs
+against the same preview deployment, so letting the loop also run them would double the
+`aw-tester` dispatch for no new signal. This phase owns the rehearsal; the loop opts out.
 
 ### Step 2.5: Re-check CI if `review-loop` pushed
 

--- a/skills/workflow/autonomous-workflow/rules/phase-7-ci-gate.md
+++ b/skills/workflow/autonomous-workflow/rules/phase-7-ci-gate.md
@@ -436,6 +436,12 @@ report-only preview-spec run at exit (its Step 1.6). This phase's
 against the same preview deployment, so letting the loop also run them would double the
 `aw-tester` dispatch for no new signal. This phase owns the rehearsal; the loop opts out.
 
+This covers only the **direct** review-loop call above. Phase 6 invokes `create-pr`
+bare, and `create-pr` Step 6.5 runs `review-loop --no-ci` **without** `--no-preview-run`,
+so Step 1.6 can also fire once in Phase 6. That is not a second real dispatch: at Phase 6
+the just-opened draft's preview is not deployed yet, so Step 1.6 returns `inconclusive`
+without running `aw-tester`. Phase 7's Spec Rehearsal is the authoritative run.
+
 ### Step 2.5: Re-check CI if `review-loop` pushed
 
 `review-loop` **pushes** — sub-step B commits applied findings and sub-step C commits


### PR DESCRIPTION
## Why

`create-pr` Step 6.4 authors a `preview-spec:v1` block into a UI PR's body, but nothing executed it. The only auto-run was `autonomous-workflow`'s Phase 7 rehearsal — which a **hand-driven** `/create-pr` PR never reaches. So the spec was written and never run.

Follow-up to #157 (the `preview-spec` skill) and #159 (author-side single-sourcing). This adds the missing **run** half, in the one path both `create-pr` and standalone go through: `review-loop`.

## What changed

- **`review-loop` Step 1.6** — after the loop exits, dispatch `preview-spec run` **once** against the live preview deployment. It reads the committed `preview-spec:v1` block (checkout-independent, never the gitignored `.agent/{branch}/specs.md`), runs `aw-tester --all`, records the verdict.
- **Report-only.** The verdict never gates convergence and never undrafts — matching Phase 7, and sidestepping preview flakiness stalling the loop. Convergence is already decided (threads-resolved + CI-settled) before this runs.
- **New `--no-preview-run` flag.** `autonomous-workflow` passes it (its Phase 7 rehearses the same specs, so running here too would double the `aw-tester` dispatch); `create-pr` does **not**, so a hand-driven UI PR gets both halves: authored at 6.4, verified at 6.5.
- Report line, hard rule, relationship row; `review-loop` version 1.4.0 → 1.5.0.
- `create-pr` and `phase-7-ci-gate` note the pairing / the opt-out rationale.

Independent of #159 — none of the 6 files here overlap its diff.

## How to verify

- `node scripts/eval/l1.mjs` — 758/758 (link/anchor integrity, incl. the new `#step-16-...` anchor + cross-links).
- Read `review-loop` Step 1.6: source is the committed block only; outcome mapping treats "preview not deployed at exit" as inconclusive, never red.