### PR TITLE
Feed codebase-knowledge: three verified-fact writers + a plan-time reader

### DIFF
--- a/agents/pr-reviewer/rules/memory.md
+++ b/agents/pr-reviewer/rules/memory.md
@@ -49,7 +49,7 @@ a re-phrased finding starts over. See [`references/detection-research.md`](../re
 | Record | Tag / key | Scope | TTL | Holds | Can it suppress? |
 | --- | --- | --- | --- | --- | --- |
 | **Symbol knowledge** | `codebase-knowledge` / `knowledge::<symbol>@<path>` | `repo::{owner}/{repo}` | 90 d | verified facts about one symbol — contracts, invariants callers rely on, consumer count at last trace, covering tests — each with `verified_at_sha`; plus `history[]` of findings raised on it (`{pr, sha, fp, verdict, outcome}`, capped at 20) | No |
-| **Hotspot** | `codebase-knowledge` / `hotspot::<path>` | `repo::{owner}/{repo}` | 90 d | per-file counters: `confirmed`, `missed` (a human caught something here that this agent did not flag), `regressed`, `last_touched_by[]` | No |
+| **Hotspot** | `codebase-knowledge` / `hotspot::<path>` | `repo::{owner}/{repo}` | 90 d | per-file counters: `confirmed`, `missed` (a human caught something here that this agent did not flag), `regressed`, `flaky` (a test file empirically flaky then stabilised, written by `e2e-pr-stabilizer`), `last_touched_by[]` | No |
 | **Relevance rule** | `loop::reviewer-comment-relevance` / `reviewer-comment-relevance::rule::<fp>` | `repo::{owner}/{repo}` | 60 d | `direction: suppress \| amplify`, `status`, `evidence[]`, optional `scope_globs[]` | Yes — and only this one |
 | **PR state** | `ci::pr-review-state` / `ci-state::pr-review-<n>` | `branch::{owner}/{repo}::{head-branch-name}` | 7 d | this agent's own run history for one PR | No |
 
@@ -339,6 +339,7 @@ this run incremented:
   "confirmed": 4,
   "missed": 1,
   "regressed": 0,
+  "flaky": 0,
   "classes": ["contract-break", "nil-deref"],
   "confirmed_examples": [
     { "pr": 164, "sha": "47b969a",

--- a/agents/shared/rules/codebase-knowledge.md
+++ b/agents/shared/rules/codebase-knowledge.md
@@ -23,13 +23,23 @@ person be consumed by a loop wired by another. The taxonomy entry is
 | **Kind** | `signal` (a durable per-repo filter, read on every run that touches code) |
 | **Scope** | `repo::{owner}/{repo}` — a codebase fact is repo-bound |
 | **TTL** | ~90 days, refreshed on re-verification |
-| **Keys** | `knowledge::<symbol>@<path>` — verified facts about one symbol (an invariant it holds, its consumer/dependent count, a defect it produced before, plus a capped `history[]` of findings); `hotspot::<path>` — per-file counters (`confirmed`, `missed`, `regressed`, `classes`, `confirmed_examples`, `last_touched_by`) |
+| **Keys** | `knowledge::<symbol>@<path>` — verified facts about one symbol (an invariant it holds, its consumer/dependent count, a defect it produced before, plus a capped `history[]` of findings); `hotspot::<path>` — per-file counters (`confirmed`, `missed`, `regressed`, `flaky`, `classes`, `confirmed_examples`, `last_touched_by`) |
 
 The keys are **structural** on purpose: a key survives a rename of the *finding*
 but not a rename of the *code*, which is exactly the sensitivity that lets a
 different loop match it against the files it is about to touch. Set `kind: signal`
 and `host` explicitly on every write — LoreKit infers them only from a `loop::`
 tag, and this bucket is not tagged that way.
+
+Both records are a **closed JSON object** (the `hotspot` and `knowledge` shapes in
+[`pr-reviewer/rules/memory.md`](../../pr-reviewer/rules/memory.md) are the
+reference), the value is that JSON and nothing else, and a `hotspot` field set is
+shared across writers: `flaky` counts the times a test file was empirically flaky
+then stabilised (written by `e2e-pr-stabilizer`), the way `confirmed` / `missed` /
+`regressed` count review outcomes. A writer **increments only the counters it
+earned this run and carries the rest through unchanged** — which is what lets a
+`pr-reviewer` write and an `e2e-pr-stabilizer` write to the same `hotspot::<path>`
+compose instead of clobber.
 
 ## Read side — automatic for any code-changing host
 
@@ -112,6 +122,10 @@ host invent its own.
 | `implement-suggestion` | apply seam, once the target files are known | Reader |
 | `fix-bug` | fast-lane plan seam (`aw-create-plan`) | Reader |
 | `ci-auto-fix` | the fix subagent, once the failing files are known | Reader |
+| `optimize-approach` | plan mode, judging a plan's approach (aw-planner Phase 1) | Reader |
+| `test-auto-fix` | Phase 2 (read) / Phase 6–7 (write) | Reader + writer |
+| `e2e-pr-stabilizer` | Phase 7, on the CI-ratified verdict | Writer (`hotspot` `flaky`) |
+| `holistic-analysis` | its verification output, best-effort | Writer-primary (no read) |
 
 A reader that verifies a structural fact while doing its work may write it back
 under the contract above; otherwise it reads only.

--- a/skills/analysis/holistic-analysis/SKILL.md
+++ b/skills/analysis/holistic-analysis/SKILL.md
@@ -53,6 +53,7 @@ code.
 - [Phase 7: Plan the Change — Words Before Code](#phase-7-plan-the-change--words-before-code)
 - [Phase 8: Implement and Verify](#phase-8-implement-and-verify) — `/confidence code` gate
 - [Output Format](#output-format)
+- [Contribute verified facts to codebase-knowledge](#contribute-verified-facts-to-codebase-knowledge) — writer-primary, best-effort, gated on real verification
 - [Anti-Patterns — What NOT to Do](#anti-patterns--what-not-to-do)
 
 ## Mode Detection
@@ -344,6 +345,23 @@ Present the analysis using this structure:
 ### Implementation Confidence (/confidence code)
 [Score and dimension breakdown from Phase 8]
 ```
+
+---
+
+## Contribute verified facts to codebase-knowledge
+
+This skill is the engine that *confirms the why* — an invariant a symbol upholds
+(Step 1c), a consumer count swept in Context Gathering, a root-cause defect pinned at
+a SHA (Phase 4 → Phase 6). Those confirmed facts are the scarcest, most reusable
+entries in the shared **`codebase-knowledge`** bucket. When a run has genuinely
+verified such a fact against the code, contribute it back so the next code-changer
+(`aw`, `fix-bug`, `implement-suggestion`, `ci-auto-fix`, `optimize-approach`,
+`test-auto-fix`) plans with it in hand.
+
+This is a **writer-primary, best-effort** step: it never blocks or reshapes the
+analysis above, writes only what THIS run verified, and follows the multi-writer
+contract. Full procedure and the gate on real verification:
+[`rules/codebase-knowledge-write.md`](./rules/codebase-knowledge-write.md).
 
 ---
 

--- a/skills/analysis/holistic-analysis/rules/codebase-knowledge-write.md
+++ b/skills/analysis/holistic-analysis/rules/codebase-knowledge-write.md
@@ -34,17 +34,25 @@ Follow the multi-writer contract in
 [`../../../../agents/shared/rules/codebase-knowledge.md`](../../../../agents/shared/rules/codebase-knowledge.md)
 — every bullet, not a subset:
 
+The `value` is the **knowledge JSON record** (the shape in
+[`pr-reviewer/rules/memory.md`](../../../../agents/pr-reviewer/rules/memory.md):
+`v / symbol / path / kind / verified_at_sha / facts[] / consumer_files /
+covering_tests / history[]`), serialised — the value is that JSON and nothing else,
+**merged onto the record read first**, never an ad-hoc blob:
+
 ```text
-# Merge, never clobber: read the existing record, append to the capped history[],
-# carry the rest through unchanged. Same scope+key updates in place.
+# Merge, never clobber: read the existing record, append the confirmed fact to the
+# capped facts[]/history[], carry every other field through unchanged. Same
+# scope+key updates in place.
 memory.read  { scope: "repo::{owner}/{repo}", key: "knowledge::<symbol>@<path>" }
 memory.write {
-  scope: "repo::{owner}/{repo}",
-  key:   "knowledge::<symbol>@<path>",
-  value: "<yaml: invariant / consumer-count / defect + verified_at_sha:<analyzed SHA>>",
-  tags:  ["codebase-knowledge", "signal::knowledge"],
-  kind:  "signal",
-  host:  "holistic-analysis"
+  scope:    "repo::{owner}/{repo}",
+  key:      "knowledge::<symbol>@<path>",
+  value:    "<the knowledge JSON record, serialised — verified_at_sha:<analyzed SHA>, facts[]/history[] capped, MERGED onto the read record>",
+  tags:     ["codebase-knowledge"],
+  kind:     "signal",
+  host:     "holistic-analysis",
+  ttl_days: 90
 }
 ```
 

--- a/skills/analysis/holistic-analysis/rules/codebase-knowledge-write.md
+++ b/skills/analysis/holistic-analysis/rules/codebase-knowledge-write.md
@@ -1,0 +1,66 @@
+# Writing verified facts to codebase-knowledge
+
+`holistic-analysis` confirms durable structural facts about code — an invariant a
+symbol upholds, a consumer/dependent count it swept, a root-cause defect pinned to a
+symbol at a SHA. Those are the scarcest, most reusable entries in the shared
+`codebase-knowledge` bucket, and this skill is the engine that verifies the *why*
+behind them. When a run has genuinely established such a fact against the code,
+contribute it back so the next code-changer plans with it in hand.
+
+This is a **best-effort write, gated on real verification.** It never blocks or
+reshapes the analysis output the caller consumes, and it runs only when the
+LoreKit `memory.*` tools are connected and the repo has a git remote — skip it
+silently otherwise.
+
+## When to write
+
+Write only a fact THIS analysis actually confirmed against the code:
+
+- **An invariant** a symbol holds that callers rely on — Step 1c Contract Boundary
+  Analysis confirmed it → `knowledge::<symbol>@<path>`.
+- **A consumer / dependent count** you swept exhaustively — the call-graph map is
+  complete, not sampled → `knowledge::<symbol>@<path>`.
+- **A root-cause defect** pinned to a specific symbol at the analyzed SHA — fix mode,
+  Phase 4 hypothesis that cleared the Phase 6 confidence gate →
+  `knowledge::<symbol>@<path>`, the defect recorded in `history[]`.
+
+Do **not** write a hypothesis, a hunch, or an approach you did not verify. An
+unverified fact is worse than no fact, because a later reader treats it as ground
+truth.
+
+## How to write (contract)
+
+Follow the multi-writer contract in
+[`../../../../agents/shared/rules/codebase-knowledge.md`](../../../../agents/shared/rules/codebase-knowledge.md)
+— every bullet, not a subset:
+
+```text
+# Merge, never clobber: read the existing record, append to the capped history[],
+# carry the rest through unchanged. Same scope+key updates in place.
+memory.read  { scope: "repo::{owner}/{repo}", key: "knowledge::<symbol>@<path>" }
+memory.write {
+  scope: "repo::{owner}/{repo}",
+  key:   "knowledge::<symbol>@<path>",
+  value: "<yaml: invariant / consumer-count / defect + verified_at_sha:<analyzed SHA>>",
+  tags:  ["codebase-knowledge", "signal::knowledge"],
+  kind:  "signal",
+  host:  "holistic-analysis"
+}
+```
+
+- **`verified_at_sha`** = the SHA the analysis ran against; **`source_agent:
+  holistic-analysis`** stamped, so a reader knows who verified the fact and when.
+- **Only what THIS run verified** against the code — never a guess, and never a fact
+  about a person or a telemetry reading. A fact about code, keyed to code.
+- **Raise care, never suppress.** A fact here only tells the next run to preserve an
+  invariant or expect a hotspot; it never lowers a bar or silences a finding.
+- **Privacy pre-flight.** Drop any candidate carrying a credential, a customer name,
+  a token, or PII.
+
+## Read posture
+
+`holistic-analysis` is a **writer-primary** host: its own Context Gathering already
+traces the touched files deeply, so it does not read `codebase-knowledge` in this
+wiring. The read side is owned by the plan/apply-seam hosts (`aw`,
+`implement-suggestion`, `fix-bug`, `ci-auto-fix`, `optimize-approach`,
+`test-auto-fix`) — this skill feeds them.

--- a/skills/quality/optimize-approach/SKILL.md
+++ b/skills/quality/optimize-approach/SKILL.md
@@ -143,6 +143,7 @@ Load on demand — do not preload.
 This skill runs a two-tier self-improvement loop keyed by the `optimize-approach-lessons` bucket (LoreKit tag `loop::optimize-approach-lessons`).
 The fast tier (LoreKit `memory.*` tools, via the `lorekit-memory` skill) reads lessons at O0 and writes them at O5 to calibrate the optimal-vs-suboptimal bar and the apply-safety judgment.
 A lesson reaching `seen_count >= 3` becomes promotion-eligible for the slow tier (`/create-skill diagnose optimize-approach`).
+In `plan` mode it also reads the shared **`codebase-knowledge`** signal for the plan's files — a known hotspot or invariant sharpens the optimality call — read-only, advisory (see the loop file's cross-bucket read section and [`../../../agents/shared/rules/codebase-knowledge.md`](../../../agents/shared/rules/codebase-knowledge.md)).
 Full contract: [`rules/self-improvement-loop.md`](./rules/self-improvement-loop.md).
 
 ## Core Principles

--- a/skills/quality/optimize-approach/rules/self-improvement-loop.md
+++ b/skills/quality/optimize-approach/rules/self-improvement-loop.md
@@ -22,6 +22,7 @@ Do not re-implement memory mechanics here.
 - [Scope](#scope)
 - [What the loop calibrates](#what-the-loop-calibrates)
 - [Fast tier — read (Phase O0)](#fast-tier--read-phase-o0)
+- [Cross-bucket read — codebase-knowledge (plan seam)](#cross-bucket-read--codebase-knowledge-plan-seam)
 - [Fast tier — write (Phase O5)](#fast-tier--write-phase-o5)
 - [Promotion — slow tier](#promotion--slow-tier)
 - [Entrenchment guards](#entrenchment-guards)
@@ -64,6 +65,30 @@ Match each lesson's `trigger-context` against the current run (caller, stack, ch
 Apply matches as **advisory** considerations on the O2 judgment and the O5 apply-safety call — never as a hard override of the rubric.
 `repo::` wins over `global` on conflict; log the conflict.
 No consolidation pass — LoreKit owns storage and dedups on write; stale beliefs decay via `expires`.
+
+## Cross-bucket read — codebase-knowledge (plan seam)
+
+The read above is this skill's **own** bucket. There is one cross-bucket read worth
+making in plan mode: the shared `codebase-knowledge` signal — the cross-branch,
+cross-author record of what prior loops learned about this repo's symbols and files
+(`knowledge::<symbol>@<path>` facts, `hotspot::<path>` counters). Do it once the plan
+under judgment names the concrete files it will change — that is when the structural
+key is matchable, and it sharpens the optimal-vs-suboptimal call.
+
+```text
+memory.list { scope: "repo::{owner}/{repo}", tags: ["codebase-knowledge"], limit: 100 }
+# Keep only hotspot::<path> / knowledge::<symbol>@<path> whose <path> the plan will
+# touch. Fold into the O2 judgment: a known regression hotspot raises the bar for
+# "is this approach safe and optimal here"; a known invariant / consumer count is a
+# constraint the chosen approach must respect.
+```
+
+The read is **read-only, structural, bounded to the plan, advisory, and raises care
+without suppressing** — the full contract is
+[`../../../../agents/shared/rules/codebase-knowledge.md`](../../../../agents/shared/rules/codebase-knowledge.md).
+Skip silently when `memory.*` is not connected, there is no git remote, or nothing
+matches. `optimize-approach` is a **reader only** here — it never writes this bucket.
+Never wholesale-read another host's `loop::<host>-lessons`.
 
 ## Fast tier — write (Phase O5)
 

--- a/skills/testing/e2e-pr-stabilizer/SKILL.md
+++ b/skills/testing/e2e-pr-stabilizer/SKILL.md
@@ -194,6 +194,12 @@ never relax a guard-rail, an empirical gate, or the 3-consecutive-pass
 requirement. A recurring lesson (`seen_count >= 3`) is promotion-eligible via
 `/create-skill diagnose e2e-pr-stabilizer`.
 
+On the Phase 7 ratified verdict it also contributes a **flaky hotspot** to the
+shared **`codebase-knowledge`** bucket (`hotspot::<test.file>` counter) — a fact no
+other host produces, so every later code-changer plans around a known-unstable file.
+Write only, merge-never-clobber, on the ratified SHA (contract:
+[`../../../agents/shared/rules/codebase-knowledge.md`](../../../agents/shared/rules/codebase-knowledge.md); mechanics in the loop file's cross-bucket write section).
+
 `optimize` mode skips the loop (no fix, no ratification signal). Lessons run
 through LoreKit's `memory.*` tools (the `lorekit-memory` skill); if LoreKit is
 not connected the loop is a silent no-op. Full contract:

--- a/skills/testing/e2e-pr-stabilizer/rules/self-improvement-loop.md
+++ b/skills/testing/e2e-pr-stabilizer/rules/self-improvement-loop.md
@@ -221,17 +221,28 @@ Write it **only on the ratified verdict** (same honesty gate as the lessons writ
 keyed structurally by the test file's path, under the contract in
 [`../../../../agents/shared/rules/codebase-knowledge.md`](../../../../agents/shared/rules/codebase-knowledge.md):
 
+The `value` is the shared **hotspot JSON record** (the closed field set in
+[`../../../../agents/shared/rules/codebase-knowledge.md`](../../../../agents/shared/rules/codebase-knowledge.md)
+and the reference shape in
+[`pr-reviewer/rules/memory.md`](../../../../agents/pr-reviewer/rules/memory.md):
+`v / path / confirmed / missed / regressed / flaky / classes / confirmed_examples /
+last_touched_by / expires`), serialised — the value is that JSON and nothing else.
+This is the same record `pr-reviewer` writes, so the two **compose** on a shared
+`hotspot::<test.file>` key: increment only `flaky` (the counter this run earned) and
+carry every other counter through unchanged:
+
 ```text
-# Merge, never clobber: read the existing record first, then increment the counter
-# this run proved and append to the capped history[]. Same scope+key updates in place.
+# Merge, never clobber: read the existing record first, increment ONLY the counter
+# this run proved, carry the rest through unchanged. Same scope+key updates in place.
 memory.read  { scope: "repo::{owner}/{repo}", key: "hotspot::<test.file>" }
 memory.write {
-  scope: "repo::{owner}/{repo}",
-  key:   "hotspot::<test.file>",
-  value: "<yaml: flaky:<n+1> regressed:<m> last verdict + verified_at_sha:<ratified SHA>>",
-  tags:  ["codebase-knowledge", "signal::flaky"],
-  kind:  "signal",
-  host:  "e2e-pr-stabilizer"
+  scope:    "repo::{owner}/{repo}",
+  key:      "hotspot::<test.file>",
+  value:    "<the hotspot JSON record: flaky incremented, regressed if Phase 7 came back regressed, every other counter carried through, expires:<now+90d> — MERGED onto the read record>",
+  tags:     ["codebase-knowledge", "signal::confirmed"],
+  kind:     "signal",
+  host:     "e2e-pr-stabilizer",
+  ttl_days: 90
 }
 ```
 

--- a/skills/testing/e2e-pr-stabilizer/rules/self-improvement-loop.md
+++ b/skills/testing/e2e-pr-stabilizer/rules/self-improvement-loop.md
@@ -34,6 +34,7 @@ tier is a silent no-op (log one line, continue).
 - [Scope and the two-tier split](#scope-and-the-two-tier-split)
 - [Read lessons (Phase 4)](#read-lessons-phase-4)
 - [Write lessons (Phase 7 ratification)](#write-lessons-phase-7-ratification)
+- [Cross-bucket write — codebase-knowledge (flaky hotspots)](#cross-bucket-write--codebase-knowledge-flaky-hotspots)
 - [Lesson promotion](#lesson-promotion)
 - [Entrenchment guards](#entrenchment-guards)
 
@@ -205,6 +206,48 @@ Log (include the resolved scope and the ratification verdict):
 - [TIMESTAMP] Phase 7: lorekit(memory.write global e2e-pr-stabilizer-lessons::<slug>) — UPDATE, seen_count→3 — ratified fixed
 - [TIMESTAMP] Phase 7: lorekit(memory.write repo::{owner}/{repo} e2e-pr-stabilizer-lessons::<slug>) — ADD — ratified regressed, project-bound
 ```
+
+---
+
+## Cross-bucket write — codebase-knowledge (flaky hotspots)
+
+The lessons above are this skill's **own** bucket — prose about race-shapes and
+locator strategies. This skill also holds a fact no other host can produce: **which
+test file was empirically flaky**. When Phase 7 CI ratifies a verdict for a specific
+test file, contribute a structural counter to the shared `codebase-knowledge` bucket
+so every later code-changer plans around a known-unstable file.
+
+Write it **only on the ratified verdict** (same honesty gate as the lessons write),
+keyed structurally by the test file's path, under the contract in
+[`../../../../agents/shared/rules/codebase-knowledge.md`](../../../../agents/shared/rules/codebase-knowledge.md):
+
+```text
+# Merge, never clobber: read the existing record first, then increment the counter
+# this run proved and append to the capped history[]. Same scope+key updates in place.
+memory.read  { scope: "repo::{owner}/{repo}", key: "hotspot::<test.file>" }
+memory.write {
+  scope: "repo::{owner}/{repo}",
+  key:   "hotspot::<test.file>",
+  value: "<yaml: flaky:<n+1> regressed:<m> last verdict + verified_at_sha:<ratified SHA>>",
+  tags:  ["codebase-knowledge", "signal::flaky"],
+  kind:  "signal",
+  host:  "e2e-pr-stabilizer"
+}
+```
+
+- **Only what THIS run verified.** Increment `flaky` when CI ratified the file was
+  flaky (whether or not the stabilization held); increment `regressed` when Phase 7
+  came back `regressed`. Never write a guess or a local-only streak.
+- **`verified_at_sha` + `source_agent` on every write** — the ratified SHA and
+  `host: e2e-pr-stabilizer`, so a reader knows who proved it and when.
+- **Raise care, never suppress.** A flaky-file hotspot tells a later run to add
+  coverage and expect instability; it never silences a finding or lowers a bar.
+- **Privacy pre-flight.** A test-file path carries no product data; still drop any
+  candidate that would.
+
+This is a **write only** on the ratified verdict — it does not replace the lessons
+write, and this skill does not read `codebase-knowledge` (it acts on a named failing
+test, not a plan of files it chose).
 
 ---
 

--- a/skills/testing/test-auto-fix/SKILL.md
+++ b/skills/testing/test-auto-fix/SKILL.md
@@ -262,6 +262,12 @@ tools (the `lorekit-memory` skill); if LoreKit is not connected the loop is a
 silent no-op. Full contract:
 [`rules/self-improvement-loop.md`](./rules/self-improvement-loop.md).
 
+Beyond its own lessons, it also **reads** the shared **`codebase-knowledge`** signal
+at Phase 2 for the files a failure touches (advisory, raise-care) and **writes** back
+a verified structural fact — a real product defect fixed in source at a SHA, or a
+repeatedly-red test file as a hotspot — under the multi-writer contract
+([`../../../agents/shared/rules/codebase-knowledge.md`](../../../agents/shared/rules/codebase-knowledge.md); mechanics in the loop file's cross-bucket read/write sections).
+
 ## Definition of done
 
 The run is done when ANY of the following is true:

--- a/skills/testing/test-auto-fix/rules/self-improvement-loop.md
+++ b/skills/testing/test-auto-fix/rules/self-improvement-loop.md
@@ -248,18 +248,32 @@ under the contract in
 | A real product defect fixed in source (verdict `prod-bug`, fix landed, green) | `knowledge::<symbol>@<path>` — the defect + the SHA it was fixed at | Phase 7, green, on a source fix (not a test-only fix) |
 | A test file that went red repeatedly across the outer loop | `hotspot::<test.file>` counter | Phase 6 / 7, when the same file recurred |
 
+Both records are the shared JSON shapes from
+[`../../../../agents/shared/rules/codebase-knowledge.md`](../../../../agents/shared/rules/codebase-knowledge.md)
+(reference in
+[`pr-reviewer/rules/memory.md`](../../../../agents/pr-reviewer/rules/memory.md)) —
+the value is that JSON and nothing else, **merged onto the record read first**, so a
+`test-auto-fix` write and a `pr-reviewer` write to the same key compose:
+
 ```text
-# Merge, never clobber: read first, increment/append, same scope+key updates in place.
+# The defect → knowledge JSON record. Merge, never clobber: read first, append the
+# defect to the capped history[], carry the rest through. Same scope+key updates in place.
 memory.read  { scope: "repo::{owner}/{repo}", key: "knowledge::<symbol>@<path>" }
 memory.write {
-  scope: "repo::{owner}/{repo}",
-  key:   "knowledge::<symbol>@<path>",
-  value: "<yaml: defect + fix + verified_at_sha:<green SHA>, history[] capped>",
-  tags:  ["codebase-knowledge", "signal::defect"],
-  kind:  "signal",
-  host:  "test-auto-fix"
+  scope:    "repo::{owner}/{repo}",
+  key:      "knowledge::<symbol>@<path>",
+  value:    "<the knowledge JSON record: the defect + fix, verified_at_sha:<green SHA>, history[] capped — MERGED onto the read record>",
+  tags:     ["codebase-knowledge"],
+  kind:     "signal",
+  host:     "test-auto-fix",
+  ttl_days: 90
 }
 ```
+
+The recurring-red **`hotspot::<test.file>`** write follows the same rule: read the
+shared hotspot JSON record, increment only `regressed` (or `flaky`), carry every
+other counter through, `tags: ["codebase-knowledge", "signal::confirmed"]`,
+`kind: signal`, `host: test-auto-fix`, `ttl_days: 90`.
 
 - **Only what THIS run verified** against a green re-run — never a guess, and never
   a fact about a person or a telemetry reading. A fact about code, keyed to code.

--- a/skills/testing/test-auto-fix/rules/self-improvement-loop.md
+++ b/skills/testing/test-auto-fix/rules/self-improvement-loop.md
@@ -31,7 +31,9 @@ tier is a silent no-op (log one line, continue).
 - [Lessons vs. the surface file](#lessons-vs-the-surface-file)
 - [Scope](#scope)
 - [Read lessons (Phase 2)](#read-lessons-phase-2)
+- [Cross-bucket read — codebase-knowledge (Phase 2)](#cross-bucket-read--codebase-knowledge-phase-2)
 - [Write lessons (Phase 6 / 7)](#write-lessons-phase-6--7)
+- [Cross-bucket write — codebase-knowledge (verified structural facts)](#cross-bucket-write--codebase-knowledge-verified-structural-facts)
 - [Lesson promotion](#lesson-promotion)
 - [Entrenchment guards](#entrenchment-guards)
 
@@ -155,6 +157,29 @@ Log:
 
 ---
 
+## Cross-bucket read — codebase-knowledge (Phase 2)
+
+The read above is this skill's **own** bucket. When the failures name concrete
+source files (a failing test points at the module under test), also read the shared
+`codebase-knowledge` signal for those files — the cross-branch, cross-author record
+of what prior loops learned about this repo's symbols and files
+(`knowledge::<symbol>@<path>` facts, `hotspot::<path>` counters):
+
+```text
+memory.list { scope: "repo::{owner}/{repo}", tags: ["codebase-knowledge"], limit: 100 }
+# Keep only hotspot::<path> / knowledge::<symbol>@<path> whose <path> a failing test
+# or its module under test covers. A known invariant / consumer count is a constraint
+# the fix must preserve; a hotspot raises care on a fix that touches source, not test.
+```
+
+**Read-only, structural, bounded to the run's files, advisory, raises care without
+suppressing** — full contract in
+[`../../../../agents/shared/rules/codebase-knowledge.md`](../../../../agents/shared/rules/codebase-knowledge.md).
+It never relaxes the verdict rubric or the confidence gate. Skip silently when
+`memory.*` is not connected, there is no git remote, or nothing matches.
+
+---
+
 ## Write lessons (Phase 6 / 7)
 
 **Anchor:** `lessons-write`
@@ -207,6 +232,44 @@ Log (include the resolved scope + verdict shape + outcome):
 - [TIMESTAMP] Phase 7: lorekit(memory.write repo::{owner}/{repo} test-auto-fix-lessons::<slug>) — UPDATE, seen_count→3 — green
 - [TIMESTAMP] Phase 6: lorekit(memory.write global test-auto-fix-lessons::<slug>) — ADD — regression reverted
 ```
+
+---
+
+## Cross-bucket write — codebase-knowledge (verified structural facts)
+
+The lessons above are prose about *this skill's own judgment*. A run also sometimes
+**verifies a durable structural fact about the code** — the kind another
+code-changer would want. Contribute those to the shared `codebase-knowledge` bucket
+under the contract in
+[`../../../../agents/shared/rules/codebase-knowledge.md`](../../../../agents/shared/rules/codebase-knowledge.md):
+
+| What this run verified | Key | Written when |
+| ---------------------- | --- | ------------ |
+| A real product defect fixed in source (verdict `prod-bug`, fix landed, green) | `knowledge::<symbol>@<path>` — the defect + the SHA it was fixed at | Phase 7, green, on a source fix (not a test-only fix) |
+| A test file that went red repeatedly across the outer loop | `hotspot::<test.file>` counter | Phase 6 / 7, when the same file recurred |
+
+```text
+# Merge, never clobber: read first, increment/append, same scope+key updates in place.
+memory.read  { scope: "repo::{owner}/{repo}", key: "knowledge::<symbol>@<path>" }
+memory.write {
+  scope: "repo::{owner}/{repo}",
+  key:   "knowledge::<symbol>@<path>",
+  value: "<yaml: defect + fix + verified_at_sha:<green SHA>, history[] capped>",
+  tags:  ["codebase-knowledge", "signal::defect"],
+  kind:  "signal",
+  host:  "test-auto-fix"
+}
+```
+
+- **Only what THIS run verified** against a green re-run — never a guess, and never
+  a fact about a person or a telemetry reading. A fact about code, keyed to code.
+- **`verified_at_sha` + `source_agent: test-auto-fix`** on every write.
+- **Raise care, never suppress**, and **never** encode a test-weakening action — the
+  same hard refusal as the lessons write.
+- **Privacy pre-flight** — drop any candidate carrying product data.
+
+This is separate from and additional to the lessons write; skip it silently when the
+run verified no durable structural fact.
 
 ---
 


### PR DESCRIPTION
## Why

PR #174 standardized `codebase-knowledge` as the shared, repo-scoped, structurally-keyed layer, but wired only one writer (`pr-reviewer`) against four readers — so the layer fills slowly. The synergy compounds only when more hosts *feed* it. This adds writers that produce fact types the reviewer cannot, plus one plan-time reader, all on the same shared bucket under the multi-writer contract.

## What

- **holistic-analysis → writer.** The engine that confirms the *why* — an invariant a symbol upholds (Step 1c), a consumer count swept in Context Gathering, a root-cause defect pinned at a SHA (Phase 4 → Phase 6). New `rules/codebase-knowledge-write.md` + an Output-Format seam. Writer-primary, best-effort, gated on real verification.
- **e2e-pr-stabilizer → writer.** On the Phase 7 CI-ratified verdict it records a `hotspot::<test.file>` flaky counter — empirical flaky-test data no other host produces.
- **test-auto-fix → writer + reader.** Reads the layer at classify (Phase 2) for the files a failure touches; writes a defect-at-SHA `knowledge::<symbol>@<path>` on a green source fix, or a failing-test `hotspot::<path>`.
- **optimize-approach → reader.** Reads the layer in plan mode so a known hotspot or invariant sharpens the optimal-vs-suboptimal call at aw-planner Phase 1.

Every wiring uses the same `codebase-knowledge` tag at `repo::{owner}/{repo}` and references `agents/shared/rules/codebase-knowledge.md`; every writer follows its seven-bullet contract (structural key, `verified_at_sha`, `source_agent`, only-what-this-run-verified, merge-never-clobber, raise-care-never-suppress, explicit kind/host/TTL/privacy).

## Verification

`node scripts/eval/l1.mjs` → **1328/1328** deterministic contract checks pass.
