### PR TITLE
Point agent0_org at the Dash0 organization UUID

### DIFF
--- a/.github/review.yaml
+++ b/.github/review.yaml
@@ -1,3 +1,3 @@
 agent0_fix_links: true
 agent0_environment: development
-agent0_org: dash0-development
+agent0_org: e8b3aed4-ae5f-4093-a1af-448a98405346


### PR DESCRIPTION
## Why

`agent0_org` shipped in #177 with `dash0-development` as this repo's value, but the canonical identifier for the organization is its UUID. Fix buttons should open it unambiguously.

## What changed

- `.github/review.yaml`: `agent0_org: dash0-development` → `agent0_org: e8b3aed4-ae5f-4093-a1af-448a98405346`

## How to verify

```bash
node agents/pr-reviewer/scripts/build-agent0-link.mjs --env development --org e8b3aed4-ae5f-4093-a1af-448a98405346 --source fix-all "x"
```

Emits `…&utm_source=pr-reviewer-fix-all&org=e8b3aed4-ae5f-4093-a1af-448a98405346`. The shell resolution in `review-config.md` accepts it too, and L1 is green at 1474/1474.

## Notes for reviewers

The UUID is 36 chars of hex and hyphens starting with `e`, so it satisfies both `ORG_RE` and the config regex unchanged — no validation change was needed. The docs still use `dash0-development` as their example slug; left alone here, happy to switch them if the UUID is the canonical form.

https://claude.ai/code/session_018vqEFrNqNC9BrMze5tc2jC

---
_Generated by [Claude Code](https://claude.ai/code/session_018vqEFrNqNC9BrMze5tc2jC)_