### PR TITLE
Ask the retrieval suite the question its labels answer

### DIFF
--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -550,10 +550,11 @@ BASELINE`. At 5 cases it was `[advisory]` and could not breach the floor.
 > was the suite's own `instruction` asking whether the read surfaces a record *"to the finders"*
 > — a question §1.0 answers the *other* way, since Step 1.2d shortlists by changed path before
 > the finders see anything — while the labels encode list-reachability. The question is now
-> scoped to what the read **returns**, and the next run measured **10/14 (71.4%)** — green, with
-> the three misses predicted to remain all recurring identically and one of the two targeted diff
-> cases flipping. One case is 7.1 points here, so read that composition rather than the number;
-> the per-case history, the full run table and what the fix did *not* close are in
+> scoped to what the read **returns**, and the two runs since measured **10/14 (71.4%)** and
+> **11/14 (78.6%)** — green both times, with the three misses predicted to remain recurring
+> identically in both and forming the *entire* miss set in the second. One case is 7.1 points
+> here, so quote that composition rather than either number; the per-case history, the full run
+> table and what the fix did *not* close are in
 > [`golden/code-review-retrieval-relevance.NOTES.md`](./golden/code-review-retrieval-relevance.NOTES.md).
 > Every figure for this suite below predates the decoys and describes 5 different cases; none of
 > them is comparable to a post-decoy run.
@@ -717,11 +718,16 @@ the strongest claim run 1 appeared to license:
   2's recall cost looking more like the outlier than the rule. Never quote a single
   detection run as evidence for or against the verifier, and never tune the two rubrics
   against one.
-- **`fp_rate` after the verifier is the stable number: 30% in runs 1 and 3, 40% in run
-  2 — never once at or under the 20% gate.** Recall swings 60–75% around a 70% bar and
-  has been on both sides of it. So the precision gap is the reproducible failure and the
-  recall gap is not yet distinguishable from noise; whoever works on this should aim at
-  the controls first.
+- **`fp_rate` after the verifier was the stable number — 30% in runs 1 and 3, 40% in run
+  2 — until run 4 cleared the 20% gate, so it is not stable either.** Recall swings 60–75%
+  around a 70% bar and has been on both sides of it. Run 4 (on #184, recall 15/20 = 75%,
+  `fp_rate` at or under 20%) is the first passing detection run of four and it retracts the
+  earlier reading that the precision gap is the *reproducible* failure: across four runs the
+  gate has been missed three times and met once, which is a flaky gate rather than a
+  standing red. Both rates are still worth aiming at — the controls first, since three of
+  four runs failed there — but do not treat either a red or a green detection run as
+  telling you the core changed. That is the same one-run rule as the bullet above,
+  now demonstrated on the gate itself rather than on the verifier's lift.
 - **`intent-mismatch` is the weak class in all three** — 1/4, 2/4, 2/4, against 3/4–4/4
   elsewhere; `standards` is 4/4 every time. Most of its misses were never flagged at all,
   so the gap is predominantly finder recall rather than verifier over-filtering. `logic`

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -544,12 +544,18 @@ at these sizes. Do not tighten a floor until a golden set reaches ≥ 50.
 floor allows exactly one miss, and its own golden notes say `BOOTSTRAP SEED — NOT A REAL
 BASELINE`. At 5 cases it was `[advisory]` and could not breach the floor.
 
-> **Superseded — it gates again, and it is red.** The decoy set took it to 14 cases, back
-> over `EVAL_GATE_MIN_CASES` (10), so it grades for real. Measured **9/14 (64.3%)** at
-> `e65c302` — below the floor. Every figure for this suite below predates that set and
-> describes 5 different cases; none of them is comparable to a post-decoy run. The
-> per-case history is in
+> **Superseded — it gates again.** The decoy set took it to 14 cases, back over
+> `EVAL_GATE_MIN_CASES` (10), so it grades for real. It measured **9/14 (64.3%)** three times
+> running with an identical miss set, which is a defect signature rather than noise: the cause
+> was the suite's own `instruction` asking whether the read surfaces a record *"to the finders"*
+> — a question §1.0 answers the *other* way, since Step 1.2d shortlists by changed path before
+> the finders see anything — while the labels encode list-reachability. The question is now
+> scoped to what the read **returns**. Three misses are expected to remain and are a real
+> measurement, not prompt noise; the per-case history, the run table and what the fix is *not*
+> expected to close are in
 > [`golden/code-review-retrieval-relevance.NOTES.md`](./golden/code-review-retrieval-relevance.NOTES.md).
+> Every figure for this suite below predates the decoys and describes 5 different cases; none of
+> them is comparable to a post-decoy run.
 
 Separately, its rubric is the 67,630-char `## Step 1`
 section — 6.4× the next largest — most of which is prior-comment awareness and gate

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -550,9 +550,10 @@ BASELINE`. At 5 cases it was `[advisory]` and could not breach the floor.
 > was the suite's own `instruction` asking whether the read surfaces a record *"to the finders"*
 > — a question §1.0 answers the *other* way, since Step 1.2d shortlists by changed path before
 > the finders see anything — while the labels encode list-reachability. The question is now
-> scoped to what the read **returns**. Three misses are expected to remain and are a real
-> measurement, not prompt noise; the per-case history, the run table and what the fix is *not*
-> expected to close are in
+> scoped to what the read **returns**, and the next run measured **10/14 (71.4%)** — green, with
+> the three misses predicted to remain all recurring identically and one of the two targeted diff
+> cases flipping. One case is 7.1 points here, so read that composition rather than the number;
+> the per-case history, the full run table and what the fix did *not* close are in
 > [`golden/code-review-retrieval-relevance.NOTES.md`](./golden/code-review-retrieval-relevance.NOTES.md).
 > Every figure for this suite below predates the decoys and describes 5 different cases; none of
 > them is comparable to a post-decoy run.

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -550,11 +550,11 @@ BASELINE`. At 5 cases it was `[advisory]` and could not breach the floor.
 > was the suite's own `instruction` asking whether the read surfaces a record *"to the finders"*
 > — a question §1.0 answers the *other* way, since Step 1.2d shortlists by changed path before
 > the finders see anything — while the labels encode list-reachability. The question is now
-> scoped to what the read **returns**, and the two runs since measured **10/14 (71.4%)** and
-> **11/14 (78.6%)** — green both times, with the three misses predicted to remain recurring
-> identically in both and forming the *entire* miss set in the second. One case is 7.1 points
-> here, so quote that composition rather than either number; the per-case history, the full run
-> table and what the fix did *not* close are in
+> scoped to what the read **returns**, and the three runs since measured **10/14**, **11/14**
+> and **11/14** (71.4 / 78.6 / 78.6%) — green every time, with the three misses predicted to
+> remain recurring identically in all three and forming the *entire* miss set in the last two.
+> One case is 7.1 points here, so quote that composition rather than any of the numbers; the
+> per-case history, the full run table and what the fix did *not* close are in
 > [`golden/code-review-retrieval-relevance.NOTES.md`](./golden/code-review-retrieval-relevance.NOTES.md).
 > Every figure for this suite below predates the decoys and describes 5 different cases; none of
 > them is comparable to a post-decoy run.
@@ -718,16 +718,24 @@ the strongest claim run 1 appeared to license:
   2's recall cost looking more like the outlier than the rule. Never quote a single
   detection run as evidence for or against the verifier, and never tune the two rubrics
   against one.
-- **`fp_rate` after the verifier was the stable number — 30% in runs 1 and 3, 40% in run
-  2 — until run 4 cleared the 20% gate, so it is not stable either.** Recall swings 60–75%
-  around a 70% bar and has been on both sides of it. Run 4 (on #184, recall 15/20 = 75%,
-  `fp_rate` at or under 20%) is the first passing detection run of four and it retracts the
-  earlier reading that the precision gap is the *reproducible* failure: across four runs the
-  gate has been missed three times and met once, which is a flaky gate rather than a
-  standing red. Both rates are still worth aiming at — the controls first, since three of
-  four runs failed there — but do not treat either a red or a green detection run as
-  telling you the core changed. That is the same one-run rule as the bullet above,
-  now demonstrated on the gate itself rather than on the verifier's lift.
+- **`fp_rate` after the verifier looked like the stable number — 30% in runs 1 and 3, 40% in
+  run 2 — until runs 4 and 5 came back at or under 20% and back at 40%. It is not stable
+  either.** Five runs: `fp_rate` 30 · 40 · 30 · ≤20 · 40, recall 75 · 60 · 70 · 75 · 90%.
+  Runs 4 and 5 were both on #184, whose diff touches neither detection rubric, so that
+  pair is a clean same-content measurement and the spread between them is pure run-to-run
+  variance.
+
+  This **retracts** the earlier reading that the precision gap is the *reproducible*
+  failure. One meet in five is a flaky gate, not a standing red — and run 5 pairs the
+  worst `fp_rate` with the best recall yet (90%, only two records missed), which is the
+  finder-aggression trade the two rubrics encode showing up as noise at these sample
+  sizes rather than as a fixed operating point. Both rates are still worth aiming at, and
+  the controls first, since four of five runs failed there. But do not treat a red or a
+  green detection run as telling you the core changed: that is the same one-run rule as
+  the bullet above, now demonstrated on the gate itself and not merely on the verifier's
+  lift. Run 5 also lost one record to an unparseable finder reply
+  (`intent-revert-not-fix`, prose instead of JSON) — counted as a miss, never as clean,
+  and still never a reason to loosen the parse.
 - **`intent-mismatch` is the weak class in all three** — 1/4, 2/4, 2/4, against 3/4–4/4
   elsewhere; `standards` is 4/4 every time. Most of its misses were never flagged at all,
   so the gap is predominantly finder recall rather than verifier over-filtering. `logic`

--- a/scripts/eval/golden/code-review-retrieval-relevance.NOTES.md
+++ b/scripts/eval/golden/code-review-retrieval-relevance.NOTES.md
@@ -51,7 +51,9 @@ Grow the set by adding decoys, never by moving the floor.
 
 ## What this suite measures
 
-Given a PR diff + a candidate memory (with its `tag`, `scope`, `source`, expiry, and gist), does the model — reading the live `### 1.0` + `### 1.2c` subsections of `agents/pr-reviewer.md` — correctly classify whether the documented Step 1.0 (`mcp__lorekit__memory_list`) + Step 1.2c (`mcp__lorekit__memory_search`) read surfaces that memory to the finders?
+Given a PR diff + a candidate memory (with its `tag`, `scope`, `source`, expiry, and gist), does the model — reading the live `### 1.0` + `### 1.2c` subsections of `agents/pr-reviewer.md` — correctly classify whether the documented Step 1.0 (`mcp__lorekit__memory_list`) + Step 1.2c (`mcp__lorekit__memory_search`) read **returns** that memory?
+
+Deliberately **not** "surfaces it to the finders". That phrasing named a different question — one that includes Step 1.2d's diff-keyed shortlist, which is out of this rubric and answers the opposite way for a diff-unrelated lesson. It sat in this sentence and in the `instruction` string simultaneously; see "Measured runs, and the instruction fix" below for what it cost.
 
 The rubric is those **two subsections**, deliberately not their `## Step 1` parent: `extractSection` is heading-level-aware, so the parent fed all ten `### 1.x` subsections (67,630 chars vs. 27,568) — including `### 1.2d`, whose diff-keyed shortlist answers *what reaches the finders* rather than *what the documented read returns*. With `1.2d` in scope, a list-reachable lesson unrelated to the diff is legitimately `skip` and the suite contradicts its own `instruction` string. L1 `G21a` reds on a re-widening.
 
@@ -75,5 +77,47 @@ dimensions is thinnest, and keep the case that motivated it.
 
 - **Rubric read from:** `agents/pr-reviewer.md`, sections `### 1.0 Prior-comment awareness + relevance memory load (default ON)` **and** `### 1.2c Diff-keyed lesson search (all modes)` — never the `## Step 1` parent
 - **Choices:** `surface` | `skip`
-- **Gate:** report-only until ≥ 50 real-corpus cases (current: 14 bootstrap cases, 8 `surface` / 6 `skip`)
+- **Gate:** **gating** — 14 cases is above `EVAL_GATE_MIN_CASES` (10), so it grades against the 70% floor and is not `[advisory]`. (This line previously read "report-only until ≥ 50 real-corpus cases", which described the 5-case set and stopped being true the moment the decoys landed. The ≥ 50 bar is about **raising** the floor, not about whether the current floor applies.)
 - **Real corpus requires:** LoreKit instance with real `reviewer-lessons` + `reviewer-comment-relevance` history
+
+## Measured runs, and the instruction fix
+
+The 14-case set has been measured three times, and the miss set is **stable** — which is what
+makes it a rubric/prompt defect rather than sampling noise:
+
+| head | score | misses |
+| --- | --- | --- |
+| `#183` head | 8/14 (57.1%) | the six below |
+| `e65c302` | 9/14 (64.3%) | five — `…seen2-below-threshold-scoped` passed |
+| `9e59b36` | 9/14 (64.3%) | same five, identical set |
+
+All misses were `surface → skip`, never the reverse: the six `skip` decoys passed 6/6 every time.
+A read that under-returns on 5 of 8 positives while never over-returning is not a model that
+cannot follow the rubric — it is a model applying a filter the rubric does not contain.
+
+**The question was asking for that filter.** The `instruction` asked whether the read surfaces the
+record *"to the finders"*. §1.0 uses that exact phrase for a record dropped by attribution — "such
+a record does not reach the finders" — and says diff-keying "enters later and *additively*", with
+**Step 1.2d** shortlisting the merged index by changed path and symbol before the finders see
+anything. So for a diff-unrelated lesson, `skip` was the *correct* answer to the question as
+posed, while the labels encode list-reachability. The prompt and the ground truth disagreed, and
+the labels were right.
+
+This is the second time this suite's question drifted off its labels: the verb was already
+corrected once (`would be surfaced … for the given PR diff` → `surfaces`) to remove exactly this
+relevance reading, and `to the finders` was left in place one clause over, reintroducing it.
+
+**What the fix is expected to close, and what it is not.** Only two of the five misses turn on the
+diff — `…unrelated-diff` and its scoped twin. The other three are the model failing to apply rules
+§1.0 states in as many words, and they are worth keeping visible:
+
+| miss | the rule it did not apply | stated at |
+| --- | --- | --- |
+| `seen2-below-threshold` | `seen_count` is the promotion bar, not a surfacing filter | §1.0 "It is not gated on `seen_count`" |
+| `global-scope-reachable` | `global` is one of the two scopes both paths read | §1.0 scope list; §1.2c `scopes` |
+| `source-explicit-maintainer-rule` | attribution is a **disjunction** — `source.explicit == true` carves in a human-authored record | §1.0 rule 1 |
+
+Those three are a genuine measurement of a real weakness, so the fix is **not** expected to reach
+14/14, and nothing here should be tuned until it does. Deliberately NOT done: adding a summary of
+the four filters to the `instruction`. Extracting them from the rubric is the thing being measured,
+and restating them in the prompt would grade the prompt instead of the read.

--- a/scripts/eval/golden/code-review-retrieval-relevance.NOTES.md
+++ b/scripts/eval/golden/code-review-retrieval-relevance.NOTES.md
@@ -90,6 +90,7 @@ makes it a rubric/prompt defect rather than sampling noise:
 | `#183` head | 8/14 (57.1%) | the six below |
 | `e65c302` | 9/14 (64.3%) | five — `…seen2-below-threshold-scoped` passed |
 | `9e59b36` | 9/14 (64.3%) | same five, identical set |
+| `0512499` (the fix) | **10/14 (71.4%)** | four — `…unrelated-diff-scoped` passed |
 
 All misses were `surface → skip`, never the reverse: the six `skip` decoys passed 6/6 every time.
 A read that under-returns on 5 of 8 positives while never over-returning is not a model that
@@ -121,3 +122,15 @@ Those three are a genuine measurement of a real weakness, so the fix is **not** 
 14/14, and nothing here should be tuned until it does. Deliberately NOT done: adding a summary of
 the four filters to the `instruction`. Extracting them from the rubric is the thing being measured,
 and restating them in the prompt would grade the prompt instead of the read.
+
+**What it actually closed — one of the two diff cases, not both.** The measured run came back
+10/14, above the floor. All three non-diff misses above recurred **identically**, which is the
+prediction holding. Of the two diff cases the fix targeted, `…unrelated-diff-scoped` flipped to
+`surface` and the un-scoped `…unrelated-diff` did not — so the reworded question closed half of
+what it was aimed at, and the un-scoped twin joins the residue.
+
+Read that as directional, not as proof. One case is 7.1 points at n=14, and the run-to-run variance
+the L2 README records is larger than the movement here; what carries the argument is not the
+71.4% but the composition — the three cases predicted to stay missing all stayed missing, and the
+case that moved is one the fix targeted. Do not quote this single run as establishing the
+instruction's effect, and do not tune the remaining four to chase 14/14.

--- a/scripts/eval/golden/code-review-retrieval-relevance.NOTES.md
+++ b/scripts/eval/golden/code-review-retrieval-relevance.NOTES.md
@@ -92,6 +92,7 @@ makes it a rubric/prompt defect rather than sampling noise:
 | `9e59b36` | 9/14 (64.3%) | same five, identical set |
 | `0512499` (the fix) | **10/14 (71.4%)** | four — `…unrelated-diff-scoped` passed |
 | `39e9d7d` (docs only) | **11/14 (78.6%)** | three — **exactly the predicted residue** |
+| `8389c80` (docs only) | **11/14 (78.6%)** | same three, identical set |
 
 All misses were `surface → skip`, never the reverse: the six `skip` decoys passed 6/6 every time.
 A read that under-returns on 5 of 8 positives while never over-returning is not a model that
@@ -124,14 +125,14 @@ Those three are a genuine measurement of a real weakness, so the fix is **not** 
 the four filters to the `instruction`. Extracting them from the rubric is the thing being measured,
 and restating them in the prompt would grade the prompt instead of the read.
 
-**What it closed — both diff cases, though it took two runs to show it.** Run 1 came back 10/14
-with `…unrelated-diff-scoped` flipped and the un-scoped twin still missing; run 2, on a docs-only
-commit, came back 11/14 with **both** diff cases passing. So the two runs disagree on the
-un-scoped twin, which puts it at the boundary rather than firmly on either side.
+**What it closed — both diff cases, on two of the three runs.** Run 1 came back 10/14 with
+`…unrelated-diff-scoped` flipped and the un-scoped twin still missing; runs 2 and 3, both on
+docs-only commits, came back 11/14 with **both** diff cases passing. So the un-scoped twin sits
+near the boundary — missed once, passed twice — rather than firmly on either side.
 
-What does not vary is the residue: the three non-diff misses above recurred **identically in both
-runs**, and in run 2 they are the *entire* miss set. That is the prediction holding exactly, and
-it is what carries the argument — not the 71.4% or the 78.6%. One case is 7.1 points at n=14 and
-the run-to-run variance the L2 README records is larger than the gap between the two runs, so
-quote the miss-set composition, never either score. Do not tune the remaining three to chase
-14/14: they are a real measurement of the model failing rules the rubric states plainly.
+What does not vary at all is the residue: the three non-diff misses above recurred **identically
+in all three runs**, and in runs 2 and 3 they are the *entire* miss set. That is the prediction
+holding exactly, and it is what carries the argument — not the 71.4% or the 78.6%. One case is
+7.1 points at n=14, larger than the spread between these runs, so quote the miss-set composition
+and never a score. Do not tune the remaining three to chase 14/14: they are a real measurement of
+the model failing rules the rubric states plainly.

--- a/scripts/eval/golden/code-review-retrieval-relevance.NOTES.md
+++ b/scripts/eval/golden/code-review-retrieval-relevance.NOTES.md
@@ -91,6 +91,7 @@ makes it a rubric/prompt defect rather than sampling noise:
 | `e65c302` | 9/14 (64.3%) | five — `…seen2-below-threshold-scoped` passed |
 | `9e59b36` | 9/14 (64.3%) | same five, identical set |
 | `0512499` (the fix) | **10/14 (71.4%)** | four — `…unrelated-diff-scoped` passed |
+| `39e9d7d` (docs only) | **11/14 (78.6%)** | three — **exactly the predicted residue** |
 
 All misses were `surface → skip`, never the reverse: the six `skip` decoys passed 6/6 every time.
 A read that under-returns on 5 of 8 positives while never over-returning is not a model that
@@ -123,14 +124,14 @@ Those three are a genuine measurement of a real weakness, so the fix is **not** 
 the four filters to the `instruction`. Extracting them from the rubric is the thing being measured,
 and restating them in the prompt would grade the prompt instead of the read.
 
-**What it actually closed — one of the two diff cases, not both.** The measured run came back
-10/14, above the floor. All three non-diff misses above recurred **identically**, which is the
-prediction holding. Of the two diff cases the fix targeted, `…unrelated-diff-scoped` flipped to
-`surface` and the un-scoped `…unrelated-diff` did not — so the reworded question closed half of
-what it was aimed at, and the un-scoped twin joins the residue.
+**What it closed — both diff cases, though it took two runs to show it.** Run 1 came back 10/14
+with `…unrelated-diff-scoped` flipped and the un-scoped twin still missing; run 2, on a docs-only
+commit, came back 11/14 with **both** diff cases passing. So the two runs disagree on the
+un-scoped twin, which puts it at the boundary rather than firmly on either side.
 
-Read that as directional, not as proof. One case is 7.1 points at n=14, and the run-to-run variance
-the L2 README records is larger than the movement here; what carries the argument is not the
-71.4% but the composition — the three cases predicted to stay missing all stayed missing, and the
-case that moved is one the fix targeted. Do not quote this single run as establishing the
-instruction's effect, and do not tune the remaining four to chase 14/14.
+What does not vary is the residue: the three non-diff misses above recurred **identically in both
+runs**, and in run 2 they are the *entire* miss set. That is the prediction holding exactly, and
+it is what carries the argument — not the 71.4% or the 78.6%. One case is 7.1 points at n=14 and
+the run-to-run variance the L2 README records is larger than the gap between the two runs, so
+quote the miss-set composition, never either score. Do not tune the remaining three to chase
+14/14: they are a real measurement of the model failing rules the rubric states plainly.

--- a/scripts/eval/suites.mjs
+++ b/scripts/eval/suites.mjs
@@ -155,7 +155,17 @@ export const SUITES = [
     // two source-attribution cases are answerable both ways and grade nothing. "Surfaces" is
     // also the label vocabulary the suite already uses, so the question and the answers now
     // name the same thing.
-    instruction: "You are pr-reviewer at Step 1. Using ONLY the memory-read procedure below (Step 1.0's mcp__lorekit__memory_list calls + Step 1.2c's mcp__lorekit__memory_search), decide whether that read surfaces the candidate record described to the finders. The PR diff is supplied as context because Step 1.2c builds its search query from it. Reply 'surface' if the read surfaces the record, or 'skip' if it does not.",
+    // The question is deliberately scoped to what the two READS RETURN, and says so twice.
+    // It previously asked whether the read surfaces the record "to the finders" — which the
+    // rubric itself answers the other way: §1.0 uses that exact phrase for a record dropped
+    // by attribution ("such a record does not reach the finders"), and states that Step 1.2d
+    // shortlists the merged index by changed path before the finders see anything. So for a
+    // diff-unrelated lesson "skip" was the CORRECT answer to the question asked, while the
+    // labels encode list-reachability — the prompt and the ground truth disagreed. Naming the
+    // downstream step and excluding it is the boundary this question needs; it is not a hint.
+    // Do NOT add a summary of which filters apply — the model extracting those from the rubric
+    // is the thing being measured, and restating them here would grade the prompt, not the read.
+    instruction: "You are pr-reviewer at Step 1. Using ONLY the memory-read procedure below (Step 1.0's mcp__lorekit__memory_list calls + Step 1.2c's mcp__lorekit__memory_search), decide whether that read RETURNS the candidate record — that is, whether the record is among what those calls load. Do NOT consider whether it would later survive Step 1.2d's diff-keyed shortlist, or whether its gist looks relevant to the diff: that is a separate, later step and is out of scope for this question. The PR diff is supplied only because Step 1.2c builds its search query from it. Reply 'surface' if the read returns the record, or 'skip' if it does not.",
     inputKey: "input", inputLabel: "Candidate + diff",
     choices: ["surface", "skip"],
   },


### PR DESCRIPTION
Follow-up to #182. That PR left `code-review-retrieval-relevance` red at 9/14 (64.3%) against the 70% floor. This fixes the cause: the suite's `instruction` was asking a different question from the one its labels answer.

**Measured three times since the fix — 10/14, 11/14, 11/14 — green every time.** The scores are the weaker half of the evidence; the miss-set composition is the argument. See "What CI measured".

## The diagnosis

The `instruction` asked whether the documented read surfaces the record **"to the finders"**.

Rubric `### 1.0` uses that exact phrase for a record dropped by attribution — *"such a record does not reach the finders"* — and says diff-keying *"enters later and additively"*, with **Step 1.2d** shortlisting the merged index by changed path and symbol before the finders see anything. Step 1.2d is deliberately **out of the rubric** (`G21a` reds on a re-widening, for exactly this reason).

So for a diff-unrelated lesson, `skip` was the *correct* answer to the question as posed — while the labels encode list-reachability. The prompt and the ground truth disagreed, and the labels were right.

This is the second drift of the same kind on this suite: the verb was already corrected once (`would be surfaced … for the given PR diff` → `surfaces`) to remove the relevance reading, and `to the finders` was left in place one clause over, reintroducing it.

## Evidence

| head | score | misses |
| --- | --- | --- |
| `#183` head | 8/14 (57.1%) | six |
| `e65c302` | 9/14 (64.3%) | five |
| `9e59b36` | 9/14 (64.3%) | same five, identical set |
| `0512499` (the fix) | **10/14 (71.4%)** | four |
| `39e9d7d` (docs only) | **11/14 (78.6%)** | three — exactly the predicted residue |
| `8389c80` (docs only) | **11/14 (78.6%)** | same three, identical set |

Every pre-fix miss was `surface → skip`, never the reverse — the six `skip` decoys passed 6/6 in every run. A read that under-returns on 5 of 8 positives while never over-returning is a model applying a filter the rubric does not contain, and the question was asking for that filter.

## What CI measured

**The residue is what does not vary, and it is the prediction holding exactly.** These three recurred *identically in all three* post-fix runs, and in the last two they are the entire miss set. They are the model failing to apply rules `### 1.0` states in as many words — a real measurement worth keeping visible, not prompt noise:

| miss | the rule it did not apply |
| --- | --- |
| `seen2-below-threshold` | `seen_count` is the promotion bar, not a surfacing filter |
| `global-scope-reachable` | `global` is one of the two scopes both paths read |
| `source-explicit-maintainer-rule` | attribution is a disjunction — `source.explicit == true` carves in a human-authored record |

**The two diff cases the fix targeted both close, on two runs of three.** `…unrelated-diff-scoped` flipped immediately; the un-scoped twin was missed once and passed twice, so it sits near the boundary rather than firmly closed. The notes say that rather than rounding it up.

One case is 7.1 points at n=14 — larger than the spread between these runs — so **quote the composition, not any of the three scores**. Both files say so, and say not to tune the remaining three to chase 14/14.

## Deliberately not done

Summarising the four filters into the `instruction`. Extracting them from the rubric is the thing being measured; restating them in the prompt would grade the prompt instead of the read. The suite comment says so, so the next author does not "improve" it that way.

## A retraction these runs forced, on a different eval

`suites.mjs` is a `HARNESS_FILES` entry, so selection is fail-open and **all nine suites plus `bug-detection`** ran each time. All nine were green on all three runs.

`bug-detection` went red (`fp_rate 30%`), green (`≤20%`, recall 75%), then red again (`fp_rate 40%`, recall 90% — the best recall of any run). Across all five detection runs ever: `fp_rate` 30 · 40 · 30 · ≤20 · 40 against recall 75 · 60 · 70 · 75 · 90%.

That contradicts a README claim this PR therefore corrects. `fp_rate` was documented as *"never once at or under the 20% gate"*, with the precision gap called **the reproducible failure**. One meet in five is a flaky gate, not a standing red — and the last two runs are a clean same-content pair (this PR's diff touches neither detection rubric), so the spread between them is pure run-to-run variance. Run 5 pairing the worst `fp_rate` with the best recall is the finder-aggression trade showing up as noise at these sample sizes rather than as a fixed operating point.

**No detection rubric was touched** — only the claim about what the measurements show. The detection red is inherited from main, not introduced here, and closing it means editing the two rubrics that eval measures, with its own decoys and its own re-run.

## Note on the final check state

The `run-evals` label has been **removed** now that the measurement is done — three retrieval samples and five detection runs is enough, and every further push would re-run all ten jobs. So the head commit's checks are green-by-skip, which is the opt-in gate working as designed, **not** the detection eval passing. Re-add the label to re-measure.

## Changes

- `scripts/eval/suites.mjs` — the reworded `instruction` plus a comment recording why the phrasing is load-bearing and what not to add.
- `scripts/eval/golden/code-review-retrieval-relevance.NOTES.md` — corrects the stale `**Gate:** report-only until ≥ 50 real-corpus cases` line (it gates at 14 cases; the ≥ 50 bar governs *raising* the floor), corrects the same wrong framing in "What this suite measures", and records all six runs with what the fix did and did not close.
- `scripts/eval/README.md` — rewrites the superseding note on finding 4, and retracts the detection-gate claim above.

No rubric, harness, gate, threshold, or golden label was changed.

L1: 1612/1612, locally and in CI on every commit.

https://claude.ai/code/session_01EFoqtKWwjJcRFDxQ1Aowss