### PR TITLE
fix(aw-setup,preview-spec): reuse an existing repo auth convention before scaffolding

### DIFF
--- a/skills/testing/preview-spec/rules/runner.md
+++ b/skills/testing/preview-spec/rules/runner.md
@@ -36,7 +36,7 @@ Write two files under `.agent/{branch}/.preview-spec/` (the branch is the PR's h
 1. **`specs.md`** — the extracted spec body from Step 1, verbatim.
 2. **`aw-target.yml`** — the browser context, built as follows:
    - If `.claude/aw-targets/preview.yml` exists in the repo, start from it (auth, fixtures, constraints) and set `base_url` to the resolved URL. This is how a preview behind Vercel deployment protection or an app login gets authenticated — the committed file carries the auth strategy, never the credentials.
-   - If it does not exist, scaffold from [`templates/preview-target.yml.template`](../templates/preview-target.yml.template) with `auth.strategy: none` and note in the report that authed specs will be skipped by `aw-tester`.
+   - If it does not exist, first look for an existing repo auth convention the way `aw-setup` does ([aw-setup § Reuse before you scaffold](../../../workflow/autonomous-workflow/aw-setup/SKILL.md#reuse-before-you-scaffold)) — a `.claude/aw-targets/*.yml` with `auth.storage_state`, a captured `.browser/auth-state*.json`, or a `refresh-auth*.mjs` login script — and reuse it: point `storage_state` / `refresh.command` at it, capturing against the resolved `PREVIEW_URL`. Only when no convention exists, scaffold from [`templates/preview-target.yml.template`](../templates/preview-target.yml.template) with `auth.strategy: none` and note in the report that authed specs will be skipped by `aw-tester`.
    - Always override `base_url` with the resolved URL, no trailing slash.
 
 Never write the resolved URL or any credential into the committed `.claude/aw-targets/preview.yml` — only into the ephemeral `.agent/{branch}/.preview-spec/aw-target.yml`.

--- a/skills/testing/preview-spec/templates/preview-target.yml.template
+++ b/skills/testing/preview-spec/templates/preview-target.yml.template
@@ -3,8 +3,9 @@
 # It is the browser context for verifying PR preview deployments. The runner
 # reads it, then OVERRIDES base_url at runtime with the URL it resolves from the
 # GitHub deployments API for the specific PR — so leave base_url as the
-# placeholder below. Commit this file (it carries NO secrets); gitignore any
-# .auth/*.json it points at.
+# placeholder below. Commit this file (it carries NO secrets); gitignore whatever
+# storage-state file it points at (.auth/*.json, or your repo's convention such
+# as .browser/auth-state.preview.json).
 #
 # Reuses the aw-target.yml schema verbatim — see
 # skills/workflow/autonomous-workflow/templates/aw-target.yml.template for the
@@ -21,15 +22,32 @@ auth:
   # storage-state and a refresh command that authenticates against the RESOLVED
   # preview URL (read it from the PREVIEW_URL env var the runner exports).
   # For a fully public preview, set strategy: none and delete the rest.
+  #
+  # REUSE an existing repo auth convention rather than scaffolding a parallel one
+  # (see aw-setup's "Reuse before you scaffold"). Point storage_state / the
+  # refresh script at whatever the repo already uses; a per-host preview session
+  # differs per PR and per push, so `when: always` re-captures every run.
   strategy: none            # one of: storage-state | none | manual | env-credentials
+  #
+  # Default scaffold (no existing convention):
   # storage_state: ./.auth/preview.json   # gitignored; only for storage-state
   # refresh:
-  #   when: missing-or-expired
+  #   when: always
   #   command: |
   #     AUTH_LOGIN_URL="${PREVIEW_URL}/login" \
   #       AUTH_STORAGE_STATE=./.auth/preview.json \
   #       node scripts/auth-bootstrap-headful.mjs
   #   timeout_seconds: 600
+  #
+  # dash0 / playwright-cli-authed convention (reuse .browser/ + refresh-auth):
+  # storage_state: .browser/auth-state.preview.json   # gitignored under .browser/
+  # refresh:
+  #   when: always
+  #   command: |
+  #     PREVIEW_URL="${PREVIEW_URL}" \
+  #       AUTH_STORAGE_STATE=.browser/auth-state.preview.json \
+  #       node .browser/refresh-auth-preview.mjs
+  #   timeout_seconds: 120
 
 fixtures:
   # A preview usually points at a shared staging database, so seeding is often a

--- a/skills/workflow/autonomous-workflow/aw-setup/SKILL.md
+++ b/skills/workflow/autonomous-workflow/aw-setup/SKILL.md
@@ -149,14 +149,19 @@ Behaviour depends on the strategy picked in Phase B:
 
 | Strategy | Probe command | Expected outcome |
 |----------|---------------|------------------|
-| (a) Interactive headful capture | `AUTH_LOGIN_URL=... AUTH_STORAGE_STATE=./.auth/local.json node scripts/auth-bootstrap-headful.mjs` | Headful browser opens. User logs in. `.auth/local.json` is written when the user closes the browser (or hits a `POST_LOGIN_URL_PATTERN`). |
-| (b) Automated credentials | `AUTH_LOGIN_URL=... AUTH_STORAGE_STATE=./.auth/local.json AUTH_POST_LOGIN_URL_PATTERN='/dashboard' E2E_EMAIL=... E2E_PASSWORD=... node scripts/auth-bootstrap-credentials.mjs` | Headless run. `.auth/local.json` written on success. Script exits non-zero with a diagnostic if locators or credentials are wrong. |
-| (c) Existing bootstrap command | `timeout 30 <user-provided command>` | The user's command produces `.auth/local.json`. |
+| (a) Interactive headful capture | `AUTH_LOGIN_URL=... AUTH_STORAGE_STATE=<storage_state path> node scripts/auth-bootstrap-headful.mjs` | Headful browser opens. User logs in. `<storage_state path>` is written when the user closes the browser (or hits a `POST_LOGIN_URL_PATTERN`). |
+| (b) Automated credentials | `AUTH_LOGIN_URL=... AUTH_STORAGE_STATE=<storage_state path> AUTH_POST_LOGIN_URL_PATTERN='/dashboard' E2E_EMAIL=... E2E_PASSWORD=... node scripts/auth-bootstrap-credentials.mjs` | Headless run. `<storage_state path>` written on success. Script exits non-zero with a diagnostic if locators or credentials are wrong. |
+| (c) Existing bootstrap command | `timeout 30 <user-provided command>` | The user's command produces `<storage_state path>`. |
 | (d) None | (skip — no auth) | n/a |
 | (e) Manual | (skip — aw-tester will skip authed specs) | n/a |
 
+`<storage_state path>` is `.auth/local.json` by default. When
+[Reuse before you scaffold](#reuse-before-you-scaffold) detected an existing
+convention, substitute its path instead (e.g. `.browser/auth-state.json`) —
+do not probe against the default path when a convention was found.
+
 Then for every strategy except (d) / (e):
-1. Verify `.auth/local.json` was written.
+1. Verify `<storage_state path>` was written.
 2. Load one fixture URL (base_url + `/`) and confirm it renders (HTTP 200 and
    the page title is not an error page).
 3. If the probe fails, report the error and loop back to Phase B.

--- a/skills/workflow/autonomous-workflow/aw-setup/SKILL.md
+++ b/skills/workflow/autonomous-workflow/aw-setup/SKILL.md
@@ -52,7 +52,8 @@ PR that touches UI. Re-run it when auth drifts, fixtures change, or base URL mov
 - Smoke spec: run it. If green, done — no prompts needed.
 - Only prompt for what broke or is missing.
 - Show a unified diff before overwriting any field in the aw-target file.
-- Never silently overwrite `.auth/*.json`.
+- Never silently overwrite the auth storage-state file (`.auth/*.json`, or the
+  repo's own convention such as `.browser/auth-state*.json`).
 
 ---
 
@@ -68,12 +69,38 @@ Read the project to guess the aw-target configuration. Look for:
 | Auth strategy | `next-auth` / `auth.js` imports, custom `/api/auth` routes, OAuth config |
 | Test backdoors | Dev-only cookies (`__e2e_token`), test env vars (`E2E_AUTH_TOKEN`), seed scripts in `package.json` |
 | Fixtures / seed | `db:seed`, `db:reset`, `seed:aw`, `test:setup` scripts |
-| Existing aw-target | `.claude/aw-targets/local.yml` (re-run path) |
+| Existing aw-target | `.claude/aw-targets/*.yml` (re-run path) |
+| Existing auth convention | A storage-state file or login script the repo already uses — see [Reuse before you scaffold](#reuse-before-you-scaffold) |
 
 Detection confidence level:
 - **High:** base URL found in env, auth strategy clear, seed script named explicitly.
 - **Medium:** base URL guessed from port, auth strategy inferred.
 - **Low:** nothing found — fall through to Ask with all questions.
+
+#### Reuse before you scaffold
+
+`.auth/<name>.json` + `scripts/auth-bootstrap-*.mjs` is this skill's **fallback
+scaffold**, not a mandate. If the repo already has an auth convention, reuse it
+instead of creating a parallel one — a second location silently drifts from the
+one the rest of the repo maintains.
+
+Probe in this order and stop at the first hit:
+
+1. **An existing aw-target** — any `.claude/aw-targets/*.yml` that sets
+   `auth.storage_state`. Reuse its `storage_state` path and `refresh.command`
+   verbatim; do not rewrite them.
+2. **A captured storage-state file** already in the repo:
+   `.browser/auth-state*.json` (the dash0 / `playwright-cli-authed` convention),
+   else `.auth/*.json` (this skill's default).
+3. **A login / refresh script** already in the repo:
+   `.claude/aw-targets/scripts/refresh-auth*.mjs` or `.browser/refresh-auth*.mjs`
+   (dash0), else `scripts/auth-bootstrap-*.mjs` (this skill's default).
+
+When a convention is found, substitute its paths for `.auth/<name>.json` and
+`scripts/auth-bootstrap-*.mjs` everywhere below — the Phase C probe, the Phase D
+write, the gitignore guard, and the file-location table — and match the repo's
+existing gitignore entry (`.browser/` vs `.auth/`). Only when nothing is found do
+you scaffold the generic `.auth/` setup.
 
 ### Phase B — Ask
 
@@ -169,15 +196,19 @@ block in the script and confirm the user has reviewed the locators.
 Require user confirmation before writing. If the diff is empty, say "No changes
 needed — aw-target is up to date."
 
-**Gitignore guard:**
+**Gitignore guard:** ensure the auth directory actually in use is ignored — the
+reused convention's dir when one was detected (e.g. `.browser/`), otherwise the
+`.auth/` default:
 ```bash
-# Add .auth/ to .gitignore if not already present
-grep -q "^\.auth/" .gitignore 2>/dev/null || echo ".auth/" >> .gitignore
+# AUTH_DIR is the directory of auth.storage_state — .browser/ when a convention
+# was reused, else .auth/ for a fresh scaffold.
+AUTH_DIR="$(dirname "${AUTH_STORAGE_STATE:-.auth/local.json}")/"
+grep -q "^${AUTH_DIR}" .gitignore 2>/dev/null || echo "${AUTH_DIR}" >> .gitignore
 ```
 
-Never overwrite `.auth/*.json` silently. If the file exists and a new one would
-be produced by the bootstrap command, ask: "Overwrite existing auth state at
-`.auth/local.json`?"
+Never overwrite the auth storage-state file silently. If it exists and a new one
+would be produced by the bootstrap command, ask: "Overwrite existing auth state
+at `<storage_state path>`?"
 
 ### Phase E — Smoke-test
 
@@ -282,6 +313,11 @@ One field needs attention: auth storage state is missing.
 The aw-target file and bootstrap script are committed so teammates can use the
 same flow. The auth storage state and credentials are gitignored — they
 contain secrets.
+
+> When the repo already has an auth convention (see
+> [Reuse before you scaffold](#reuse-before-you-scaffold)), these paths follow it
+> instead of the defaults shown — e.g. `.browser/auth-state.json` for the storage
+> state and `.claude/aw-targets/scripts/refresh-auth.mjs` for the script.
 
 ---
 
@@ -410,9 +446,10 @@ rewrite the bootstrap script + the `refresh.command` line in lockstep.
 - [ ] If strategy (a) or (b): the matching bootstrap script written under
       `scripts/auth-bootstrap-*.mjs` and reviewed by the user (especially
       the `CUSTOMIZE` block for strategy b).
-- [ ] `.auth/local.json` exists (or `auth.strategy: manual` is set).
-- [ ] `.auth/` is in `.gitignore`. If strategy (b), `.env.local` (or whichever
-      file holds `E2E_PASSWORD`) is also in `.gitignore`.
+- [ ] The auth storage-state file exists (or `auth.strategy: manual` is set).
+- [ ] The auth directory in use is in `.gitignore` — the reused convention's dir
+      (e.g. `.browser/`) or the `.auth/` default. If strategy (b), `.env.local`
+      (or whichever file holds `E2E_PASSWORD`) is also in `.gitignore`.
 - [ ] Smoke spec returned `green` (or `inconclusive` for `manual` auth strategy).
 - [ ] User told what to do next:
   - "Run an autonomous task that touches UI — the executor's Phase 4 will

--- a/skills/workflow/autonomous-workflow/templates/aw-target.yml.template
+++ b/skills/workflow/autonomous-workflow/templates/aw-target.yml.template
@@ -6,6 +6,10 @@
 # Convention:
 #   - Commit this file (it contains no secrets).
 #   - Add .auth/<name>.json to .gitignore (it contains the auth storage state).
+#   - Reuse an existing repo auth convention if one exists (a captured
+#     storage-state + login script, e.g. dash0's .browser/auth-state.json +
+#     .claude/aw-targets/scripts/refresh-auth.mjs) instead of scaffolding a
+#     parallel .auth/ — see aw-setup's "Reuse before you scaffold".
 #   - Run `/aw-setup` once to scaffold this file and validate it with a smoke spec.
 #   - Re-run `/aw-setup` anytime auth drifts, fixtures change, or base URL moves.
 #


### PR DESCRIPTION
## Why

`aw-setup` and `preview-spec` documented `.auth/<name>.json` + `scripts/auth-bootstrap-*.mjs` as the only auth layout. But some repos already have an auth convention — dash0 uses `.browser/auth-state.json` + `.browser/credentials.json` + `.claude/aw-targets/scripts/refresh-auth.mjs` (the `playwright-cli-authed` skill's layout). Following the docs there scaffolds a **parallel, drifting** `.auth/` setup instead of reusing what the repo maintains.

`aw-tester` itself is fine — it reads whatever `storage_state` the target names. The drift was only in the two skills that *prescribe* where auth lives.

## What changed

Make `.auth/` the fallback scaffold, not a mandate.

- **aw-setup** (`SKILL.md`): new "Reuse before you scaffold" probe order — an existing `.claude/aw-targets/*.yml` with `auth.storage_state` → a captured `.browser/auth-state*.json` → `.auth/*.json`; and `refresh-auth*.mjs` → `auth-bootstrap-*.mjs`. Convention-aware gitignore guard (`.browser/` vs `.auth/`), plus matching notes in the file-location table and definition-of-done.
- **preview-spec**: the runner reuses an existing convention when no committed `preview.yml` exists (instead of defaulting straight to `.auth/` / `none`); the preview-target template shows the `.browser/` reuse example alongside the `.auth/` default and defaults preview refresh to `when: always` (a preview host differs per PR and per push).
- **aw-target.yml.template**: a one-line note to reuse an existing convention over a parallel `.auth/`.

## Scope

Docs/templates only — 4 files, no code, no secrets. The `.browser/` convention is named as an *example* of an existing layout to reuse; the skills stay portable and still scaffold `.auth/` when a repo has nothing.
